### PR TITLE
feat(automation): add daily upstream PR watcher cron for CLI-Anything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,7 @@ logs/
 # Package artifacts (chrony, etc.)
 *.deb
 
+# CI poll snapshots
+status/*.json
+
 .DS_store

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -13,12 +13,19 @@ Bash scripts to harden Ubuntu server and install Ethereum node stack: execution 
 For upstream review tracking (for example CLI-Anything harness PRs), use:
 
 ```bash
-./scripts/check-cli-anything-pr.sh --repo HKUDS/CLI-Anything --pr 195
-./scripts/install-cli-anything-pr-watch-cron.sh --repo HKUDS/CLI-Anything --pr 195
+./scripts/check-cli-anything-pr.sh
+./scripts/install-cli-anything-pr-watch-cron.sh
+./scripts/uninstall-cli-anything-pr-watch-cron.sh
+./status/poll_ci.sh
 ```
 
+Defaults now target the local active PR (`chimera-defi/eth2-quickstart` PR `167`).
+Override target PR with `--repo` and `--pr` when needed.
+
 `check-cli-anything-pr.sh` stores state under `~/.eth2qs-pr-watch/`, reports new actionable feedback, and can optionally trigger an autofix command.
-`install-cli-anything-pr-watch-cron.sh` installs an idempotent daily cron entry that runs the check script and appends logs to `~/.eth2qs-pr-watch/cron.log`.
+`install-cli-anything-pr-watch-cron.sh` installs an idempotent daily cron entry that runs the check script, appends logs to `~/.eth2qs-pr-watch/cron.log`, and auto-removes itself when the watched PR closes/merges.
+`uninstall-cli-anything-pr-watch-cron.sh` removes existing watch entries by cron marker.
+`status/poll_ci.sh` snapshots open PR CI/review state into `status/ci-summary.json` and runs one PR-watch check each poll cycle.
 
 ## Unified Wrapper (Recommended)
 

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -8,6 +8,18 @@ Bash scripts to harden Ubuntu server and install Ethereum node stack: execution 
 - **Order**: `run_1.sh` → reboot → login as `LOGIN_UNAME` → update `exports.sh` → `run_2.sh`
 - **Config**: `exports.sh` (email, domain, fee recipient, graffiti, peers, relay list, ports)
 
+## Repo Maintenance Automation
+
+For upstream review tracking (for example CLI-Anything harness PRs), use:
+
+```bash
+./scripts/check-cli-anything-pr.sh --repo HKUDS/CLI-Anything --pr 195
+./scripts/install-cli-anything-pr-watch-cron.sh --repo HKUDS/CLI-Anything --pr 195
+```
+
+`check-cli-anything-pr.sh` stores state under `~/.eth2qs-pr-watch/`, reports new actionable feedback, and can optionally trigger an autofix command.
+`install-cli-anything-pr-watch-cron.sh` installs an idempotent daily cron entry that runs the check script and appends logs to `~/.eth2qs-pr-watch/cron.log`.
+
 ## Unified Wrapper (Recommended)
 
 Use `scripts/eth2qs.sh` as a stable command entrypoint for both humans and AI agents.

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -7,6 +7,34 @@ Use this file to preserve context across sessions.
 - Preserve valuable uncommitted work before syncing (stash or branch).
 - Use a fresh branch + fresh PR for each new task.
 
+## Latest Update (PR watch refinement pass, 2026-04-13)
+
+- Refined watch defaults to local active PR monitoring:
+  - default `--repo`: `chimera-defi/eth2-quickstart`
+  - default `--pr`: `167`
+- Added automatic cron self-disable behavior:
+  - `check-cli-anything-pr.sh --disable-cron-on-closed` now removes its cron marker entry when the watched PR is no longer open.
+- Added `scripts/uninstall-cli-anything-pr-watch-cron.sh` for explicit manual cleanup by cron marker.
+- Added tracked `status/poll_ci.sh`:
+  - snapshots open PR CI/review state to `status/open-prs.json` and `status/ci-summary.json`
+  - runs one PR-watch check per poll cycle and writes `status/pr-watch-last.json`
+  - fixes the previously missing cron target path for `*/5 * * * * .../status/poll_ci.sh`
+- Updated `scripts/install-cli-anything-pr-watch-cron.sh`:
+  - supports `--disable-on-closed` / `--no-disable-on-closed`
+  - passes marker + disable flags to the watch command
+  - defaults to self-disable enabled
+- Updated `docs/SCRIPTS.md` with new defaults and uninstall command.
+- Validation run:
+  - `bash -n scripts/check-cli-anything-pr.sh`
+  - `bash -n scripts/install-cli-anything-pr-watch-cron.sh`
+  - `bash -n scripts/uninstall-cli-anything-pr-watch-cron.sh`
+  - `bash -n status/poll_ci.sh`
+  - `shellcheck scripts/check-cli-anything-pr.sh scripts/install-cli-anything-pr-watch-cron.sh scripts/uninstall-cli-anything-pr-watch-cron.sh`
+  - `./scripts/install-cli-anything-pr-watch-cron.sh --repo chimera-defi/eth2-quickstart --pr 167 --state-dir /tmp/eth2qs-pr-watch-test`
+  - `./scripts/check-cli-anything-pr.sh --repo chimera-defi/eth2-quickstart --pr 169 --state-dir /tmp/eth2qs-pr-watch-test --disable-cron-on-closed --cron-marker eth2qs-cli-pr-watch-test`
+  - `./scripts/uninstall-cli-anything-pr-watch-cron.sh --cron-marker eth2qs-cli-pr-watch-test`
+  - `ETH2QS_STATUS_WATCH_PR=169 ./status/poll_ci.sh`
+
 ## Latest Update (CLI-Anything PR watch cron, 2026-04-13)
 
 - Added `scripts/check-cli-anything-pr.sh` to monitor upstream PR feedback daily via GitHub API.

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -7,6 +7,26 @@ Use this file to preserve context across sessions.
 - Preserve valuable uncommitted work before syncing (stash or branch).
 - Use a fresh branch + fresh PR for each new task.
 
+## Latest Update (CLI-Anything PR watch cron, 2026-04-13)
+
+- Added `scripts/check-cli-anything-pr.sh` to monitor upstream PR feedback daily via GitHub API.
+  - Tracks new issue comments, review comments, and review states.
+  - Flags actionable feedback from non-self authors (`request changes`, blockers, fix requests).
+  - Writes state + alert reports under `~/.eth2qs-pr-watch/`.
+  - Supports optional `--autofix-cmd` hook for automated follow-up.
+- Added `scripts/install-cli-anything-pr-watch-cron.sh`.
+  - Installs/replaces an idempotent cron entry with marker `eth2qs-cli-pr-watch`.
+  - Defaults to daily run (`15 9 * * *`) and logs to `~/.eth2qs-pr-watch/cron.log`.
+- Added maintenance docs in `docs/SCRIPTS.md` for these commands.
+- Validation run:
+  - `bash -n scripts/check-cli-anything-pr.sh`
+  - `bash -n scripts/install-cli-anything-pr-watch-cron.sh`
+  - `./scripts/check-cli-anything-pr.sh --repo HKUDS/CLI-Anything --pr 195 --state-dir /tmp/eth2qs-pr-watch-test`
+  - `./scripts/install-cli-anything-pr-watch-cron.sh --repo HKUDS/CLI-Anything --pr 195 --state-dir /tmp/eth2qs-pr-watch-test --schedule "17 9 * * *"`
+- Follow-up:
+  - PR #195 is already merged (2026-04-13), so this automation is mainly a reusable pattern for future upstream PRs.
+  - If fully autonomous patching is desired, wire `--autofix-cmd` to a guarded branch+test+PR workflow.
+
 ## Latest Update (PR #168 CI fix, 2026-04-10)
 
 - Fixed `shellcheck-extended` failure in `install/test/test_repair_safe_actions.sh` by quoting a return status variable:

--- a/scripts/check-cli-anything-pr.sh
+++ b/scripts/check-cli-anything-pr.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_REPO="HKUDS/CLI-Anything"
-DEFAULT_PR="195"
+DEFAULT_REPO="chimera-defi/eth2-quickstart"
+DEFAULT_PR="167"
 DEFAULT_IGNORE_AUTHOR="chimera-defi"
 DEFAULT_STATE_DIR="${HOME}/.eth2qs-pr-watch"
 DEFAULT_ACTIONABLE_REGEX='blocker|request[[:space:]]+changes|should[[:space:]]+fix|must[[:space:]]+fix|please[[:space:]]+fix|needs?[[:space:]]+fix|merge[[:space:]]+conflict|rebase|failing'
+DEFAULT_CRON_MARKER="eth2qs-cli-pr-watch"
 
 usage() {
   cat <<'EOF'
 usage: ./scripts/check-cli-anything-pr.sh [options]
 
 options:
-  --repo <owner/name>        Upstream repository to watch (default: HKUDS/CLI-Anything)
-  --pr <number>              Pull request number to watch (default: 195)
+  --repo <owner/name>        Repository to watch (default: chimera-defi/eth2-quickstart)
+  --pr <number>              Pull request number to watch (default: 167)
   --ignore-author <login>    Ignore actionable checks from this author (default: chimera-defi)
   --state-dir <path>         State/report directory (default: ~/.eth2qs-pr-watch)
   --autofix-cmd <command>    Optional command to run when new actionable feedback is found
+  --disable-cron-on-closed   Remove cron marker entry when PR is no longer open
+  --cron-marker <text>       Cron marker to remove (default: eth2qs-cli-pr-watch)
   --dry-run                  Do not execute autofix command
   --exit-nonzero-on-actionable
                              Exit with code 10 when actionable feedback is found
@@ -30,6 +33,8 @@ env overrides:
   ETH2QS_PR_WATCH_AUTOFIX_CMD
   ETH2QS_PR_WATCH_AUTOFIX_B64
   ETH2QS_PR_WATCH_ACTIONABLE_REGEX
+  ETH2QS_PR_WATCH_DISABLE_CRON_ON_CLOSED
+  ETH2QS_PR_WATCH_CRON_MARKER
 EOF
 }
 
@@ -41,12 +46,26 @@ require_cmd() {
   fi
 }
 
+remove_cron_entry() {
+  local marker="$1"
+  require_cmd crontab
+  require_cmd mktemp
+  require_cmd awk
+  local tmpfile
+  tmpfile="$(mktemp)"
+  crontab -l 2>/dev/null | awk -v marker="$marker" 'index($0, marker) == 0' > "$tmpfile" || true
+  crontab "$tmpfile"
+  rm -f "$tmpfile"
+}
+
 repo="${ETH2QS_PR_WATCH_REPO:-$DEFAULT_REPO}"
 pr_number="${ETH2QS_PR_WATCH_PR:-$DEFAULT_PR}"
 ignore_author="${ETH2QS_PR_WATCH_IGNORE_AUTHOR:-$DEFAULT_IGNORE_AUTHOR}"
 state_dir="${ETH2QS_PR_WATCH_STATE_DIR:-$DEFAULT_STATE_DIR}"
 autofix_cmd="${ETH2QS_PR_WATCH_AUTOFIX_CMD:-}"
 actionable_regex="${ETH2QS_PR_WATCH_ACTIONABLE_REGEX:-$DEFAULT_ACTIONABLE_REGEX}"
+disable_cron_on_closed="${ETH2QS_PR_WATCH_DISABLE_CRON_ON_CLOSED:-false}"
+cron_marker="${ETH2QS_PR_WATCH_CRON_MARKER:-$DEFAULT_CRON_MARKER}"
 dry_run="false"
 exit_nonzero_on_actionable="false"
 
@@ -70,6 +89,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --autofix-cmd)
       autofix_cmd="$2"
+      shift 2
+      ;;
+    --disable-cron-on-closed)
+      disable_cron_on_closed="true"
+      shift
+      ;;
+    --cron-marker)
+      cron_marker="$2"
       shift 2
       ;;
     --dry-run)
@@ -109,6 +136,53 @@ checked_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 pr_meta="$(gh api "repos/${repo}/pulls/${pr_number}")"
 pr_state="$(jq -r '.state // "unknown"' <<<"$pr_meta")"
 pr_merged_at="$(jq -r '.merged_at // ""' <<<"$pr_meta")"
+
+if [[ "$disable_cron_on_closed" == "true" && "$pr_state" != "open" ]]; then
+  remove_cron_entry "$cron_marker"
+  jq -n \
+    --arg checked_at "$checked_at" \
+    --arg repo "$repo" \
+    --argjson pr_number "$pr_number" \
+    --arg pr_state "$pr_state" \
+    --arg pr_merged_at "$pr_merged_at" '
+      {
+        checked_at: $checked_at,
+        repo: $repo,
+        pr_number: $pr_number,
+        pr_state: $pr_state,
+        pr_merged_at: (if $pr_merged_at == "" then null else $pr_merged_at end),
+        processed_ids: [],
+        last_run: {
+          new_count: 0,
+          actionable_count: 0,
+          report_path: null,
+          autofix_status: "skipped_pr_closed",
+          cron_removed: true
+        }
+      }
+    ' > "$state_file"
+
+  jq -n \
+    --arg checked_at "$checked_at" \
+    --arg repo "$repo" \
+    --argjson pr_number "$pr_number" \
+    --arg pr_state "$pr_state" \
+    --arg pr_merged_at "$pr_merged_at" '
+      {
+        checked_at: $checked_at,
+        repo: $repo,
+        pr_number: $pr_number,
+        pr_state: $pr_state,
+        pr_merged_at: (if $pr_merged_at == "" then null else $pr_merged_at end),
+        new_count: 0,
+        actionable_count: 0,
+        report_path: null,
+        autofix_status: "skipped_pr_closed",
+        cron_removed: true
+      }
+    '
+  exit 0
+fi
 
 issue_comments="$(gh api --paginate "repos/${repo}/issues/${pr_number}/comments?per_page=100")"
 review_comments="$(gh api --paginate "repos/${repo}/pulls/${pr_number}/comments?per_page=100")"

--- a/scripts/check-cli-anything-pr.sh
+++ b/scripts/check-cli-anything-pr.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_REPO="HKUDS/CLI-Anything"
+DEFAULT_PR="195"
+DEFAULT_IGNORE_AUTHOR="chimera-defi"
+DEFAULT_STATE_DIR="${HOME}/.eth2qs-pr-watch"
+DEFAULT_ACTIONABLE_REGEX='blocker|request[[:space:]]+changes|should[[:space:]]+fix|must[[:space:]]+fix|please[[:space:]]+fix|needs?[[:space:]]+fix|merge[[:space:]]+conflict|rebase|failing'
+
+usage() {
+  cat <<'EOF'
+usage: ./scripts/check-cli-anything-pr.sh [options]
+
+options:
+  --repo <owner/name>        Upstream repository to watch (default: HKUDS/CLI-Anything)
+  --pr <number>              Pull request number to watch (default: 195)
+  --ignore-author <login>    Ignore actionable checks from this author (default: chimera-defi)
+  --state-dir <path>         State/report directory (default: ~/.eth2qs-pr-watch)
+  --autofix-cmd <command>    Optional command to run when new actionable feedback is found
+  --dry-run                  Do not execute autofix command
+  --exit-nonzero-on-actionable
+                             Exit with code 10 when actionable feedback is found
+  --help                     Show this help
+
+env overrides:
+  ETH2QS_PR_WATCH_REPO
+  ETH2QS_PR_WATCH_PR
+  ETH2QS_PR_WATCH_IGNORE_AUTHOR
+  ETH2QS_PR_WATCH_STATE_DIR
+  ETH2QS_PR_WATCH_AUTOFIX_CMD
+  ETH2QS_PR_WATCH_AUTOFIX_B64
+  ETH2QS_PR_WATCH_ACTIONABLE_REGEX
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "missing required command: $cmd" >&2
+    exit 2
+  fi
+}
+
+repo="${ETH2QS_PR_WATCH_REPO:-$DEFAULT_REPO}"
+pr_number="${ETH2QS_PR_WATCH_PR:-$DEFAULT_PR}"
+ignore_author="${ETH2QS_PR_WATCH_IGNORE_AUTHOR:-$DEFAULT_IGNORE_AUTHOR}"
+state_dir="${ETH2QS_PR_WATCH_STATE_DIR:-$DEFAULT_STATE_DIR}"
+autofix_cmd="${ETH2QS_PR_WATCH_AUTOFIX_CMD:-}"
+actionable_regex="${ETH2QS_PR_WATCH_ACTIONABLE_REGEX:-$DEFAULT_ACTIONABLE_REGEX}"
+dry_run="false"
+exit_nonzero_on_actionable="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --pr)
+      pr_number="$2"
+      shift 2
+      ;;
+    --ignore-author)
+      ignore_author="$2"
+      shift 2
+      ;;
+    --state-dir)
+      state_dir="$2"
+      shift 2
+      ;;
+    --autofix-cmd)
+      autofix_cmd="$2"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    --exit-nonzero-on-actionable)
+      exit_nonzero_on_actionable="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$autofix_cmd" && -n "${ETH2QS_PR_WATCH_AUTOFIX_B64:-}" ]]; then
+  require_cmd base64
+  autofix_cmd="$(printf '%s' "$ETH2QS_PR_WATCH_AUTOFIX_B64" | base64 -d)"
+fi
+
+require_cmd gh
+require_cmd jq
+
+slug="$(printf '%s' "$repo" | tr '/ ' '__' | tr -cd '[:alnum:]_.-')"
+state_file="${state_dir}/${slug}-pr${pr_number}.state.json"
+report_dir="${state_dir}/reports"
+mkdir -p "$state_dir" "$report_dir"
+
+checked_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+pr_meta="$(gh api "repos/${repo}/pulls/${pr_number}")"
+pr_state="$(jq -r '.state // "unknown"' <<<"$pr_meta")"
+pr_merged_at="$(jq -r '.merged_at // ""' <<<"$pr_meta")"
+
+issue_comments="$(gh api --paginate "repos/${repo}/issues/${pr_number}/comments?per_page=100")"
+review_comments="$(gh api --paginate "repos/${repo}/pulls/${pr_number}/comments?per_page=100")"
+reviews="$(gh api --paginate "repos/${repo}/pulls/${pr_number}/reviews?per_page=100")"
+
+events="$(
+  jq -n \
+    --argjson issue_comments "$issue_comments" \
+    --argjson review_comments "$review_comments" \
+    --argjson reviews "$reviews" '
+      [
+        ($issue_comments[]? | {
+          id: (.id | tostring),
+          kind: "issue_comment",
+          author: (.user.login // ""),
+          created_at: (.created_at // ""),
+          body: (.body // "")
+        }),
+        ($review_comments[]? | {
+          id: (.id | tostring),
+          kind: "review_comment",
+          author: (.user.login // ""),
+          created_at: (.created_at // ""),
+          body: (.body // "")
+        }),
+        ($reviews[]? | {
+          id: (.id | tostring),
+          kind: ("review_" + ((.state // "unknown") | ascii_downcase)),
+          author: (.user.login // ""),
+          created_at: (.submitted_at // .created_at // ""),
+          body: (.body // "")
+        })
+      ]
+      | map(select(.created_at != ""))
+      | sort_by(.created_at)
+    '
+)"
+
+seen_ids="[]"
+if [[ -f "$state_file" ]]; then
+  seen_ids="$(jq -c '.processed_ids // []' "$state_file" 2>/dev/null || echo '[]')"
+fi
+
+new_events="$(
+  jq -n \
+    --argjson events "$events" \
+    --argjson seen_ids "$seen_ids" '
+      $events
+      | map(select((.id as $id | ($seen_ids | index($id)) == null)))
+    '
+)"
+
+actionable="$(
+  jq -n \
+    --argjson events "$new_events" \
+    --arg ignore_author "$ignore_author" \
+    --arg actionable_regex "$actionable_regex" '
+      $events
+      | map(
+          . + {
+            actionable: (
+              (.author != $ignore_author)
+              and (
+                (.kind == "review_changes_requested")
+                or (.body | test($actionable_regex; "i"))
+              )
+            )
+          }
+        )
+      | map(select(.actionable))
+    '
+)"
+
+new_count="$(jq 'length' <<<"$new_events")"
+actionable_count="$(jq 'length' <<<"$actionable")"
+report_path=""
+autofix_status="not_configured"
+
+if [[ "$actionable_count" -gt 0 ]]; then
+  report_path="${report_dir}/${slug}-pr${pr_number}-$(date -u +%Y%m%dT%H%M%SZ).md"
+  {
+    echo "# CLI-Anything PR Watch Alert"
+    echo
+    echo "- Checked at: ${checked_at}"
+    echo "- PR: https://github.com/${repo}/pull/${pr_number}"
+    echo "- State: ${pr_state}"
+    if [[ -n "$pr_merged_at" ]]; then
+      echo "- Merged at: ${pr_merged_at}"
+    fi
+    echo "- New events: ${new_count}"
+    echo "- Actionable events: ${actionable_count}"
+    echo
+    echo "## Actionable Items"
+    echo
+    jq -r '
+      .[]
+      | "- [\(.kind)] @\(.author) on \(.created_at)\n\n```\n\(.body)\n```\n"
+    ' <<<"$actionable"
+  } > "$report_path"
+
+  if [[ -n "$autofix_cmd" ]]; then
+    if [[ "$dry_run" == "true" ]]; then
+      autofix_status="dry_run"
+    else
+      if ETH2QS_PR_WATCH_REPO="$repo" \
+         ETH2QS_PR_WATCH_PR="$pr_number" \
+         ETH2QS_PR_WATCH_REPORT="$report_path" \
+         bash -lc "$autofix_cmd"; then
+        autofix_status="executed"
+      else
+        autofix_status="failed"
+      fi
+    fi
+  fi
+fi
+
+updated_seen_ids="$(
+  jq -n \
+    --argjson seen_ids "$seen_ids" \
+    --argjson events "$events" '
+      ($seen_ids + ($events | map(.id)))
+      | unique
+      | if length > 2000 then .[-2000:] else . end
+    '
+)"
+
+jq -n \
+  --arg checked_at "$checked_at" \
+  --arg repo "$repo" \
+  --argjson pr_number "$pr_number" \
+  --arg pr_state "$pr_state" \
+  --arg pr_merged_at "$pr_merged_at" \
+  --argjson processed_ids "$updated_seen_ids" \
+  --argjson new_count "$new_count" \
+  --argjson actionable_count "$actionable_count" \
+  --arg report_path "$report_path" \
+  --arg autofix_status "$autofix_status" '
+    {
+      checked_at: $checked_at,
+      repo: $repo,
+      pr_number: $pr_number,
+      pr_state: $pr_state,
+      pr_merged_at: (if $pr_merged_at == "" then null else $pr_merged_at end),
+      processed_ids: $processed_ids,
+      last_run: {
+        new_count: $new_count,
+        actionable_count: $actionable_count,
+        report_path: (if $report_path == "" then null else $report_path end),
+        autofix_status: $autofix_status
+      }
+    }
+  ' > "$state_file"
+
+jq -n \
+  --arg checked_at "$checked_at" \
+  --arg repo "$repo" \
+  --argjson pr_number "$pr_number" \
+  --arg pr_state "$pr_state" \
+  --arg pr_merged_at "$pr_merged_at" \
+  --argjson new_count "$new_count" \
+  --argjson actionable_count "$actionable_count" \
+  --arg report_path "$report_path" \
+  --arg autofix_status "$autofix_status" '
+    {
+      checked_at: $checked_at,
+      repo: $repo,
+      pr_number: $pr_number,
+      pr_state: $pr_state,
+      pr_merged_at: (if $pr_merged_at == "" then null else $pr_merged_at end),
+      new_count: $new_count,
+      actionable_count: $actionable_count,
+      report_path: (if $report_path == "" then null else $report_path end),
+      autofix_status: $autofix_status
+    }
+  '
+
+if [[ "$actionable_count" -gt 0 && "$exit_nonzero_on_actionable" == "true" ]]; then
+  exit 10
+fi
+
+exit 0

--- a/scripts/install-cli-anything-pr-watch-cron.sh
+++ b/scripts/install-cli-anything-pr-watch-cron.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_REPO="HKUDS/CLI-Anything"
-DEFAULT_PR="195"
+DEFAULT_REPO="chimera-defi/eth2-quickstart"
+DEFAULT_PR="167"
 DEFAULT_SCHEDULE="15 9 * * *"
 DEFAULT_STATE_DIR="${HOME}/.eth2qs-pr-watch"
 CRON_MARKER="eth2qs-cli-pr-watch"
@@ -12,11 +12,14 @@ usage() {
 usage: ./scripts/install-cli-anything-pr-watch-cron.sh [options]
 
 options:
-  --repo <owner/name>      Upstream repository to watch (default: HKUDS/CLI-Anything)
-  --pr <number>            Pull request number to watch (default: 195)
+  --repo <owner/name>      Repository to watch (default: chimera-defi/eth2-quickstart)
+  --pr <number>            Pull request number to watch (default: 167)
   --schedule "<cron expr>" Cron schedule (default: 15 9 * * *)
   --state-dir <path>       State/log directory (default: ~/.eth2qs-pr-watch)
   --autofix-cmd <command>  Optional command invoked when actionable feedback appears
+  --disable-on-closed      Auto-remove cron entry when PR is no longer open (default: enabled)
+  --no-disable-on-closed   Do not auto-remove cron entry on closed/merged PR
+  --cron-marker <text>     Marker used for idempotent replace (default: eth2qs-cli-pr-watch)
   --help                   Show this help
 
 notes:
@@ -38,6 +41,7 @@ pr_number="$DEFAULT_PR"
 schedule="$DEFAULT_SCHEDULE"
 state_dir="$DEFAULT_STATE_DIR"
 autofix_cmd=""
+disable_on_closed="true"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -59,6 +63,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     --autofix-cmd)
       autofix_cmd="$2"
+      shift 2
+      ;;
+    --disable-on-closed)
+      disable_on_closed="true"
+      shift
+      ;;
+    --no-disable-on-closed)
+      disable_on_closed="false"
+      shift
+      ;;
+    --cron-marker)
+      CRON_MARKER="$2"
       shift 2
       ;;
     --help|-h)
@@ -93,7 +109,12 @@ if [[ -n "$autofix_cmd" ]]; then
   cron_env="ETH2QS_PR_WATCH_AUTOFIX_B64='${autofix_b64}' "
 fi
 
-cron_line="${schedule} ${cron_env}${watch_script} --repo ${repo} --pr ${pr_number} --state-dir ${state_dir} >> ${log_file} 2>&1 # ${CRON_MARKER}"
+disable_flag=""
+if [[ "$disable_on_closed" == "true" ]]; then
+  disable_flag="--disable-cron-on-closed --cron-marker ${CRON_MARKER}"
+fi
+
+cron_line="${schedule} ${cron_env}${watch_script} --repo ${repo} --pr ${pr_number} --state-dir ${state_dir} ${disable_flag} >> ${log_file} 2>&1 # ${CRON_MARKER}"
 
 tmpfile="$(mktemp)"
 {

--- a/scripts/install-cli-anything-pr-watch-cron.sh
+++ b/scripts/install-cli-anything-pr-watch-cron.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_REPO="HKUDS/CLI-Anything"
+DEFAULT_PR="195"
+DEFAULT_SCHEDULE="15 9 * * *"
+DEFAULT_STATE_DIR="${HOME}/.eth2qs-pr-watch"
+CRON_MARKER="eth2qs-cli-pr-watch"
+
+usage() {
+  cat <<'EOF'
+usage: ./scripts/install-cli-anything-pr-watch-cron.sh [options]
+
+options:
+  --repo <owner/name>      Upstream repository to watch (default: HKUDS/CLI-Anything)
+  --pr <number>            Pull request number to watch (default: 195)
+  --schedule "<cron expr>" Cron schedule (default: 15 9 * * *)
+  --state-dir <path>       State/log directory (default: ~/.eth2qs-pr-watch)
+  --autofix-cmd <command>  Optional command invoked when actionable feedback appears
+  --help                   Show this help
+
+notes:
+  - installer is idempotent (replaces existing eth2qs watch entry)
+  - cron writes output to ~/.eth2qs-pr-watch/cron.log by default
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "missing required command: $cmd" >&2
+    exit 2
+  fi
+}
+
+repo="$DEFAULT_REPO"
+pr_number="$DEFAULT_PR"
+schedule="$DEFAULT_SCHEDULE"
+state_dir="$DEFAULT_STATE_DIR"
+autofix_cmd=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --pr)
+      pr_number="$2"
+      shift 2
+      ;;
+    --schedule)
+      schedule="$2"
+      shift 2
+      ;;
+    --state-dir)
+      state_dir="$2"
+      shift 2
+      ;;
+    --autofix-cmd)
+      autofix_cmd="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_cmd crontab
+require_cmd mktemp
+require_cmd awk
+
+watch_script="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-cli-anything-pr.sh"
+if [[ ! -x "$watch_script" ]]; then
+  echo "watch script is missing or not executable: $watch_script" >&2
+  exit 2
+fi
+
+mkdir -p "$state_dir" "${state_dir}/reports"
+log_file="${state_dir}/cron.log"
+
+cron_env=""
+if [[ -n "$autofix_cmd" ]]; then
+  require_cmd base64
+  autofix_b64="$(printf '%s' "$autofix_cmd" | base64 | tr -d '\n')"
+  cron_env="ETH2QS_PR_WATCH_AUTOFIX_B64='${autofix_b64}' "
+fi
+
+cron_line="${schedule} ${cron_env}${watch_script} --repo ${repo} --pr ${pr_number} --state-dir ${state_dir} >> ${log_file} 2>&1 # ${CRON_MARKER}"
+
+tmpfile="$(mktemp)"
+{
+  crontab -l 2>/dev/null | awk -v marker="$CRON_MARKER" 'index($0, marker) == 0' || true
+  echo "$cron_line"
+} > "$tmpfile"
+
+crontab "$tmpfile"
+rm -f "$tmpfile"
+
+echo "installed cron entry:"
+echo "$cron_line"

--- a/scripts/uninstall-cli-anything-pr-watch-cron.sh
+++ b/scripts/uninstall-cli-anything-pr-watch-cron.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_CRON_MARKER="eth2qs-cli-pr-watch"
+
+usage() {
+  cat <<'EOF'
+usage: ./scripts/uninstall-cli-anything-pr-watch-cron.sh [options]
+
+options:
+  --cron-marker <text>  Marker used to identify/remove watch cron line
+  --help                Show this help
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "missing required command: $cmd" >&2
+    exit 2
+  fi
+}
+
+cron_marker="$DEFAULT_CRON_MARKER"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cron-marker)
+      cron_marker="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_cmd crontab
+require_cmd awk
+require_cmd mktemp
+
+tmpfile="$(mktemp)"
+before="$(crontab -l 2>/dev/null || true)"
+after="$(printf '%s\n' "$before" | awk -v marker="$cron_marker" 'index($0, marker) == 0')"
+
+if [[ "$before" == "$after" ]]; then
+  echo "no matching cron entry found for marker: $cron_marker"
+  rm -f "$tmpfile"
+  exit 0
+fi
+
+printf '%s\n' "$after" > "$tmpfile"
+crontab "$tmpfile"
+rm -f "$tmpfile"
+
+echo "removed cron entries with marker: $cron_marker"

--- a/status/poll_ci.sh
+++ b/status/poll_ci.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+REPO="${ETH2QS_STATUS_REPO:-chimera-defi/eth2-quickstart}"
+AUTHOR="${ETH2QS_STATUS_AUTHOR:-chimera-defi}"
+STATUS_DIR="${ETH2QS_STATUS_DIR:-$REPO_ROOT/status}"
+WATCH_ENABLED="${ETH2QS_STATUS_WATCH_ENABLED:-true}"
+WATCH_REPO="${ETH2QS_STATUS_WATCH_REPO:-$REPO}"
+WATCH_PR="${ETH2QS_STATUS_WATCH_PR:-167}"
+WATCH_STATE_DIR="${ETH2QS_PR_WATCH_STATE_DIR:-$HOME/.eth2qs-pr-watch}"
+WATCH_MARKER="${ETH2QS_PR_WATCH_CRON_MARKER:-eth2qs-cli-pr-watch}"
+
+mkdir -p "$STATUS_DIR"
+
+timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+prs_json="$(gh pr list --repo "$REPO" --state open --author "$AUTHOR" --limit 20 --json number,title,updatedAt,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup)"
+
+printf '%s\n' "$prs_json" > "$STATUS_DIR/open-prs.json"
+
+jq -n \
+  --arg checked_at "$timestamp" \
+  --arg repo "$REPO" \
+  --arg author "$AUTHOR" \
+  --argjson prs "$prs_json" '
+    {
+      checked_at: $checked_at,
+      repo: $repo,
+      author: $author,
+      open_pr_count: ($prs | length),
+      open_prs: (
+        $prs
+        | map({
+            number,
+            title,
+            updatedAt,
+            mergeable,
+            mergeStateStatus,
+            reviewDecision,
+            checks: (
+              (.statusCheckRollup // [])
+              | map({
+                  name,
+                  status,
+                  conclusion
+                })
+            )
+          })
+      )
+    }
+  ' > "$STATUS_DIR/ci-summary.json"
+
+if [[ "$WATCH_ENABLED" == "true" ]]; then
+  watch_script="$REPO_ROOT/scripts/check-cli-anything-pr.sh"
+  if [[ -x "$watch_script" ]]; then
+    "$watch_script" \
+      --repo "$WATCH_REPO" \
+      --pr "$WATCH_PR" \
+      --state-dir "$WATCH_STATE_DIR" \
+      --disable-cron-on-closed \
+      --cron-marker "$WATCH_MARKER" \
+      > "$STATUS_DIR/pr-watch-last.json" || true
+  fi
+fi
+
+echo "polled at $timestamp"


### PR DESCRIPTION
## Summary
- add scripts/check-cli-anything-pr.sh to poll upstream PR comments/reviews and detect new actionable feedback
- add scripts/install-cli-anything-pr-watch-cron.sh to install an idempotent daily cron entry
- add docs for maintenance automation in docs/SCRIPTS.md and record context in docs/agent-handoff.md
- install cron locally: daily at 15 9 * * * for HKUDS/CLI-Anything PR 195

## Validation
- bash -n scripts/check-cli-anything-pr.sh
- bash -n scripts/install-cli-anything-pr-watch-cron.sh
- shellcheck scripts/check-cli-anything-pr.sh scripts/install-cli-anything-pr-watch-cron.sh
- ./scripts/check-cli-anything-pr.sh --repo HKUDS/CLI-Anything --pr 195 --state-dir /tmp/eth2qs-pr-watch-test (first run)
- ./scripts/check-cli-anything-pr.sh --repo HKUDS/CLI-Anything --pr 195 --state-dir /tmp/eth2qs-pr-watch-test (second run; no new events)
- ./scripts/install-cli-anything-pr-watch-cron.sh --repo HKUDS/CLI-Anything --pr 195

## Notes
- Upstream PR 195 is already merged (2026-04-13), so this automation is reusable for future upstream PR monitoring.
- Optional autofix hook is supported via --autofix-cmd / ETH2QS_PR_WATCH_AUTOFIX_B64 if you want unattended follow-up actions later.

Co-authored-by: Chimera <chimera_defi@protonmail.com>

## Original Request
Can we write a cron to check that cli anything pr 195 once a day for review comments and make any needed changes