### PR TITLE
feat(agent): add phase2 preview contracts [Agent: GPT-5 Codex]

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Use one stable entrypoint for common workflows:
 ./scripts/eth2qs.sh help
 ./scripts/eth2qs.sh configure --non-interactive
 ./scripts/eth2qs.sh client-options --json
+./scripts/eth2qs.sh phase2-preview --execution=geth --consensus=prysm --mev=mev-boost --json
 ./scripts/eth2qs.sh phase1
 ./scripts/eth2qs.sh phase2
 ./scripts/eth2qs.sh monad-install
@@ -102,6 +103,7 @@ codex mcp add eth2-quickstart ./mcp_server/run_eth2qs_mcp.sh
 
 The MCP server can expose the core lifecycle directly: Phase 1 hardening, Phase 2 Ethereum client install, planner-driven install, health checks, logs, and safe cleanup.
 - For machine-readable client names and tested presets, use `./scripts/eth2qs.sh client-options --json`.
+- For a machine-readable explicit Phase 2 preview, use `./scripts/eth2qs.sh phase2-preview --execution=geth --consensus=prysm --mev=mev-boost --json`.
 - For the command surface and safety rules, start with [`skills/eth2-quickstart/SKILL.md`](skills/eth2-quickstart/SKILL.md)
 
 This is a repo-backed operations skill, not a standalone blockchain package.

--- a/config/client_options.json
+++ b/config/client_options.json
@@ -21,6 +21,10 @@
     "mev-boost",
     "none"
   ],
+  "networks": [
+    "holesky",
+    "mainnet"
+  ],
   "ethgas_requires": {
     "mev": "commit-boost"
   },

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -16,10 +16,13 @@ Use `scripts/eth2qs.sh` as a stable command entrypoint for both humans and AI ag
 ./scripts/eth2qs.sh help
 ./scripts/eth2qs.sh configure --non-interactive
 ./scripts/eth2qs.sh client-options --json
