### PR TITLE
feat(security): make Snort IDS enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ This is a repo-backed operations skill, not a standalone blockchain package.
    
    - Upgrades Ubuntu and programs
    - Sets up firewalls and security hardening
+   - Optional Snort IDS profile (off by default; enable via `ENABLE_SNORT=true` in `config/user_config.env`)
    - Creates non-root user (SSH key-only, migrates root's keys)
    - Installs required programs
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This is a repo-backed operations skill, not a standalone blockchain package.
    
    - Upgrades Ubuntu and programs
    - Sets up firewalls and security hardening
-   - Optional Snort IDS profile (off by default; enable via `ENABLE_SNORT=true` in `config/user_config.env`)
+   - Snort IDS profile (enabled by default; disable via `ENABLE_SNORT=false` in `config/user_config.env`)
    - Creates non-root user (SSH key-only, migrates root's keys)
    - Installs required programs
 

--- a/config/user_config.env.example
+++ b/config/user_config.env.example
@@ -41,3 +41,11 @@ export MEV_SOLUTION='mev-boost'
 
 # Optional: Override checkpoint sync URL
 # export PRYSM_CPURL='https://beaconstate.ethstaker.cc'
+
+# Optional: Enable Snort IDS profile during Phase 1 hardening (off by default)
+# Note: Ubuntu package is Snort 2.x and adds packet-inspection overhead. Keep disabled unless needed.
+# export ENABLE_SNORT='true'
+# export SNORT_INTERFACE='auto'              # e.g., eth0
+# export SNORT_HOME_NET=''                   # e.g., 10.10.0.0/16 (empty = auto-detect)
+# export SNORT_STARTUP='boot'                # boot | manual
+# export SNORT_DISABLE_PROMISCUOUS='true'    # true for host-only traffic inspection

--- a/config/user_config.env.example
+++ b/config/user_config.env.example
@@ -42,9 +42,9 @@ export MEV_SOLUTION='mev-boost'
 # Optional: Override checkpoint sync URL
 # export PRYSM_CPURL='https://beaconstate.ethstaker.cc'
 
-# Optional: Enable Snort IDS profile during Phase 1 hardening (off by default)
-# Note: Ubuntu package is Snort 2.x and adds packet-inspection overhead. Keep disabled unless needed.
-# export ENABLE_SNORT='true'
+# Optional: Disable Snort IDS profile during Phase 1 hardening (enabled by default)
+# Note: Ubuntu package is Snort 2.x and adds packet-inspection overhead. Disable if this is not desired.
+# export ENABLE_SNORT='false'
 # export SNORT_INTERFACE='auto'              # e.g., eth0
 # export SNORT_HOME_NET=''                   # e.g., 10.10.0.0/16 (empty = auto-detect)
 # export SNORT_STARTUP='boot'                # boot | manual

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -85,7 +85,7 @@ ssh LOGIN_UNAME@<server-ip>
 - Backs up and migrates authorized_keys from root, SUDO_USER, and all /home/* users to new user (prevents lockout)
 - Copies eth2-quickstart to `~/eth2-quickstart` for new user (handoff: `cd ~/eth2-quickstart && ./run_2.sh`)
 - Security: runs consolidated security script
-- Optional IDS: Snort can be enabled via `ENABLE_SNORT=true` (off by default)
+- IDS: Snort is enabled by default; set `ENABLE_SNORT=false` to disable
 - NTP: installs `chrony` and enables NTP
 - Security: mounts `/run/shm` as `tmpfs` with `ro,noexec,nosuid`
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -64,6 +64,8 @@ Key variables:
 - `MAX_PEERS`: Consensus client peer cap
 - `GETH_CACHE`: Geth cache size in MB (default `8192`)
 - `MEV_RELAYS`: Comma-separated MEV-Boost relay URLs
+- `ENABLE_SNORT`: Optional Snort IDS profile toggle (`false` by default)
+- `SNORT_INTERFACE` / `SNORT_HOME_NET`: Optional Snort capture interface and CIDR scope
 
 ## Stage 1: Initial Hardening (run_1.sh)
 
@@ -83,6 +85,7 @@ ssh LOGIN_UNAME@<server-ip>
 - Backs up and migrates authorized_keys from root, SUDO_USER, and all /home/* users to new user (prevents lockout)
 - Copies eth2-quickstart to `~/eth2-quickstart` for new user (handoff: `cd ~/eth2-quickstart && ./run_2.sh`)
 - Security: runs consolidated security script
+- Optional IDS: Snort can be enabled via `ENABLE_SNORT=true` (off by default)
 - NTP: installs `chrony` and enables NTP
 - Security: mounts `/run/shm` as `tmpfs` with `ro,noexec,nosuid`
 

--- a/docs/SECURITY_GUIDE.md
+++ b/docs/SECURITY_GUIDE.md
@@ -9,6 +9,7 @@ This guide provides comprehensive security information for the Ethereum node set
 - **Localhost Binding**: All services bind to `127.0.0.1` only
 - **Firewall Protection**: UFW firewall with comprehensive rules
 - **Fail2ban Integration**: Protection against brute force attacks
+- **Optional Snort IDS**: Host-level packet inspection profile (explicit opt-in)
 - **Private Network Blocking**: Prevents network scan abuse
 
 ### File Security
@@ -36,7 +37,7 @@ This guide provides comprehensive security information for the Ethereum node set
 ## Security Scripts
 
 ### Core Security Scripts
-- **`install/security/consolidated_security.sh`** - Main security setup (firewall, fail2ban, AIDE)
+- **`install/security/consolidated_security.sh`** - Main security setup (firewall, fail2ban, optional Snort, AIDE)
 - **`install/security/nginx_harden.sh`** - Nginx proxy abuse protection
 - **`install/security/test_security_fixes.sh`** - Security testing suite
 
@@ -108,6 +109,19 @@ AIDE (Advanced Intrusion Detection Environment) creates a baseline of critical s
 - **`/bin`, `/usr/bin`, `/usr/sbin`** – Executables
 
 The config uses SHA-256 checksums for content integrity (per [AIDE best practices](https://github.com/aide/aide/blob/master/doc/aide.conf.5)). Daily checks run at 2 AM via cron. Review `/var/log/aide_check.log` for changes.
+
+### Optional Snort IDS Profile
+Snort support is intentionally off by default to avoid extra packet-inspection overhead on validator hosts.
+
+Enable via `config/user_config.env`:
+
+```bash
+export ENABLE_SNORT='true'
+export SNORT_INTERFACE='auto'
+export SNORT_HOME_NET=''
+export SNORT_STARTUP='boot'
+export SNORT_DISABLE_PROMISCUOUS='true'
+```
 
 ### Monitoring Schedule
 - **Security Monitoring**: Every 15 minutes

--- a/docs/SECURITY_GUIDE.md
+++ b/docs/SECURITY_GUIDE.md
@@ -9,7 +9,7 @@ This guide provides comprehensive security information for the Ethereum node set
 - **Localhost Binding**: All services bind to `127.0.0.1` only
 - **Firewall Protection**: UFW firewall with comprehensive rules
 - **Fail2ban Integration**: Protection against brute force attacks
-- **Optional Snort IDS**: Host-level packet inspection profile (explicit opt-in)
+- **Snort IDS**: Host-level packet inspection profile (enabled by default, configurable)
 - **Private Network Blocking**: Prevents network scan abuse
 
 ### File Security
@@ -37,7 +37,7 @@ This guide provides comprehensive security information for the Ethereum node set
 ## Security Scripts
 
 ### Core Security Scripts
-- **`install/security/consolidated_security.sh`** - Main security setup (firewall, fail2ban, optional Snort, AIDE)
+- **`install/security/consolidated_security.sh`** - Main security setup (firewall, fail2ban, Snort, AIDE)
 - **`install/security/nginx_harden.sh`** - Nginx proxy abuse protection
 - **`install/security/test_security_fixes.sh`** - Security testing suite
 
@@ -110,13 +110,13 @@ AIDE (Advanced Intrusion Detection Environment) creates a baseline of critical s
 
 The config uses SHA-256 checksums for content integrity (per [AIDE best practices](https://github.com/aide/aide/blob/master/doc/aide.conf.5)). Daily checks run at 2 AM via cron. Review `/var/log/aide_check.log` for changes.
 
-### Optional Snort IDS Profile
-Snort support is intentionally off by default to avoid extra packet-inspection overhead on validator hosts.
+### Snort IDS Profile
+Snort support is enabled by default during Phase 1 hardening.
 
-Enable via `config/user_config.env`:
+Disable via `config/user_config.env`:
 
 ```bash
-export ENABLE_SNORT='true'
+export ENABLE_SNORT='false'
 export SNORT_INTERFACE='auto'
 export SNORT_HOME_NET=''
 export SNORT_STARTUP='boot'

--- a/docs/SECURITY_STATUS.md
+++ b/docs/SECURITY_STATUS.md
@@ -3,7 +3,7 @@
 ## Current Architecture
 
 **Active Security Scripts**:
-- `install/security/consolidated_security.sh` - firewall, fail2ban, optional Snort IDS, AIDE setup. Called from run_1.sh
+- `install/security/consolidated_security.sh` - firewall, fail2ban, Snort IDS, AIDE setup. Called from run_1.sh
   - Functions: `setup_firewall()`, `setup_fail2ban()`, `setup_snort()`, `setup_aide()`, `verify_security_setup()`
   - Uses: `install_dependencies()`, `enable_and_start_systemd_service()`, `require_root()`, `get_script_directories()`
 - `install/security/nginx_harden.sh` (66 lines) - nginx proxy abuse protection. Called from nginx install scripts

--- a/docs/SECURITY_STATUS.md
+++ b/docs/SECURITY_STATUS.md
@@ -3,8 +3,8 @@
 ## Current Architecture
 
 **Active Security Scripts**:
-- `install/security/consolidated_security.sh` (239 lines) - firewall, fail2ban, AIDE setup. Called from run_1.sh
-  - Functions: `setup_firewall()`, `setup_fail2ban()`, `setup_aide()`, `verify_security_setup()`
+- `install/security/consolidated_security.sh` - firewall, fail2ban, optional Snort IDS, AIDE setup. Called from run_1.sh
+  - Functions: `setup_firewall()`, `setup_fail2ban()`, `setup_snort()`, `setup_aide()`, `verify_security_setup()`
   - Uses: `install_dependencies()`, `enable_and_start_systemd_service()`, `require_root()`, `get_script_directories()`
 - `install/security/nginx_harden.sh` (66 lines) - nginx proxy abuse protection. Called from nginx install scripts
 - `install/security/test_security_fixes.sh` - security testing suite

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -171,6 +171,27 @@ Use this file to preserve context across sessions.
   - add a guarded `repair --apply` path for clearly safe actions only
   - add explicit software release freshness checks before offering updater automation
 
+## Latest Update (Snort Default-On Baseline, 2026-04-13)
+
+- Switched Snort IDS from opt-in to enabled-by-default baseline:
+  - `exports.sh` now defaults `ENABLE_SNORT='true'`
+  - `install/security/consolidated_security.sh` now treats missing `ENABLE_SNORT` as enabled (`${ENABLE_SNORT:-true}`)
+- Kept explicit disable path for constrained hosts:
+  - set `ENABLE_SNORT=false` in `config/user_config.env`
+- Updated user-facing docs to match runtime behavior:
+  - `README.md`
+  - `config/user_config.env.example`
+  - `docs/SCRIPTS.md`
+  - `docs/SECURITY_GUIDE.md`
+  - `docs/SECURITY_STATUS.md`
+- Updated CI guardrails in `test/ci_test_run_1.sh` so defaults and gating checks assert default-on behavior.
+- Validation run:
+  - `bash -n exports.sh`
+  - `bash -n install/security/consolidated_security.sh`
+  - `bash -n test/ci_test_run_1.sh`
+  - `bash test/ci_test_run_1.sh`
+  - `bash test/ci_test_docs_consistency.sh`
+
 ## Latest Update (Optional Snort IDS Profile, 2026-04-09)
 
 - Added optional Snort IDS integration to Phase 1 security hardening with `ENABLE_SNORT=false` default in `exports.sh`

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -171,6 +171,33 @@ Use this file to preserve context across sessions.
   - add a guarded `repair --apply` path for clearly safe actions only
   - add explicit software release freshness checks before offering updater automation
 
+## Latest Update (Optional Snort IDS Profile, 2026-04-09)
+
+- Added optional Snort IDS integration to Phase 1 security hardening with `ENABLE_SNORT=false` default in `exports.sh`
+- Added Snort config knobs:
+  - `SNORT_INTERFACE` (default `auto`)
+  - `SNORT_HOME_NET` (default empty; auto-detect)
+  - `SNORT_STARTUP` (`boot|manual`, default `boot`)
+  - `SNORT_DISABLE_PROMISCUOUS` (default `true`)
+- `install/security/consolidated_security.sh` now includes:
+  - truthy parser + interface/CIDR auto-detection helpers
+  - gated `setup_snort()` path with debconf preseeding for non-interactive installs
+  - package install + config patching + `snort -T` self-test + optional service enable/start
+  - verification checks when Snort is enabled
+- Updated docs/user config examples to document optional Snort profile:
+  - `README.md`
+  - `config/user_config.env.example`
+  - `docs/SCRIPTS.md`
+  - `docs/SECURITY_GUIDE.md`
+  - `docs/SECURITY_STATUS.md`
+- Added CI structure checks in `test/ci_test_run_1.sh` to ensure Snort remains off-by-default and gated
+- Validation run:
+  - `bash -n install/security/consolidated_security.sh`
+  - `bash -n test/ci_test_run_1.sh`
+  - `bash -n exports.sh`
+  - `bash test/ci_test_run_1.sh`
+  - `bash test/ci_test_docs_consistency.sh`
+
 ## Latest Update (Safe Repair Workflow, 2026-04-08)
 
 - Added `install/utils/repair.sh` and wrapper command `./scripts/eth2qs.sh repair`
@@ -240,7 +267,6 @@ Use this file to preserve context across sessions.
 - Follow-up:
   - `stats --json` is still the latency bottleneck because it walks recent journals for every known service; next pass should add an explicit fast mode or incremental cache instead of re-scanning the full fleet on every call
   - `repair --apply` is still intentionally bounded to allowlisted restart actions; do not widen it into unattended software upgrades without explicit freshness + safety gates
-
 ## MCP Meta Learnings
 
 - Composite GitHub actions must not reference `secrets.*` directly in `action.yml`; pass tokens through explicit action inputs from the workflow.

--- a/exports.sh
+++ b/exports.sh
@@ -29,6 +29,15 @@ export CHAIN='ethereum'
 export maxretry='3'
 export REPO_NAME="eth2-quickstart"
 
+# Optional IDS profile (off by default).
+# ENABLE_SNORT=true enables Snort package install/config in Phase 1.
+# Defaults are safe for host-level IDS on a validator/RPC node.
+export ENABLE_SNORT='false'
+export SNORT_INTERFACE='auto'               # auto-detect default route interface
+export SNORT_HOME_NET=''                    # auto-detect CIDR from interface when empty
+export SNORT_STARTUP='boot'                 # boot | manual
+export SNORT_DISABLE_PROMISCUOUS='true'     # true = inspect traffic for host interface only
+
 # Server name used for nginx, caddy & ssl setup
 export SERVER_NAME="rpc.sharedtools.org"
 

--- a/exports.sh
+++ b/exports.sh
@@ -29,10 +29,10 @@ export CHAIN='ethereum'
 export maxretry='3'
 export REPO_NAME="eth2-quickstart"
 
-# Optional IDS profile (off by default).
-# ENABLE_SNORT=true enables Snort package install/config in Phase 1.
+# IDS profile (enabled by default).
+# Set ENABLE_SNORT=false to skip Snort package install/config in Phase 1.
 # Defaults are safe for host-level IDS on a validator/RPC node.
-export ENABLE_SNORT='false'
+export ENABLE_SNORT='true'
 export SNORT_INTERFACE='auto'               # auto-detect default route interface
 export SNORT_HOME_NET=''                    # auto-detect CIDR from interface when empty
 export SNORT_STARTUP='boot'                 # boot | manual

--- a/install/security/consolidated_security.sh
+++ b/install/security/consolidated_security.sh
@@ -17,6 +17,36 @@ require_root
 
 log_installation_start "Consolidated Security Suite"
 
+is_truthy() {
+    local value="${1:-}"
+    case "${value,,}" in
+        1|true|yes|y|on) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+detect_default_interface() {
+    local iface=""
+    iface=$(ip -o -4 route show to default 2>/dev/null | awk '{print $5; exit}')
+    if [[ -z "$iface" ]]; then
+        iface=$(ip -o link show 2>/dev/null | awk -F': ' '$2 != "lo" {print $2; exit}')
+    fi
+    echo "$iface"
+}
+
+detect_home_net_cidr() {
+    local iface="${1:-}"
+    local cidr=""
+    if [[ -n "$iface" ]]; then
+        cidr=$(ip -o -4 addr show dev "$iface" scope global 2>/dev/null | awk '{print $4; exit}')
+    fi
+    if [[ -z "$cidr" ]]; then
+        cidr="192.168.0.0/16"
+        log_warn "Unable to auto-detect SNORT_HOME_NET; falling back to $cidr"
+    fi
+    echo "$cidr"
+}
+
 # Function 1: Setup Firewall
 setup_firewall() {
     log_info "Setting up UFW firewall with comprehensive rules..."
@@ -188,7 +218,95 @@ EOF
     log_info "✓ Fail2ban installation and configuration complete"
 }
 
-# Function 3: Setup AIDE
+# Function 3: Setup optional Snort IDS (off by default)
+setup_snort() {
+    if ! is_truthy "${ENABLE_SNORT:-false}"; then
+        log_info "Snort IDS disabled (ENABLE_SNORT=false)"
+        return 0
+    fi
+
+    log_info "Setting up optional Snort IDS..."
+
+    local snort_iface="${SNORT_INTERFACE:-auto}"
+    local snort_home_net="${SNORT_HOME_NET:-}"
+    local snort_startup="${SNORT_STARTUP:-boot}"
+    local snort_disable_promisc="false"
+    if is_truthy "${SNORT_DISABLE_PROMISCUOUS:-true}"; then
+        snort_disable_promisc="true"
+    fi
+
+    if [[ "$snort_startup" != "boot" && "$snort_startup" != "manual" ]]; then
+        log_warn "Invalid SNORT_STARTUP='$snort_startup' (valid: boot|manual); defaulting to boot"
+        snort_startup="boot"
+    fi
+
+    if [[ -z "$snort_iface" || "$snort_iface" == "auto" ]]; then
+        snort_iface=$(detect_default_interface)
+    fi
+    if [[ -z "$snort_iface" ]]; then
+        snort_iface="eth0"
+        log_warn "Unable to auto-detect network interface; defaulting SNORT_INTERFACE=$snort_iface"
+    fi
+
+    if [[ -z "$snort_home_net" ]]; then
+        snort_home_net=$(detect_home_net_cidr "$snort_iface")
+    fi
+
+    if ! command -v debconf-set-selections >/dev/null 2>&1; then
+        log_error "debconf-set-selections is required for non-interactive Snort setup"
+        exit 1
+    fi
+
+    log_info "Preseeding Snort package config (iface=$snort_iface, HOME_NET=$snort_home_net, startup=$snort_startup)"
+    cat <<EOF | debconf-set-selections
+snort snort/startup select $snort_startup
+snort snort/interface string $snort_iface
+snort snort/address_range string $snort_home_net
+snort snort/disable_promiscuous boolean $snort_disable_promisc
+EOF
+
+    # Ubuntu/Debian package currently provides Snort 2.x; keep this opt-in.
+    install_dependencies snort snort-rules-default
+
+    local snort_debian_conf="/etc/snort/snort.debian.conf"
+    if [[ -f "$snort_debian_conf" ]]; then
+        if grep -q '^DEBIAN_SNORT_HOME_NET=' "$snort_debian_conf"; then
+            sed -i "s|^DEBIAN_SNORT_HOME_NET=.*|DEBIAN_SNORT_HOME_NET=\"$snort_home_net\"|" "$snort_debian_conf"
+        else
+            echo "DEBIAN_SNORT_HOME_NET=\"$snort_home_net\"" >> "$snort_debian_conf"
+        fi
+
+        if grep -q '^DEBIAN_SNORT_INTERFACE=' "$snort_debian_conf"; then
+            sed -i "s|^DEBIAN_SNORT_INTERFACE=.*|DEBIAN_SNORT_INTERFACE=\"$snort_iface\"|" "$snort_debian_conf"
+        else
+            echo "DEBIAN_SNORT_INTERFACE=\"$snort_iface\"" >> "$snort_debian_conf"
+        fi
+    fi
+
+    if command -v snort >/dev/null 2>&1; then
+        if snort -T -q -c /etc/snort/snort.conf >/tmp/snort-selftest.log 2>&1; then
+            log_info "✓ Snort configuration self-test passed"
+        else
+            log_warn "Snort self-test reported issues; see /tmp/snort-selftest.log"
+        fi
+    else
+        log_error "Snort command not found after installation"
+        exit 1
+    fi
+
+    if [[ "$snort_startup" == "boot" ]]; then
+        enable_and_start_systemd_service snort
+        if systemctl is-active --quiet snort 2>/dev/null; then
+            log_info "✓ Snort service running"
+        else
+            log_warn "Snort service not active - check: systemctl status snort"
+        fi
+    else
+        log_info "Snort configured for manual startup"
+    fi
+}
+
+# Function 4: Setup AIDE
 setup_aide() {
     log_info "Setting up AIDE file integrity monitoring..."
 
@@ -263,7 +381,7 @@ EOF
     log_info "✓ AIDE file integrity monitoring setup complete"
 }
 
-# Function 4: Security Verification
+# Function 5: Security Verification
 verify_security_setup() {
     log_info "Verifying security setup..."
 
@@ -302,6 +420,27 @@ verify_security_setup() {
         issues=$((issues + 1))
     fi
 
+    # Check optional Snort
+    if is_truthy "${ENABLE_SNORT:-false}"; then
+        log_info "Checking Snort service..."
+        if command -v snort >/dev/null 2>&1; then
+            log_info "✓ Snort is installed"
+            if [[ "${SNORT_STARTUP:-boot}" == "boot" ]]; then
+                if systemctl is-active --quiet snort 2>/dev/null; then
+                    log_info "✓ Snort service is running"
+                else
+                    log_warn "Snort installed but service is not active"
+                    issues=$((issues + 1))
+                fi
+            else
+                log_info "Snort startup mode is manual; service check skipped"
+            fi
+        else
+            log_error "✗ Snort is not installed"
+            issues=$((issues + 1))
+        fi
+    fi
+
     if [[ $issues -eq 0 ]]; then
         log_info "✓ All security features verified successfully"
     else
@@ -317,6 +456,7 @@ main() {
     # Run all security setup functions
     setup_firewall
     setup_fail2ban
+    setup_snort
     setup_aide
     
     # Verify security setup
@@ -326,6 +466,9 @@ main() {
     log_info "✓ Firewall configured with comprehensive rules"
     log_info "✓ Fail2ban intrusion prevention active"
     log_info "✓ AIDE file integrity monitoring scheduled"
+    if is_truthy "${ENABLE_SNORT:-false}"; then
+        log_info "✓ Snort IDS configured (optional profile)"
+    fi
     log_info "✓ All security features are now active and protecting your system"
     
     log_installation_complete "Consolidated Security Suite" "security-suite"

--- a/install/security/consolidated_security.sh
+++ b/install/security/consolidated_security.sh
@@ -218,14 +218,14 @@ EOF
     log_info "✓ Fail2ban installation and configuration complete"
 }
 
-# Function 3: Setup optional Snort IDS (off by default)
+# Function 3: Setup Snort IDS (enabled by default; can be disabled via ENABLE_SNORT=false)
 setup_snort() {
-    if ! is_truthy "${ENABLE_SNORT:-false}"; then
-        log_info "Snort IDS disabled (ENABLE_SNORT=false)"
+    if ! is_truthy "${ENABLE_SNORT:-true}"; then
+        log_info "Snort IDS disabled via configuration (ENABLE_SNORT=false)"
         return 0
     fi
 
-    log_info "Setting up optional Snort IDS..."
+    log_info "Setting up Snort IDS..."
 
     local snort_iface="${SNORT_INTERFACE:-auto}"
     local snort_home_net="${SNORT_HOME_NET:-}"
@@ -265,7 +265,7 @@ snort snort/address_range string $snort_home_net
 snort snort/disable_promiscuous boolean $snort_disable_promisc
 EOF
 
-    # Ubuntu/Debian package currently provides Snort 2.x; keep this opt-in.
+    # Ubuntu/Debian package currently provides Snort 2.x.
     install_dependencies snort snort-rules-default
 
     local snort_debian_conf="/etc/snort/snort.debian.conf"
@@ -420,8 +420,8 @@ verify_security_setup() {
         issues=$((issues + 1))
     fi
 
-    # Check optional Snort
-    if is_truthy "${ENABLE_SNORT:-false}"; then
+    # Check Snort when enabled
+    if is_truthy "${ENABLE_SNORT:-true}"; then
         log_info "Checking Snort service..."
         if command -v snort >/dev/null 2>&1; then
             log_info "✓ Snort is installed"
@@ -466,8 +466,8 @@ main() {
     log_info "✓ Firewall configured with comprehensive rules"
     log_info "✓ Fail2ban intrusion prevention active"
     log_info "✓ AIDE file integrity monitoring scheduled"
-    if is_truthy "${ENABLE_SNORT:-false}"; then
-        log_info "✓ Snort IDS configured (optional profile)"
+    if is_truthy "${ENABLE_SNORT:-true}"; then
+        log_info "✓ Snort IDS configured"
     fi
     log_info "✓ All security features are now active and protecting your system"
     

--- a/test/ci_test_run_1.sh
+++ b/test/ci_test_run_1.sh
@@ -423,6 +423,29 @@ else
     exit 1
 fi
 
+# Test 32: Verify optional Snort config defaults are present and safe
+log_info "Test 32: Verify optional Snort defaults..."
+if grep -q "export ENABLE_SNORT='false'" "$PROJECT_ROOT/exports.sh" && \
+   grep -q "export SNORT_INTERFACE='auto'" "$PROJECT_ROOT/exports.sh" && \
+   grep -q "export SNORT_STARTUP='boot'" "$PROJECT_ROOT/exports.sh"; then
+    log_info "  Snort defaults are present and off-by-default"
+else
+    log_error "  exports.sh must define safe optional Snort defaults"
+    exit 1
+fi
+
+# Test 33: Verify Snort setup is gated and non-default in consolidated security
+log_info "Test 33: Verify Snort gating in consolidated security..."
+if grep -q "^setup_snort()" "$PROJECT_ROOT/install/security/consolidated_security.sh" && \
+   grep -q 'ENABLE_SNORT:-false' "$PROJECT_ROOT/install/security/consolidated_security.sh" && \
+   grep -q "install_dependencies snort snort-rules-default" "$PROJECT_ROOT/install/security/consolidated_security.sh" && \
+   grep -q "setup_snort" "$PROJECT_ROOT/install/security/consolidated_security.sh"; then
+    log_info "  consolidated security script includes gated optional Snort setup"
+else
+    log_error "  consolidated security script missing gated optional Snort integration"
+    exit 1
+fi
+
 log_info "╔════════════════════════════════════════════════════════════════╗"
 log_info "║  run_1.sh CI Test PASSED                                      ║"
 log_info "║  Validated: Structure, syntax, functions, SSH safety,         ║"

--- a/test/ci_test_run_1.sh
+++ b/test/ci_test_run_1.sh
@@ -423,26 +423,26 @@ else
     exit 1
 fi
 
-# Test 32: Verify optional Snort config defaults are present and safe
-log_info "Test 32: Verify optional Snort defaults..."
-if grep -q "export ENABLE_SNORT='false'" "$PROJECT_ROOT/exports.sh" && \
+# Test 32: Verify Snort config defaults are present and enabled
+log_info "Test 32: Verify Snort defaults..."
+if grep -q "export ENABLE_SNORT='true'" "$PROJECT_ROOT/exports.sh" && \
    grep -q "export SNORT_INTERFACE='auto'" "$PROJECT_ROOT/exports.sh" && \
    grep -q "export SNORT_STARTUP='boot'" "$PROJECT_ROOT/exports.sh"; then
-    log_info "  Snort defaults are present and off-by-default"
+    log_info "  Snort defaults are present and enabled-by-default"
 else
-    log_error "  exports.sh must define safe optional Snort defaults"
+    log_error "  exports.sh must define safe Snort defaults with default enablement"
     exit 1
 fi
 
-# Test 33: Verify Snort setup is gated and non-default in consolidated security
+# Test 33: Verify Snort setup is gated in consolidated security
 log_info "Test 33: Verify Snort gating in consolidated security..."
 if grep -q "^setup_snort()" "$PROJECT_ROOT/install/security/consolidated_security.sh" && \
-   grep -q 'ENABLE_SNORT:-false' "$PROJECT_ROOT/install/security/consolidated_security.sh" && \
+   grep -q 'ENABLE_SNORT:-true' "$PROJECT_ROOT/install/security/consolidated_security.sh" && \
    grep -q "install_dependencies snort snort-rules-default" "$PROJECT_ROOT/install/security/consolidated_security.sh" && \
    grep -q "setup_snort" "$PROJECT_ROOT/install/security/consolidated_security.sh"; then
-    log_info "  consolidated security script includes gated optional Snort setup"
+    log_info "  consolidated security script includes gated Snort setup"
 else
-    log_error "  consolidated security script missing gated optional Snort integration"
+    log_error "  consolidated security script missing gated Snort integration"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- switch Snort IDS baseline from opt-in to enabled-by-default during Phase 1 hardening
- keep explicit disable path via `ENABLE_SNORT=false` for constrained hosts
- update consolidated security defaults to treat missing `ENABLE_SNORT` as enabled
- refresh docs and user config examples to reflect default-on behavior
- update CI assertions in `test/ci_test_run_1.sh` to enforce default-on + gated setup

## Usage
Snort is enabled by default. Disable in `config/user_config.env` only when needed:

```bash
export ENABLE_SNORT='false'
export SNORT_INTERFACE='auto'
export SNORT_HOME_NET=''
export SNORT_STARTUP='boot'
export SNORT_DISABLE_PROMISCUOUS='true'
```

## Validation
- `bash -n exports.sh`
- `bash -n install/security/consolidated_security.sh`
- `bash -n test/ci_test_run_1.sh`
- `bash test/ci_test_run_1.sh`
- `bash test/ci_test_docs_consistency.sh`

## Runtime verification
- phase-1 security flow run locally with Snort enabled
- `snort -T -q -c /etc/snort/snort.conf` passes
- `systemctl is-enabled snort` => enabled
- `systemctl is-active snort` => active