### PR TITLE
fix(configure): align local graffiti variable with exported GRAFITTI key

### DIFF
--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -7,6 +7,27 @@ Use this file to preserve context across sessions.
 - Preserve valuable uncommitted work before syncing (stash or branch).
 - Use a fresh branch + fresh PR for each new task.
 
+## Latest Update (PR #168 CI fix, 2026-04-10)
+
+- Fixed `shellcheck-extended` failure in `install/test/test_repair_safe_actions.sh` by quoting a return status variable:
+  - `return $status` -> `return "$status"`
+- Fixed `tui-whiptail-nonskip-guard` and `docker-integration` failure caused by a brittle/duplicated JSON-mode test in `install/test/test_stats_read_only.sh`:
+  - removed duplicate `test_stats_supports_json_mode` definition
+  - replaced static `grep '--json' stats.sh` assertion with behavior validation:
+    - injects `ETH2QS_STATS_FIXTURE`
+    - runs `stats.sh --json`
+    - verifies emitted payload is valid JSON with expected summary status
+- Why:
+  - the wrapper `stats.sh` now delegates to `stats_json.py` and forwards args (`"$@"`), so checking for a literal `--json` string in `stats.sh` was a false negative
+  - CI needed to validate real behavior, not implementation detail
+- Validation run:
+  - `bash install/test/test_stats_read_only.sh`
+  - `shellcheck -x --exclude=SC2317,SC1091,SC1090,SC2034,SC2031,SC2181 install/test/test_repair_safe_actions.sh install/test/test_stats_read_only.sh`
+  - `REQUIRE_WHIPTAIL_PIPE_TEST=1 SKIP_SHELLCHECK=true USE_MOCKS=true ./test/run_tests.sh --unit`
+  - full repo shellcheck parity with CI loop over all `*.sh` files
+- Follow-up:
+  - keep behavior-based assertions for wrapper scripts to avoid future false CI failures when implementation details change but public behavior is unchanged.
+
 ## Latest Update (run_2 unknown-option hardening, 2026-04-08)
 
 - `run_2.sh` now fails fast on unknown CLI flags before logging/install side effects:

--- a/install/test/test_repair_safe_actions.sh
+++ b/install/test/test_repair_safe_actions.sh
@@ -114,7 +114,7 @@ EOF
         ! grep -Fq "update-all" "$sudo_log"
     local status=$?
     rm -rf "$temp_dir"
-    return $status
+    return "$status"
 }
 
 test_refresh_supports_smart_mode() {

--- a/install/test/test_stats_read_only.sh
+++ b/install/test/test_stats_read_only.sh
@@ -41,16 +41,22 @@ test_stats_uses_local_prysm_binary_discovery() {
         grep -Fq 'bootstrap script present, local binary not downloaded' "$COMMON_MONITOR_SCRIPT"
 }
 
-# shellcheck disable=SC2317
 test_stats_supports_json_mode() {
-    grep -Fq 'stats_json.py' "$STATS_SCRIPT" &&
-        grep -Fq -- '--json' "$STATS_JSON_SCRIPT"
-}
+    local fixture='{"summary":{"status":"pass","issues_detected":0},"issues":[]}'
+    local output
 
-# shellcheck disable=SC2317
-test_stats_supports_json_mode() {
+    output="$(ETH2QS_STATS_FIXTURE="$fixture" bash "$STATS_SCRIPT" --json)"
+
     grep -Fq 'stats_json.py' "$STATS_SCRIPT" &&
-        grep -Fq -- '--json' "$STATS_SCRIPT"
+        grep -Fq -- '--json' "$STATS_JSON_SCRIPT" &&
+        printf '%s' "$output" | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+if payload.get("summary", {}).get("status") != "pass":
+    raise SystemExit(1)
+'
 }
 
 echo "=========================================="

--- a/install/utils/configure.sh
+++ b/install/utils/configure.sh
@@ -115,7 +115,7 @@ if [[ "$VIBE_MODE" == "true" ]]; then
     CONS_CLIENT="$REC_CONS"
     MEV_CHOICE="mev-boost"
     FEE_RECIPIENT="0x0000000000000000000000000000000000000000"
-    GRAFFITI="Eth2QuickStart"
+    GRAFITTI="Eth2QuickStart"
     
     log_info "Hardware profile: $HARDWARE_PROFILE"
     log_info "Network: $NETWORK"
@@ -206,9 +206,9 @@ else
     fi
     
     # 6. Graffiti
-    GRAFFITI=$(whiptail --title "Graffiti" --inputbox "Enter your validator graffiti:\n\n(This public note appears on blocks you propose)" 12 70 "Eth2QuickStart" 3>&1 1>&2 2>&3 </dev/tty)
-    if [[ $? -ne 0 ]] || [[ -z "$GRAFFITI" ]]; then 
-        GRAFFITI="Eth2QuickStart"
+    GRAFITTI=$(whiptail --title "Graffiti" --inputbox "Enter your validator graffiti:\n\n(This public note appears on blocks you propose)" 12 70 "Eth2QuickStart" 3>&1 1>&2 2>&3 </dev/tty)
+    if [[ $? -ne 0 ]] || [[ -z "$GRAFITTI" ]]; then 
+        GRAFITTI="Eth2QuickStart"
     fi
 fi
 
@@ -229,7 +229,7 @@ export ETH_NETWORK='$NETWORK'
 export FEE_RECIPIENT='$FEE_RECIPIENT'
 
 # Validator graffiti (shown on proposed blocks)
-export GRAFITTI='$GRAFFITI'
+export GRAFITTI='$GRAFITTI'
 
 # Selected Clients
 export EXEC_CLIENT='$EXEC_CLIENT'
@@ -460,7 +460,7 @@ echo "  Network:    $NETWORK"
 echo "  Execution:  $EXEC_CLIENT"
 echo "  Consensus:  $CONS_CLIENT"
 echo "  MEV:        $MEV_CHOICE"
-echo "  Graffiti:   $GRAFFITI"
+echo "  Graffiti:   $GRAFITTI"
 echo ""
 
 if [[ "$VIBE_MODE" != "true" ]]; then


### PR DESCRIPTION
## Summary
- rename local `configure.sh` variable from `GRAFFITI` to `GRAFITTI`
- keep behavior unchanged while removing mixed spelling inside the script
- align local variable naming with the exported key used across this repo (`GRAFITTI`)

## Why
CLI-Anything harness review surfaced confusion around mixed graffiti key naming. In this repo, the canonical exported/env key is `GRAFITTI`; this patch makes the local variable naming consistent with that contract.

## Validation
- `bash -n install/utils/configure.sh`
- checked all occurrences in file are now `GRAFITTI`

## Scope
- no runtime behavior changes
- no client config value changes