+./scripts/eth2qs.sh phase2-preview --execution=geth --consensus=prysm --mev=mev-boost --json
 ./scripts/eth2qs.sh phase1
 ./scripts/eth2qs.sh phase2
 ./scripts/eth2qs.sh doctor --json
 ```
+
+Use `client-options --json` as the enum source of truth and `phase2-preview --json` when a wrapper needs the exact explicit `run_2.sh` command plus any required `config/user_config.env` network overrides before execution.
 
 ## Environment Configuration (exports.sh)
 

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -53,6 +53,17 @@ Use this file to preserve context across sessions.
 - Validation run: `./scripts/eth2qs.sh client-options --json`, `python3 -m unittest discover -s test -p 'test_mcp_tools.py'`, `bash test/ci_test_mcp_server.sh`
 - Follow-up: external harnesses like CLI-Anything can switch from embedded client enums to the repo-native `client-options --json` surface
 
+## Latest Update (Phase 2 Preview Contract, 2026-04-08)
+
+- Added `install/utils/phase2_preview.py` and wired `./scripts/eth2qs.sh phase2-preview` as a read-only preview for explicit `run_2.sh` installs
+- Preview returns machine-readable `wrapper_command`, `run_2_command`, `config_updates`, `constraints`, and source-of-truth metadata
+- Added `networks` to `config/client_options.json` so wrappers can use one repo-native enum source for both client choices and supported network overrides
+- Added MCP `eth2qs_phase2_preview` so native-tool runtimes can preview explicit installs without mutating the host
+- Added wrapper contract schemas under `test/contracts/` plus `test/test_wrapper_contracts.py` to validate live JSON output from `doctor`, `plan`, `client-options`, and `phase2-preview`
+- Expanded MCP CI to cover the new preview tool and all Python wrapper/MCP tests
+- Validation run: `./scripts/eth2qs.sh phase2-preview --execution=geth --consensus=prysm --mev=mev-boost --json`, `python3 -m unittest discover -s test -p 'test_*.py'`, `bash test/ci_test_mcp_server.sh`
+- Follow-up: add a machine-readable monitoring/stats surface so wrappers do not need to parse the current human-only `stats.sh` output
+
 ## MCP Meta Learnings
 
 - Composite GitHub actions must not reference `secrets.*` directly in `action.yml`; pass tokens through explicit action inputs from the workflow.

--- a/install/utils/client_options.sh
+++ b/install/utils/client_options.sh
@@ -37,6 +37,7 @@ data = json.loads(Path(sys.argv[1]).read_text())
 print("Execution clients:", ", ".join(data["execution_clients"]))
 print("Consensus clients:", ", ".join(data["consensus_clients"]))
 print("MEV options:", ", ".join(data["mev_options"]))
+print("Networks:", ", ".join(data["networks"]))
 print("ETHGas requires:", f"mev={data['ethgas_requires']['mev']}")
 print("Common presets:")
 for preset in data["common_presets"]:

--- a/install/utils/phase2_preview.py
+++ b/install/utils/phase2_preview.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Preview the explicit Phase 2 command and config updates without mutating the host."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+CLIENT_OPTIONS_FILE = ROOT_DIR / "config" / "client_options.json"
+
+
+def load_client_options() -> dict:
+    return json.loads(CLIENT_OPTIONS_FILE.read_text(encoding="utf-8"))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="./install/utils/phase2_preview.py",
+        description="Preview the explicit Phase 2 command and config updates.",
+    )
+    parser.add_argument("--json", action="store_true", help="Output JSON")
+    parser.add_argument("--network")
+    parser.add_argument("--execution")
+    parser.add_argument("--consensus")
+    parser.add_argument("--mev")
+    parser.add_argument("--ethgas", action="store_true")
+    parser.add_argument("--skip-deps", action="store_true")
+    return parser.parse_args()
+
+
+def validate_choice(name: str, value: str | None, allowed: set[str]) -> None:
+    if value is not None and value not in allowed:
+        raise SystemExit(f"Unsupported {name}: {value}")
+
+
+def preview_payload(args: argparse.Namespace, options: dict) -> dict:
+    validate_choice("network", args.network, set(options["networks"]))
+    validate_choice("execution client", args.execution, set(options["execution_clients"]))
+    validate_choice("consensus client", args.consensus, set(options["consensus_clients"]))
+    validate_choice("mev", args.mev, set(options["mev_options"]))
+
+    if args.ethgas and args.mev != options["ethgas_requires"]["mev"]:
+        raise SystemExit("ETHGas requires --mev=commit-boost")
+
+    interactive = not any([args.execution, args.consensus, args.mev, args.ethgas])
+    wrapper_command = ["./scripts/eth2qs.sh", "phase2"]
+    run_2_command = ["./run_2.sh"]
+    if args.execution:
+        wrapper_command.append(f"--execution={args.execution}")
+        run_2_command.append(f"--execution={args.execution}")
+    if args.consensus:
+        wrapper_command.append(f"--consensus={args.consensus}")
+        run_2_command.append(f"--consensus={args.consensus}")
+    if args.mev:
+        wrapper_command.append(f"--mev={args.mev}")
+        run_2_command.append(f"--mev={args.mev}")
+    if args.ethgas:
+        wrapper_command.append("--ethgas")
+        run_2_command.append("--ethgas")
+    if args.skip_deps:
+        wrapper_command.append("--skip-deps")
+        run_2_command.append("--skip-deps")
+
+    config_updates: dict[str, str] = {}
+    if args.network:
+        config_updates["ETH_NETWORK"] = args.network
+        config_updates["ETHGAS_NETWORK"] = args.network
+
+    notes = []
+    if interactive:
+        notes.append("No explicit execution/consensus/MEV flags were provided; running phase2 bare will enter the interactive installer.")
+    else:
+        notes.append("The preview is explicit and non-interactive if you run the returned command as the configured non-root operator.")
+    if config_updates:
+        notes.append("Apply the returned config_updates to config/user_config.env before running phase2 if you want the network override persisted.")
+
+    return {
+        "requested": {
+            "network": args.network,
+            "execution": args.execution,
+            "consensus": args.consensus,
+            "mev": args.mev,
+            "ethgas": args.ethgas,
+            "skip_deps": args.skip_deps,
+        },
+        "interactive": interactive,
+        "wrapper_command": wrapper_command,
+        "run_2_command": run_2_command,
+        "config_updates": config_updates,
+        "constraints": {"ethgas_requires": options["ethgas_requires"]},
+        "source_of_truth": {
+            "client_options_json": "./config/client_options.json"
+        },
+        "notes": notes,
+    }
+
+
+def print_human(payload: dict) -> None:
+    print("Phase 2 preview")
+    print(f"Interactive:     {payload['interactive']}")
+    print("Wrapper command: " + " ".join(payload["wrapper_command"]))
+    print("run_2 command:   " + " ".join(payload["run_2_command"]))
+    if payload["config_updates"]:
+        print("Config updates:")
+        for key, value in payload["config_updates"].items():
+            print(f"  - {key}={value}")
+    else:
+        print("Config updates:  none")
+    print("Notes:")
+    for note in payload["notes"]:
+        print(f"  - {note}")
+
+
+def main() -> None:
+    args = parse_args()
+    payload = preview_payload(args, load_client_options())
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return
+    print_human(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server/eth2qs_mcp_server.py
+++ b/mcp_server/eth2qs_mcp_server.py
@@ -26,6 +26,7 @@ from mcp_server.eth2qs_mcp_tools import (  # noqa: E402
     monad_install,
     phase1,
     phase2,
+    phase2_preview,
     plan_json,
     server_info,
     start,
@@ -84,6 +85,26 @@ def eth2qs_ensure_apply(chain: str | None = None, confirm: bool = False, confirm
 def eth2qs_client_options() -> dict:
     """List valid Phase 2 execution/consensus/MEV choices and a few common tested presets."""
     return client_options()
+
+
+@mcp.tool(name="eth2qs_phase2_preview")
+def eth2qs_phase2_preview(
+    network: str | None = None,
+    execution: str | None = None,
+    consensus: str | None = None,
+    mev: str | None = None,
+    ethgas: bool = False,
+    skip_deps: bool = False,
+) -> dict:
+    """Preview the explicit Phase 2 command/config updates without changing the host."""
+    return phase2_preview(
+        network=network,
+        execution=execution,
+        consensus=consensus,
+        mev=mev,
+        ethgas=ethgas,
+        skip_deps=skip_deps,
+    )
 
 
 @mcp.tool(name="eth2qs_phase1")

--- a/mcp_server/eth2qs_mcp_tools.py
+++ b/mcp_server/eth2qs_mcp_tools.py
@@ -25,6 +25,7 @@ CLIENT_OPTIONS = _load_client_options()
 ALLOWED_EXECUTION_CLIENTS = set(CLIENT_OPTIONS["execution_clients"])
 ALLOWED_CONSENSUS_CLIENTS = set(CLIENT_OPTIONS["consensus_clients"])
 ALLOWED_MEV_OPTIONS = set(CLIENT_OPTIONS["mev_options"])
+ALLOWED_NETWORKS = set(CLIENT_OPTIONS["networks"])
 
 
 def resolve_repo_root() -> Path:
@@ -141,6 +142,30 @@ def phase2(
     return _eth2qs(*args)
 
 
+def phase2_preview(
+    network: Optional[str] = None,
+    execution: Optional[str] = None,
+    consensus: Optional[str] = None,
+    mev: Optional[str] = None,
+    *,
+    ethgas: bool = False,
+    skip_deps: bool = False,
+) -> Dict[str, Any]:
+    args = [
+        "phase2-preview",
+        *_optional_choice("network", network, ALLOWED_NETWORKS),
+        *_optional_choice("execution", execution, ALLOWED_EXECUTION_CLIENTS),
+        *_optional_choice("consensus", consensus, ALLOWED_CONSENSUS_CLIENTS),
+        *_optional_choice("mev", mev, ALLOWED_MEV_OPTIONS),
+        "--json",
+    ]
+    if ethgas:
+        args.append("--ethgas")
+    if skip_deps:
+        args.append("--skip-deps")
+    return _eth2qs(*args)
+
+
 def client_options() -> Dict[str, Any]:
     return _load_client_options()
 
@@ -184,12 +209,14 @@ def monad_install(*, confirm: bool = False, confirmation_token: str = "") -> Dic
 
 
 TOOL_NAMES = (
+    "eth2qs_info",
     "eth2qs_help",
     "eth2qs_doctor_json",
     "eth2qs_plan_json",
     "eth2qs_ensure_preview",
     "eth2qs_ensure_apply",
     "eth2qs_client_options",
+    "eth2qs_phase2_preview",
     "eth2qs_phase1",
     "eth2qs_phase2",
     "eth2qs_stats",
@@ -217,6 +244,7 @@ def server_info() -> Dict[str, Any]:
                 "eth2qs_plan_json",
                 "eth2qs_ensure_preview",
                 "eth2qs_client_options",
+                "eth2qs_phase2_preview",
                 "eth2qs_stats",
                 "eth2qs_logs",
                 "eth2qs_clean_data_dry_run",
@@ -236,6 +264,11 @@ def server_info() -> Dict[str, Any]:
             "eth2qs_doctor_json": {},
             "eth2qs_plan_json": {"chain": "ethereum"},
             "eth2qs_client_options": {},
+            "eth2qs_phase2_preview": {
+                "execution": "geth",
+                "consensus": "prysm",
+                "mev": "mev-boost",
+            },
             "eth2qs_phase1": {"confirm": True, "confirmation_token": "apply"},
             "eth2qs_phase2": {
                 "execution": "geth",
@@ -262,11 +295,12 @@ __all__ = [
     "doctor_json",
     "ensure_apply",
     "ensure_preview",
-    "phase1",
-    "phase2",
     "help_tool",
     "logs",
     "monad_install",
+    "phase1",
+    "phase2",
+    "phase2_preview",
     "plan_json",
     "resolve_repo_root",
     "restart",

--- a/scripts/eth2qs.sh
+++ b/scripts/eth2qs.sh
@@ -16,6 +16,7 @@ Core lifecycle:
   bootstrap [args...]     Run one-line bootstrap installer (install.sh)
   configure [args...]     Run configuration wizard
   client-options [args...] Show supported client names and tested presets
+  phase2-preview [args...] Preview the explicit Phase 2 command without mutating the host
   plan [args...]          Detect the next safe install step
   ensure [args...]        Preview or execute the next safe install step
   phase1 [args...]        Run run_1.sh (root/system hardening)
@@ -40,6 +41,7 @@ Utility:
 Examples:
   ./scripts/eth2qs.sh bootstrap --non-interactive
   ./scripts/eth2qs.sh client-options --json
+  ./scripts/eth2qs.sh phase2-preview --execution=geth --consensus=prysm --mev=mev-boost --json
   ./scripts/eth2qs.sh plan --json
   ./scripts/eth2qs.sh ensure
   ./scripts/eth2qs.sh configure --interactive
@@ -78,6 +80,9 @@ case "$cmd" in
         ;;
     client-options)
         run_cmd "$ROOT_DIR/install/utils/client_options.sh" "$@"
+        ;;
+    phase2-preview)
+        run_cmd "$ROOT_DIR/install/utils/phase2_preview.py" "$@"
         ;;
     plan)
         run_cmd "$ROOT_DIR/install/utils/plan.sh" "$@"

--- a/skills/eth2-quickstart/references/commands.md
+++ b/skills/eth2-quickstart/references/commands.md
@@ -6,6 +6,7 @@ Canonical command surface:
 - Configure scripts: `./scripts/eth2qs.sh configure --non-interactive`
 - Detect the next safe install step: `./scripts/eth2qs.sh plan --json`
 - List supported clients and tested presets: `./scripts/eth2qs.sh client-options --json`
+- Preview an explicit Phase 2 install command: `./scripts/eth2qs.sh phase2-preview --execution=geth --consensus=prysm --mev=mev-boost --json`
 - Preview/apply the next safe step: `./scripts/eth2qs.sh ensure` or `./scripts/eth2qs.sh ensure --apply --confirm`
 - Run Phase 1 hardening: `sudo ./scripts/eth2qs.sh phase1`
 - Run Phase 2 install: `./scripts/eth2qs.sh phase2 --execution=geth --consensus=prysm --mev=mev-boost`

--- a/skills/eth2-quickstart/references/mcp.md
+++ b/skills/eth2-quickstart/references/mcp.md
@@ -16,6 +16,7 @@ Safe read/plan tools:
 - `eth2qs_plan_json`
 - `eth2qs_ensure_preview`
 - `eth2qs_client_options`
+- `eth2qs_phase2_preview`
 - `eth2qs_stats`
 - `eth2qs_logs`
 - `eth2qs_clean_data_dry_run`
@@ -79,6 +80,7 @@ If your Codex runtime uses config files instead of the CLI, point the server com
 - Prefer `eth2qs_doctor_json` and `eth2qs_plan_json` before any apply tool.
 - Use `eth2qs_phase1` for root/system hardening and `eth2qs_phase2` for explicit Ethereum client install when you do not want planner-driven routing.
 - Use `eth2qs_client_options` before `eth2qs_phase2` if the agent needs valid client names or a tested preset.
+- Use `eth2qs_phase2_preview` when a wrapper needs the exact explicit `run_2.sh` command shape and any matching config override hints before execution.
 - The MCP `eth2qs_client_options` payload now mirrors `./scripts/eth2qs.sh client-options --json`, so external wrappers can consume the same repo-native source of truth.
 - Use the MCP server for native tool use; use `llms.txt` or the skill files for raw-ingest instruction loading.
 - `cleanup_host_dry_run` is intentionally preview-only at the MCP layer.

--- a/skills/eth2-quickstart/references/outputs.md
+++ b/skills/eth2-quickstart/references/outputs.md
@@ -10,6 +10,14 @@ Use:
 
 This is the canonical machine-readable health path for agents.
 
+Other stable machine-readable surfaces:
+
+```bash
+./scripts/eth2qs.sh plan --json
+./scripts/eth2qs.sh client-options --json
+./scripts/eth2qs.sh phase2-preview --execution=geth --consensus=prysm --mev=mev-boost --json
+```
+
 ## Expected Uses
 
 - Confirm whether a host is ready for node install or is missing obvious prerequisites
@@ -25,7 +33,7 @@ This is the canonical machine-readable health path for agents.
 - `./scripts/eth2qs.sh logs --run1 -n 100`
 - `./scripts/eth2qs.sh logs --run2 -n 200`
 
-Use the JSON output when another agent step needs stable parsing. Use the human-readable output and logs when doing RCA.
+Use the JSON output when another agent step needs stable parsing. Use the human-readable output and logs when doing RCA. `stats` is still a human-oriented summary, not a stable JSON contract.
 
 ## `doctor --json` Output Shape
 

--- a/test/ci_test_mcp_server.sh
+++ b/test/ci_test_mcp_server.sh
@@ -14,6 +14,7 @@ TOOLS_FILE="$MCP_DIR/eth2qs_mcp_tools.py"
 SERVER_FILE="$MCP_DIR/eth2qs_mcp_server.py"
 WRAPPER_FILE="$MCP_DIR/run_eth2qs_mcp.sh"
 CLIENT_OPTIONS_SCRIPT="$PROJECT_ROOT/install/utils/client_options.sh"
+PHASE2_PREVIEW_SCRIPT="$PROJECT_ROOT/install/utils/phase2_preview.py"
 CLAUDE_PLUGIN_FILE="$PROJECT_ROOT/.claude-plugin/plugin.json"
 CLAUDE_MARKETPLACE_FILE="$PROJECT_ROOT/.claude-plugin/marketplace.json"
 CLAUDE_SETTINGS_FILE="$PROJECT_ROOT/.claude/settings.json"
@@ -28,6 +29,7 @@ assert_file_exists "$TOOLS_FILE" "mcp_server/eth2qs_mcp_tools.py"
 assert_file_exists "$SERVER_FILE" "mcp_server/eth2qs_mcp_server.py"
 assert_file_exists "$WRAPPER_FILE" "mcp_server/run_eth2qs_mcp.sh"
 assert_file_exists "$CLIENT_OPTIONS_SCRIPT" "install/utils/client_options.sh"
+assert_file_exists "$PHASE2_PREVIEW_SCRIPT" "install/utils/phase2_preview.py"
 assert_file_exists "$CLAUDE_PLUGIN_FILE" ".claude-plugin/plugin.json"
 assert_file_exists "$CLAUDE_MARKETPLACE_FILE" ".claude-plugin/marketplace.json"
 assert_file_exists "$CLAUDE_SETTINGS_FILE" ".claude/settings.json"
@@ -35,6 +37,11 @@ assert_file_exists "$CLAUDE_INSTALLER_FILE" "scripts/install_claude_eth2qs_mcp.s
 assert_valid_syntax "$WRAPPER_FILE" "run_eth2qs_mcp.sh"
 assert_valid_syntax "$CLIENT_OPTIONS_SCRIPT" "client_options.sh"
 assert_valid_syntax "$CLAUDE_INSTALLER_FILE" "install_claude_eth2qs_mcp.sh"
+if python3 -m py_compile "$PHASE2_PREVIEW_SCRIPT"; then
+    record_test "phase2_preview.py compiles" "PASS"
+else
+    record_test "phase2_preview.py compiles" "FAIL"
+fi
 
 if python3 -m py_compile "$TOOLS_FILE" "$SERVER_FILE"; then
     record_test "python MCP files compile" "PASS"
@@ -42,10 +49,10 @@ else
     record_test "python MCP files compile" "FAIL"
 fi
 
-if python3 -m unittest discover -s "$PROJECT_ROOT/test" -p "test_mcp_tools.py"; then
-    record_test "python MCP unit tests pass" "PASS"
+if python3 -m unittest discover -s "$PROJECT_ROOT/test" -p "test_*.py"; then
+    record_test "python wrapper and MCP unit tests pass" "PASS"
 else
-    record_test "python MCP unit tests pass" "FAIL"
+    record_test "python wrapper and MCP unit tests pass" "FAIL"
 fi
 
 if grep -Fq "references/mcp.md" "$SKILL_FILE" &&
@@ -53,7 +60,8 @@ if grep -Fq "references/mcp.md" "$SKILL_FILE" &&
    grep -Fq "Codex" "$MCP_REF" &&
    grep -Fq "mcp_server/run_eth2qs_mcp.sh" "$README_FILE" &&
    grep -Fq ".claude-plugin/" "$README_FILE" &&
-   grep -Fq "client-options --json" "$README_FILE"; then
+   grep -Fq "client-options --json" "$README_FILE" &&
+   grep -Fq "phase2-preview" "$README_FILE"; then
     record_test "MCP docs are wired from the skill and README" "PASS"
 else
     record_test "MCP docs are wired from the skill and README" "FAIL"
@@ -77,6 +85,7 @@ fi
 
 if grep -Fq "eth2qs_doctor_json" "$TOOLS_FILE" &&
    grep -Fq "eth2qs_client_options" "$TOOLS_FILE" &&
+   grep -Fq "eth2qs_phase2_preview" "$TOOLS_FILE" &&
    grep -Fq "eth2qs_phase1" "$TOOLS_FILE" &&
    grep -Fq "eth2qs_phase2" "$TOOLS_FILE" &&
    grep -Fq "eth2qs_ensure_apply" "$TOOLS_FILE" &&

--- a/test/contracts/client_options.schema.json
+++ b/test/contracts/client_options.schema.json
@@ -1,0 +1,54 @@
+{
+  "type": "object",
+  "required": [
+    "execution_clients",
+    "consensus_clients",
+    "mev_options",
+    "networks",
+    "ethgas_requires",
+    "common_presets"
+  ],
+  "properties": {
+    "execution_clients": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "consensus_clients": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "mev_options": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "networks": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "ethgas_requires": {
+      "type": "object",
+      "required": ["mev"],
+      "properties": {
+        "mev": { "type": "string" }
+      }
+    },
+    "common_presets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "execution", "consensus", "mev", "ethgas"],
+        "properties": {
+          "name": { "type": "string" },
+          "execution": { "type": "string" },
+          "consensus": { "type": "string" },
+          "mev": { "type": "string" },
+          "ethgas": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}

--- a/test/contracts/doctor.schema.json
+++ b/test/contracts/doctor.schema.json
@@ -1,0 +1,28 @@
+{
+  "type": "object",
+  "required": ["summary", "checks"],
+  "properties": {
+    "summary": {
+      "type": "object",
+      "required": ["passed", "warnings", "failed", "status"],
+      "properties": {
+        "passed": { "type": "integer" },
+        "warnings": { "type": "integer" },
+        "failed": { "type": "integer" },
+        "status": { "type": "string", "enum": ["pass", "warn", "fail"] }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["status", "name", "details"],
+        "properties": {
+          "status": { "type": "string", "enum": ["pass", "warn", "fail"] },
+          "name": { "type": "string" },
+          "details": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/test/contracts/phase2_preview.schema.json
+++ b/test/contracts/phase2_preview.schema.json
@@ -1,0 +1,65 @@
+{
+  "type": "object",
+  "required": [
+    "requested",
+    "interactive",
+    "wrapper_command",
+    "run_2_command",
+    "config_updates",
+    "constraints",
+    "source_of_truth",
+    "notes"
+  ],
+  "properties": {
+    "requested": {
+      "type": "object",
+      "required": ["network", "execution", "consensus", "mev", "ethgas", "skip_deps"],
+      "properties": {
+        "network": { "type": ["string", "null"] },
+        "execution": { "type": ["string", "null"] },
+        "consensus": { "type": ["string", "null"] },
+        "mev": { "type": ["string", "null"] },
+        "ethgas": { "type": "boolean" },
+        "skip_deps": { "type": "boolean" }
+      }
+    },
+    "interactive": { "type": "boolean" },
+    "wrapper_command": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "type": "string" }
+    },
+    "run_2_command": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "config_updates": {
+      "type": "object"
+    },
+    "constraints": {
+      "type": "object",
+      "required": ["ethgas_requires"],
+      "properties": {
+        "ethgas_requires": {
+          "type": "object",
+          "required": ["mev"],
+          "properties": {
+            "mev": { "type": "string" }
+          }
+        }
+      }
+    },
+    "source_of_truth": {
+      "type": "object",
+      "required": ["client_options_json"],
+      "properties": {
+        "client_options_json": { "type": "string" }
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/test/contracts/plan.schema.json
+++ b/test/contracts/plan.schema.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "required": [
+    "chain",
+    "current_user",
+    "is_root",
+    "operator_user",
+    "operator_user_exists",
+    "state",
+    "next_action",
+    "reason",
+    "core_services_expected",
+    "core_services_installed",
+    "core_services_running",
+    "service_states"
+  ],
+  "properties": {
+    "chain": { "type": "string" },
+    "current_user": { "type": "string" },
+    "is_root": { "type": "boolean" },
+    "operator_user": { "type": "string" },
+    "operator_user_exists": { "type": "boolean" },
+    "state": { "type": "string" },
+    "next_action": { "type": "string" },
+    "reason": { "type": "string" },
+    "core_services_expected": { "type": "integer" },
+    "core_services_installed": { "type": "integer" },
+    "core_services_running": { "type": "integer" },
+    "service_states": {
+      "type": "object"
+    }
+  }
+}

--- a/test/test_mcp_tools.py
+++ b/test/test_mcp_tools.py
@@ -11,9 +11,11 @@ from mcp_server import eth2qs_mcp_tools as tools
 
 class McpToolsTest(unittest.TestCase):
     def test_tool_names_contain_expected_contract(self):
+        self.assertIn("eth2qs_info", tools.TOOL_NAMES)
         self.assertIn("eth2qs_doctor_json", tools.TOOL_NAMES)
         self.assertIn("eth2qs_ensure_apply", tools.TOOL_NAMES)
         self.assertIn("eth2qs_client_options", tools.TOOL_NAMES)
+        self.assertIn("eth2qs_phase2_preview", tools.TOOL_NAMES)
         self.assertIn("eth2qs_phase1", tools.TOOL_NAMES)
         self.assertIn("eth2qs_phase2", tools.TOOL_NAMES)
         self.assertIn("eth2qs_cleanup_host_dry_run", tools.TOOL_NAMES)
@@ -24,6 +26,7 @@ class McpToolsTest(unittest.TestCase):
         self.assertIn("call_examples", info)
         self.assertIn("eth2qs_phase2", info["tool_groups"]["mutating_confirm_required"])
         self.assertIn("eth2qs_client_options", info["tool_groups"]["read_only"])
+        self.assertIn("eth2qs_phase2_preview", info["tool_groups"]["read_only"])
         self.assertEqual(info["call_examples"]["eth2qs_phase1"]["confirmation_token"], "apply")
 
     def test_client_options_lists_valid_choices(self):
@@ -31,6 +34,7 @@ class McpToolsTest(unittest.TestCase):
         self.assertIn("geth", options["execution_clients"])
         self.assertIn("prysm", options["consensus_clients"])
         self.assertIn("mev-boost", options["mev_options"])
+        self.assertIn("holesky", options["networks"])
         self.assertEqual(options["ethgas_requires"]["mev"], "commit-boost")
 
     def test_wrapper_client_options_json_matches_mcp(self):
@@ -107,6 +111,34 @@ class McpToolsTest(unittest.TestCase):
         self.assertIn("--execution=geth", called)
         self.assertIn("--consensus=prysm", called)
         self.assertIn("--mev=mev-boost", called)
+
+    def test_phase2_preview_maps_flags(self):
+        fake = {
+            "command": [],
+            "cwd": "/repo",
+            "exit_code": 0,
+            "stdout": "",
+            "stderr": "",
+            "ok": True,
+        }
+        with patch("mcp_server.eth2qs_mcp_tools._run", return_value=fake) as run_mock:
+            tools.phase2_preview(
+                network="holesky",
+                execution="geth",
+                consensus="prysm",
+                mev="commit-boost",
+                ethgas=True,
+                skip_deps=True,
+            )
+        called = run_mock.call_args[0][0]
+        self.assertIn("phase2-preview", called)
+        self.assertIn("--network=holesky", called)
+        self.assertIn("--execution=geth", called)
+        self.assertIn("--consensus=prysm", called)
+        self.assertIn("--mev=commit-boost", called)
+        self.assertIn("--ethgas", called)
+        self.assertIn("--skip-deps", called)
+        self.assertIn("--json", called)
 
     def test_repo_root_env_override_is_honored(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/test/test_wrapper_contracts.py
+++ b/test/test_wrapper_contracts.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+WRAPPER = ROOT_DIR / "scripts" / "eth2qs.sh"
+CONTRACTS_DIR = ROOT_DIR / "test" / "contracts"
+
+
+def load_schema(name: str) -> dict:
+    return json.loads((CONTRACTS_DIR / name).read_text(encoding="utf-8"))
+
+
+def assert_matches_schema(case: unittest.TestCase, value, schema: dict, path: str = "$") -> None:
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        allowed = expected_type if isinstance(expected_type, list) else [expected_type]
+        type_map = {
+            "array": list,
+            "boolean": bool,
+            "integer": int,
+            "null": type(None),
+            "object": dict,
+            "string": str,
+        }
+        if not any(isinstance(value, type_map[name]) for name in allowed):
+            case.fail(f"{path} expected type {allowed}, got {type(value).__name__}")
+
+    if "enum" in schema and value not in schema["enum"]:
+        case.fail(f"{path} expected one of {schema['enum']}, got {value!r}")
+
+    if "required" in schema:
+        for key in schema["required"]:
+            case.assertIn(key, value, msg=f"{path} missing required key {key!r}")
+
+    if isinstance(value, dict):
+        for key, subschema in schema.get("properties", {}).items():
+            if key in value:
+                assert_matches_schema(case, value[key], subschema, f"{path}.{key}")
+
+    if isinstance(value, list):
+        min_items = schema.get("minItems")
+        if min_items is not None and len(value) < min_items:
+            case.fail(f"{path} expected at least {min_items} items, got {len(value)}")
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for index, item in enumerate(value):
+                assert_matches_schema(case, item, item_schema, f"{path}[{index}]")
+
+
+class WrapperContractTest(unittest.TestCase):
+    def run_wrapper_json(self, *args: str, allow_nonzero: bool = False) -> dict:
+        completed = subprocess.run(
+            [str(WRAPPER), *args],
+            cwd=str(ROOT_DIR),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if not allow_nonzero:
+            self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        self.assertTrue(completed.stdout.strip(), msg=completed.stderr)
+        return json.loads(completed.stdout)
+
+    def assert_contract(self, schema_name: str, *args: str, allow_nonzero: bool = False) -> dict:
+        payload = self.run_wrapper_json(*args, allow_nonzero=allow_nonzero)
+        assert_matches_schema(self, payload, load_schema(schema_name))
+        return payload
+
+    def test_client_options_json_contract(self):
+        payload = self.assert_contract("client_options.schema.json", "client-options", "--json")
+        self.assertIn("mainnet", payload["networks"])
+
+    def test_doctor_json_contract(self):
+        payload = self.assert_contract("doctor.schema.json", "doctor", "--json", allow_nonzero=True)
+        self.assertIn(payload["summary"]["status"], {"pass", "warn", "fail"})
+
+    def test_plan_json_contract(self):
+        payload = self.assert_contract("plan.schema.json", "plan", "--json")
+        self.assertIn("service_states", payload)
+
+    def test_phase2_preview_json_contract(self):
+        payload = self.assert_contract(
+            "phase2_preview.schema.json",
+            "phase2-preview",
+            "--network=holesky",
+            "--execution=geth",
+            "--consensus=prysm",
+            "--mev=commit-boost",
+            "--ethgas",
+            "--skip-deps",
+            "--json",
+        )
+        self.assertEqual(payload["config_updates"]["ETHGAS_NETWORK"], "holesky")
+        self.assertIn("--skip-deps", payload["run_2_command"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a read-only `phase2-preview` wrapper and MCP surface for explicit `run_2.sh` installs
- extend the repo-native client options contract with supported networks and validate preview inputs against the same source of truth
- add live wrapper contract tests and docs wiring for `doctor`, `plan`, `client-options`, and `phase2-preview`

## Validation
- `./scripts/eth2qs.sh phase2-preview --network=holesky --execution=geth --consensus=prysm --mev=commit-boost --ethgas --skip-deps --json`
- `python3 -m unittest discover -s test -p 'test_*.py'`
- `bash test/ci_test_mcp_server.sh`
- `git diff --check`

**Agent:** GPT-5 Codex
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Original Request
Merged. Pull latest master and continue till all your suggestions are done then plan and suggest more improvements and reviews. Let’s try to reduce total lines of code if possible. Also how’s the monitoring and status tooling? Is it top notch ?
