### PR TITLE
fix(validators): fix P1 bugs, remove dead code, add docs

### DIFF
--- a/docs/VALIDATOR_MANAGEMENT.md
+++ b/docs/VALIDATOR_MANAGEMENT.md
@@ -1,0 +1,185 @@
+# Validator Management
+
+Two standalone helper scripts for managing validators on this node.
+Both are also available through the unified `eth2qs.sh` wrapper.
+
+---
+
+## Quick Reference
+
+```bash
+# List local validators (human-readable table)
+./scripts/eth2qs.sh validators
+./install/utils/validator_list.sh
+
+# List local validators (JSON — for scripting)
+./scripts/eth2qs.sh validators --json
+./install/utils/validator_list.sh --json
+
+# Interactive management menu (exit / consolidate)
+./scripts/eth2qs.sh validator-manage
+./install/utils/validator_manage.sh
+
+# Go straight to voluntary exit flow
+./scripts/eth2qs.sh validator-manage --exit
+./install/utils/validator_manage.sh --exit
+
+# Go straight to consolidation flow (EIP-7251)
+./scripts/eth2qs.sh validator-manage --consolidate
+./install/utils/validator_manage.sh --consolidate
+```
+
+---
+
+## `validator_list.sh` — How It Works
+
+1. Detects the running consensus client from the `validator` systemd service.
+2. Scans the client's well-known keystore directory for EIP-2335 keystore files.
+3. Extracts the public key from each keystore's JSON.
+4. Queries the local beacon node API (`/eth/v1/beacon/states/head/validators`)
+   filtered to those public keys only.
+5. Displays a table with validator index, pubkey, status, balance, and
+   effective balance.
+
+**Nothing is read from the network validator set** — only validators whose
+keystore files exist on this machine are shown.
+
+### Keystore Directories by Client
+
+| Client     | Keystore directory                                      |
+|------------|---------------------------------------------------------|
+| Lighthouse | `~/.lighthouse/mainnet/validators/`                     |
+| Prysm      | `~/prysm/`                                              |
+| Teku       | `~/.local/share/teku/validator/keys/`                   |
+| Lodestar   | `~/.local/share/lodestar/validators/keystores/`         |
+| Nimbus     | `~/.local/share/nimbus/validators/`                     |
+| Grandine   | `~/.local/share/grandine/validator/keystores/`          |
+
+### JSON Output Schema
+
+```json
+{
+  "client": "lighthouse",
+  "beacon_url": "http://127.0.0.1:5052",
+  "validators": [
+    {
+      "index": "123456",
+      "balance": "32004100000",
+      "status": "active_ongoing",
+      "validator": {
+        "pubkey": "0xabc...",
+        "effective_balance": "32000000000",
+        ...
+      }
+    }
+  ]
+}
+```
+
+---
+
+## `validator_manage.sh` — Operations
+
+### 1. Voluntary Exit
+
+> **This is permanent and irreversible.** An exited validator cannot
+> re-enter the active set.
+
+The exit flow:
+
+1. Shows all local validators (same discovery as `validator_list.sh`).
+2. Prompts for the validator index or pubkey to exit. Enter `all` to exit
+   all local validators.
+3. Requires you to type `yes` to confirm.
+4. Calls the client-specific exit CLI.
+
+**Per-client exit commands** (called internally, shown here for reference):
+
+| Client     | CLI                                                                    |
+|------------|------------------------------------------------------------------------|
+| Lighthouse | `lighthouse account validator exit --beacon-node <url> --pubkeys <pk>` |
+| Prysm      | `prysm.sh validator accounts voluntary-exit --pubkeys <pk>`            |
+| Teku       | `teku voluntary-exit --validator-public-key <pk>`                      |
+| Lodestar   | `lodestar validator voluntary-exit --pubkeys <pk>`                     |
+| Nimbus     | `nimbus_beacon_node deposits exit --validator <pk>`                    |
+| Grandine   | Uses `ethdo` (see below)                                               |
+
+**Universal alternative — ethdo:**
+
+```bash
+# Install
+go install github.com/wealdtech/ethdo@latest
+
+# Exit a specific validator
+ethdo validator exit \
+  --validator=<index_or_pubkey> \
+  --connection=http://127.0.0.1:5052
+```
+
+### 2. Consolidation (EIP-7251)
+
+Consolidation merges two of your validators into one, combining their
+balances. The source validator exits; its stake moves to the target.
+
+**Prerequisites:**
+
+- Both validators must have `0x01` withdrawal credentials pointing to an
+  Ethereum address you control.
+- You need the private key of that withdrawal address to sign the transaction.
+- A dynamic fee is required (queried live from the contract).
+
+**Contract:** `0x00431F263cE400f4455c2dCf564e53007Ca4bbBb` (mainnet)
+
+The consolidation flow:
+
+1. Shows all local validators.
+2. Prompts for source pubkey and target pubkey.
+3. Queries the current fee from the consolidation contract.
+4. Displays the full `cast send` command with filled-in values.
+5. Optionally executes it (requires [Foundry](https://getfoundry.sh) `cast`).
+
+**Manual execution** (if you prefer not to enter a private key interactively):
+
+```bash
+# The script prints the exact command — copy and run it yourself:
+cast send 0x00431F263cE400f4455c2dCf564e53007Ca4bbBb \
+  --value <fee_wei>wei \
+  --data 0x<source_pubkey_hex><target_pubkey_hex> \
+  --rpc-url http://127.0.0.1:8545 \
+  --private-key <YOUR_WITHDRAWAL_ADDRESS_PRIVATE_KEY>
+
+# Install Foundry if needed:
+curl -L https://foundry.paradigm.xyz | bash && foundryup
+```
+
+---
+
+## Beacon API Ports by Client
+
+The scripts auto-detect the correct port from the `cl` systemd service.
+
+| Client     | Default Port |
+|------------|--------------|
+| Lighthouse | 5052         |
+| Prysm      | 5052         |
+| Teku       | 5051         |
+| Lodestar   | 9596         |
+| Nimbus     | 5052         |
+| Grandine   | 5052         |
+
+---
+
+## Troubleshooting
+
+**"No keystore files found"**
+- Check that validator keys have been imported into the client's keystore
+  directory (see table above).
+- Run `systemctl status validator` to confirm the service is running.
+
+**"No validator data returned from beacon node"**
+- The beacon node may still be syncing. Check with `./scripts/eth2qs.sh doctor`.
+- Verify the beacon node is reachable: `curl -s http://127.0.0.1:5052/eth/v1/node/syncing`
+
+**Exit command fails with unknown flag**
+- Client versions change CLI flags. If the auto-detected command fails,
+  use the manual `ethdo` path shown in the output.

--- a/install/utils/validator_list.sh
+++ b/install/utils/validator_list.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Eth2 Quick Start — Validator List
-# Lists all validator keys managed by the local validator client,
+# Lists validator keys managed by the local validator client,
 # cross-referenced with the beacon node API for live status and balance.
 #
 # Usage: ./install/utils/validator_list.sh [--json]
@@ -47,20 +47,13 @@ detect_client() {
         echo "unknown"
         return
     fi
-    if echo "$exec_start" | grep -qi "lighthouse"; then
-        echo "lighthouse"
-    elif echo "$exec_start" | grep -qi "prysm"; then
-        echo "prysm"
-    elif echo "$exec_start" | grep -qi "teku"; then
-        echo "teku"
-    elif echo "$exec_start" | grep -qi "lodestar"; then
-        echo "lodestar"
-    elif echo "$exec_start" | grep -qi "nimbus"; then
-        echo "nimbus"
-    elif echo "$exec_start" | grep -qi "grandine"; then
-        echo "grandine"
-    else
-        echo "unknown"
+    if echo "$exec_start"   | grep -qi "lighthouse"; then echo "lighthouse"
+    elif echo "$exec_start" | grep -qi "prysm";      then echo "prysm"
+    elif echo "$exec_start" | grep -qi "teku";       then echo "teku"
+    elif echo "$exec_start" | grep -qi "lodestar";   then echo "lodestar"
+    elif echo "$exec_start" | grep -qi "nimbus";     then echo "nimbus"
+    elif echo "$exec_start" | grep -qi "grandine";   then echo "grandine"
+    else echo "unknown"
     fi
 }
 
@@ -108,12 +101,14 @@ find_pubkeys() {
             )
             ;;
         lodestar)
+            # Path set by lodestar.sh: $HOME/.local/share/lodestar/validators/keystores
             search_dirs=(
+                "$HOME/.local/share/lodestar/validators/keystores"
                 "$HOME/lodestar/keystores"
-                "$HOME/.lodestar/keystores"
             )
             ;;
         nimbus)
+            # Path set by nimbus.sh: $HOME/.local/share/nimbus/validators
             search_dirs=(
                 "$HOME/.local/share/nimbus/validators"
                 "$HOME/nimbus/validators"
@@ -126,25 +121,31 @@ find_pubkeys() {
             )
             ;;
         *)
-            # Fallback: scan all likely locations
+            # Fallback: scan all known locations
             search_dirs=(
                 "$HOME/.lighthouse/mainnet/validators"
                 "$HOME/.lighthouse/validators"
                 "$HOME/lighthouse/validators"
                 "$HOME/.local/share/teku/validator/keys"
-                "$HOME/lodestar/keystores"
-                "$HOME/grandine/validators"
-                "$HOME/nimbus/validators"
+                "$HOME/.local/share/lodestar/validators/keystores"
+                "$HOME/.local/share/nimbus/validators"
+                "$HOME/.local/share/grandine/validator/keystores"
             )
             ;;
     esac
 
     for dir in "${search_dirs[@]}"; do
         [[ -d "$dir" ]] || continue
-        # Find JSON keystores with a pubkey field (EIP-2335)
         while IFS= read -r -d '' f; do
             local pubkey
-            pubkey=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('pubkey',''))" "$f" 2>/dev/null || true)
+            pubkey=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(d.get('pubkey', ''))
+except Exception:
+    pass
+" "$f" 2>/dev/null || true)
             [[ -n "$pubkey" ]] && echo "$pubkey"
         done < <(find "$dir" -maxdepth 4 -name "*.json" -print0 2>/dev/null)
     done | sort -u
@@ -154,33 +155,34 @@ find_pubkeys() {
 # BEACON API QUERY
 # =============================================================================
 
-# Queries beacon node for one or more validator pubkeys.
-# Accepts pubkeys as newline-separated stdin.
-# Outputs raw JSON from the beacon API.
+# Queries beacon node for a list of validator pubkeys (max ~100 at a time to
+# stay within URL length limits). Writes merged JSON to the given output file.
 query_beacon_validators() {
     local beacon_url="$1"
-    shift
+    local out_file="$2"
+    shift 2
     local pubkeys=("$@")
 
     if [[ ${#pubkeys[@]} -eq 0 ]]; then
-        echo '{"data":[]}'
+        echo '{"data":[]}' > "$out_file"
         return
     fi
 
-    # Build comma-separated id list
+    # Build id= query string with 0x-prefixed pubkeys
     local ids
-    ids=$(IFS=,; echo "${pubkeys[*]/#/0x}")
+    ids=$(printf "0x%s," "${pubkeys[@]}")
+    ids="${ids%,}"
 
     local response
     response=$(curl -sf \
-        --max-time 10 \
+        --max-time 15 \
         "${beacon_url}/eth/v1/beacon/states/head/validators?id=${ids}" \
         2>/dev/null || true)
 
     if [[ -z "$response" ]]; then
-        echo '{"data":[]}'
+        echo '{"data":[]}' > "$out_file"
     else
-        echo "$response"
+        echo "$response" > "$out_file"
     fi
 }
 
@@ -188,43 +190,36 @@ query_beacon_validators() {
 # DISPLAY
 # =============================================================================
 
-gwei_to_eth() {
-    python3 -c "print(f'{int(\"$1\") / 1e9:.6f}')" 2>/dev/null || echo "?"
-}
-
 print_table() {
-    local data="$1"
+    local data_file="$1"
 
-    local count
-    count=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(len(d.get('data',[])))" "$data" 2>/dev/null || echo 0)
-
-    if [[ "$count" -eq 0 ]]; then
-        log_warn "No validators found via beacon API. They may be pending or the node may still be syncing."
-        return
-    fi
-
-    printf "\n%-12s %-98s %-15s %-15s %s\n" \
-        "Index" "Public Key" "Status" "Balance (ETH)" "Eff. Balance (ETH)"
-    printf '%s\n' "$(printf '%.0s-' {1..155})"
-
-    python3 - "$data" <<'EOF'
+    python3 - "$data_file" <<'PYEOF'
 import json, sys
 
 with open(sys.argv[1]) as f:
-    data = json.load(f)
+    raw = json.load(f)
 
-for v in data.get("data", []):
-    idx   = v.get("index", "?")
-    pubk  = v.get("validator", {}).get("pubkey", "?")
-    short = pubk[:10] + "..." + pubk[-8:] if len(pubk) > 18 else pubk
-    full  = pubk
+rows = raw.get("data", [])
+if not rows:
+    print("  No validator data returned from beacon node.")
+    print("  The node may still be syncing or no keys are imported yet.")
+    sys.exit(0)
+
+hdr = f"{'Index':<12} {'Public Key':<98} {'Status':<22} {'Balance (ETH)':<16} Eff. Balance (ETH)"
+print()
+print(hdr)
+print("-" * len(hdr))
+for v in rows:
+    idx    = v.get("index", "?")
+    pubkey = v.get("validator", {}).get("pubkey", "?")
     status = v.get("status", "?")
     bal    = int(v.get("balance", 0)) / 1e9
     eff    = int(v.get("validator", {}).get("effective_balance", 0)) / 1e9
-    print(f"{idx:<12} {full:<98} {status:<15} {bal:<15.6f} {eff:.6f}")
-EOF
-    printf '%s\n' "$(printf '%.0s-' {1..155})"
-    printf "  %d validator(s) found\n\n" "$count"
+    print(f"{idx:<12} {pubkey:<98} {status:<22} {bal:<16.6f} {eff:.6f}")
+print("-" * len(hdr))
+print(f"  {len(rows)} validator(s)")
+print()
+PYEOF
 }
 
 # =============================================================================
@@ -250,7 +245,6 @@ main() {
             echo '{"client":"'"$client"'","beacon_url":"'"$beacon_url"'","validators":[],"error":"no_keystores_found"}'
         else
             log_warn "No keystore files found for client '${client}'."
-            echo "  Searched in the standard keystore directories."
             echo "  Import validator keys first, then re-run this command."
         fi
         return
@@ -265,20 +259,19 @@ main() {
     # shellcheck disable=SC2064
     trap "rm -f '$tmpfile'" EXIT
 
-    query_beacon_validators "$beacon_url" "${pubkeys[@]}" > "$tmpfile"
+    query_beacon_validators "$beacon_url" "$tmpfile" "${pubkeys[@]}"
 
     if [[ "$JSON_OUTPUT" == "true" ]]; then
-        python3 - "$tmpfile" "$client" "$beacon_url" <<'EOF'
+        python3 - "$tmpfile" "$client" "$beacon_url" <<'PYEOF'
 import json, sys
 with open(sys.argv[1]) as f:
     raw = json.load(f)
-out = {
+print(json.dumps({
     "client": sys.argv[2],
     "beacon_url": sys.argv[3],
     "validators": raw.get("data", [])
-}
-print(json.dumps(out, indent=2))
-EOF
+}, indent=2))
+PYEOF
     else
         print_table "$tmpfile"
     fi

--- a/install/utils/validator_manage.sh
+++ b/install/utils/validator_manage.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
 # Eth2 Quick Start — Validator Manager
-# Interactive tool for validator operations: voluntary exits and EIP-7251 consolidations.
+# Interactive tool for local validator operations: voluntary exits and EIP-7251
+# consolidations. Operates only on validators managed by this node.
 #
 # Usage:
-#   ./install/utils/validator_manage.sh [--exit | --consolidate] [--json]
-#   ./install/utils/validator_manage.sh          # interactive menu
+#   ./install/utils/validator_manage.sh            # interactive menu
+#   ./install/utils/validator_manage.sh --exit     # go straight to exit flow
+#   ./install/utils/validator_manage.sh --consolidate
 #
-# WARNING: Voluntary exit is IRREVERSIBLE. Exited validators cannot re-enter the active set.
+# WARNING: Voluntary exit is IRREVERSIBLE.
 
 set -euo pipefail
 
@@ -39,8 +41,8 @@ while [[ $# -gt 0 ]]; do
 Usage: ./install/utils/validator_manage.sh [options]
 
 Options:
-  --exit          Initiate voluntary exit for one or more validators
-  --consolidate   Consolidate two validators via EIP-7251
+  --exit          Initiate voluntary exit for one or more local validators
+  --consolidate   Consolidate two local validators via EIP-7251
   --help          Show this help
 
 Without options, an interactive menu is shown.
@@ -55,7 +57,7 @@ EOF
 done
 
 # =============================================================================
-# HELPERS (shared with validator_list.sh logic, inlined to keep scripts standalone)
+# CLIENT DETECTION
 # =============================================================================
 
 detect_client() {
@@ -84,97 +86,83 @@ detect_beacon_url() {
     echo "http://127.0.0.1:${port}"
 }
 
+# Returns the validator client binary path from the validator systemd service.
 get_client_binary() {
-    local client="$1"
     local exec_start
     exec_start=$(systemctl show validator --property=ExecStart --value 2>/dev/null || true)
-    case "$client" in
-        lighthouse)
-            # ExecStart starts with the binary path
-            echo "$exec_start" | awk '{print $1}' | head -1
-            ;;
-        prysm)
-            echo "$exec_start" | awk '{print $1}' | head -1
-            ;;
-        teku)
-            echo "$exec_start" | awk '{print $1}' | head -1
-            ;;
-        lodestar)
-            echo "$exec_start" | awk '{print $1}' | head -1
-            ;;
-        *)
-            echo ""
-            ;;
-    esac
+    echo "$exec_start" | awk '{print $1}' | head -1
 }
 
-# Fetches active validators from beacon node API, returns JSON array.
-fetch_validators() {
-    local beacon_url="$1"
-    local response
-    response=$(curl -sf --max-time 10 \
-        "${beacon_url}/eth/v1/beacon/states/head/validators?status=active_ongoing" \
-        2>/dev/null || true)
-    if [[ -z "$response" ]]; then
-        # Try without status filter as fallback
-        response=$(curl -sf --max-time 10 \
-            "${beacon_url}/eth/v1/beacon/states/head/validators" \
-            2>/dev/null || true)
-    fi
-    echo "${response:-{\"data\":[]}}"
-}
+# =============================================================================
+# LOCAL VALIDATOR LIST (delegates to validator_list.sh for correct discovery)
+# =============================================================================
 
-list_validators_interactive() {
-    local beacon_url="$1"
+# Calls validator_list.sh --json, writes result to $1, prints table to stdout.
+# Returns 1 if no local validators found.
+load_local_validators() {
+    local out_file="$1"
 
-    log_info "Fetching validators from beacon node..."
-
-    local tmpfile
-    tmpfile=$(mktemp /tmp/vmgr_XXXXXX.json)
-    # shellcheck disable=SC2064
-    trap "rm -f '$tmpfile'" EXIT
-
-    fetch_validators "$beacon_url" > "$tmpfile"
-
-    local count
-    count=$(python3 -c "
-import json, sys
-d = json.load(open(sys.argv[1]))
-print(len(d.get('data', [])))
-" "$tmpfile" 2>/dev/null || echo 0)
-
-    if [[ "$count" -eq 0 ]]; then
-        log_warn "No active validators found on this node."
+    if [[ ! -x "$SCRIPT_DIR/validator_list.sh" ]]; then
+        log_error "validator_list.sh not found or not executable at $SCRIPT_DIR"
         return 1
     fi
 
-    echo ""
-    printf "%-6s %-98s %-20s %s\n" "Index" "Public Key" "Status" "Balance (ETH)"
-    printf '%s\n' "$(printf '%.0s-' {1..140})"
+    local json
+    json=$("$SCRIPT_DIR/validator_list.sh" --json 2>/dev/null) || true
 
-    python3 - "$tmpfile" <<'EOF'
+    local count=0
+    if [[ -n "$json" ]]; then
+        count=$(python3 -c "
+import json, sys
+d = json.loads(sys.argv[1])
+print(len(d.get('validators', [])))
+" "$json" 2>/dev/null || echo 0)
+    fi
+
+    if [[ "$count" -eq 0 ]]; then
+        log_warn "No local validators found. Import keys and ensure the beacon node is synced."
+        return 1
+    fi
+
+    echo "$json" > "$out_file"
+    return 0
+}
+
+# Renders the validator table from the JSON file written by load_local_validators.
+print_local_validators() {
+    local data_file="$1"
+    python3 - "$data_file" <<'PYEOF'
 import json, sys
 with open(sys.argv[1]) as f:
-    data = json.load(f)
-for v in data.get("data", []):
+    d = json.load(f)
+rows = d.get("validators", [])
+if not rows:
+    print("  (none)")
+    sys.exit(0)
+hdr = f"  {'Index':<10} {'Public Key':<98} {'Status':<22} Balance (ETH)"
+print()
+print(hdr)
+print("  " + "-" * (len(hdr) - 2))
+for v in rows:
     idx    = v.get("index", "?")
     pubkey = v.get("validator", {}).get("pubkey", "?")
     status = v.get("status", "?")
     bal    = int(v.get("balance", 0)) / 1e9
-    print(f"{idx:<6} {pubkey:<98} {status:<20} {bal:.6f}")
-EOF
-    printf '%s\n' "$(printf '%.0s-' {1..140})"
-    printf "  %s active validator(s)\n\n" "$count"
-
-    echo "$tmpfile"  # caller can read this file if needed
+    print(f"  {idx:<10} {pubkey:<98} {status:<22} {bal:.6f}")
+print("  " + "-" * (len(hdr) - 2))
+print(f"  {len(rows)} validator(s)\n")
+PYEOF
 }
+
+# =============================================================================
+# SHARED HELPERS
+# =============================================================================
 
 confirm_destructive() {
     local prompt="$1"
-    echo ""
-    echo -e "  ${RED}⚠  WARNING: ${prompt}${NC}"
-    echo -e "  ${RED}   This action CANNOT be undone.${NC}"
-    echo ""
+    printf "\n"
+    printf "  %b⚠  WARNING: %s%b\n" "${RED}" "$prompt" "${NC}"
+    printf "  %bThis action CANNOT be undone.%b\n\n" "${RED}" "${NC}"
     read -rp "  Type 'yes' to confirm: " answer
     [[ "$answer" == "yes" ]]
 }
@@ -188,19 +176,23 @@ cmd_exit() {
     client=$(detect_client)
     local beacon_url
     beacon_url=$(detect_beacon_url)
+    local bin
+    bin=$(get_client_binary)
 
-    echo ""
+    printf "\n"
     log_info "=== Voluntary Validator Exit ==="
-    echo ""
-    echo "  Client   : ${client}"
-    echo "  Beacon   : ${beacon_url}"
-    echo ""
+    printf "  Client : %s\n  Beacon : %s\n\n" "$client" "$beacon_url"
 
-    list_validators_interactive "$beacon_url" || return 1
+    local tmpfile
+    tmpfile=$(mktemp /tmp/vmgr_XXXXXX.json)
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmpfile'" EXIT
 
-    echo "  Enter validator indices or pubkeys to exit."
-    echo "  Separate multiple with spaces. Enter 'all' to exit all."
-    echo ""
+    load_local_validators "$tmpfile" || return 0
+    print_local_validators "$tmpfile"
+
+    printf "  Enter the validator index or pubkey to exit.\n"
+    printf "  Separate multiple with spaces. Enter 'all' to exit all local validators.\n\n"
     read -rp "  Selection: " selection
 
     if [[ -z "$selection" ]]; then
@@ -213,115 +205,124 @@ cmd_exit() {
         return 0
     fi
 
-    echo ""
-    _do_exit "$client" "$beacon_url" "$selection"
+    printf "\n"
+    _do_exit "$client" "$beacon_url" "$bin" "$selection"
 }
 
 _do_exit() {
     local client="$1"
     local beacon_url="$2"
-    local selection="$3"
-
-    local bin
-    bin=$(get_client_binary "$client")
+    local bin="$3"
+    local selection="$4"
 
     case "$client" in
         lighthouse)
             if [[ -z "$bin" ]]; then
                 log_error "Could not determine Lighthouse binary path."
+                _print_manual_exit_instructions "$client" "$beacon_url"
                 return 1
             fi
-            local wallet_dir
-            wallet_dir=$(dirname "$bin")
             local pass_file="$HOME/secrets/pass.txt"
-
+            # Lighthouse 4+: 'lighthouse account validator exit'
+            # --pubkeys accepts comma-separated list of 0x-prefixed pubkeys or indices
             if [[ "$selection" == "all" ]]; then
-                log_info "Initiating exit for all validators..."
+                log_info "Initiating exit for all local validators..."
                 "$bin" account validator exit \
                     --beacon-node "$beacon_url" \
-                    --datadir "$wallet_dir" \
-                    --password-file "$pass_file" \
-                    --no-confirmation
+                    --no-confirmation \
+                    --password-file "$pass_file"
             else
-                for sel in $selection; do
-                    log_info "Exiting validator: $sel"
-                    "$bin" account validator exit \
-                        --beacon-node "$beacon_url" \
-                        --datadir "$wallet_dir" \
-                        --password-file "$pass_file" \
-                        --no-confirmation \
-                        --pubkey "$sel" 2>/dev/null || \
-                    "$bin" account validator exit \
-                        --beacon-node "$beacon_url" \
-                        --datadir "$wallet_dir" \
-                        --password-file "$pass_file" \
-                        --no-confirmation
-                done
+                local pubkey_list
+                pubkey_list=$(echo "$selection" | tr ' ' ',')
+                log_info "Initiating exit for: $pubkey_list"
+                "$bin" account validator exit \
+                    --beacon-node "$beacon_url" \
+                    --no-confirmation \
+                    --password-file "$pass_file" \
+                    --pubkeys "$pubkey_list"
             fi
             ;;
 
         prysm)
             if [[ -z "$bin" ]]; then
                 log_error "Could not determine Prysm binary path."
+                _print_manual_exit_instructions "$client" "$beacon_url"
                 return 1
             fi
             local prysm_dir
             prysm_dir=$(dirname "$bin")
             local pass_file="$HOME/secrets/pass.txt"
+            # Prysm: --pubkeys accepts comma-separated 0x-prefixed pubkeys
+            local pubkey_args=""
+            if [[ "$selection" != "all" ]]; then
+                pubkey_args="--pubkeys=$(echo "$selection" | tr ' ' ',')"
+            fi
             log_info "Running Prysm voluntary exit..."
+            # shellcheck disable=SC2086
             "$bin" validator accounts voluntary-exit \
                 --wallet-dir="$prysm_dir/wallet" \
                 --wallet-password-file="$pass_file" \
                 --beacon-rpc-provider="127.0.0.1:4000" \
-                --accept-terms-of-use
+                --accept-terms-of-use \
+                $pubkey_args
             ;;
 
         teku)
             if [[ -z "$bin" ]]; then
                 log_error "Could not determine Teku binary path."
+                _print_manual_exit_instructions "$client" "$beacon_url"
                 return 1
             fi
-            local validator_data="$HOME/.local/share/teku/validator"
+            local validator_keys="$HOME/.local/share/teku/validator"
             log_info "Running Teku voluntary exit..."
-            "$bin" voluntary-exit \
-                --beacon-node-api-endpoint="$beacon_url" \
-                --validator-keys="$validator_data/keys:$validator_data/passwords"
+            if [[ "$selection" == "all" ]]; then
+                "$bin" voluntary-exit \
+                    --beacon-node-api-endpoint="$beacon_url" \
+                    --validator-keys="$validator_keys/keys:$validator_keys/passwords"
+            else
+                "$bin" voluntary-exit \
+                    --beacon-node-api-endpoint="$beacon_url" \
+                    --validator-public-key="$(echo "$selection" | tr ' ' ',')" \
+                    --validator-keys="$validator_keys/keys:$validator_keys/passwords"
+            fi
             ;;
 
         lodestar)
             if [[ -z "$bin" ]]; then
                 log_error "Could not determine Lodestar binary path."
+                _print_manual_exit_instructions "$client" "$beacon_url"
                 return 1
             fi
             log_info "Running Lodestar voluntary exit..."
+            local pubkey_args=""
+            if [[ "$selection" != "all" ]]; then
+                pubkey_args="--pubkeys=$(echo "$selection" | tr ' ' ',')"
+            fi
+            # shellcheck disable=SC2086
             "$bin" validator voluntary-exit \
                 --beaconNodes="$beacon_url" \
-                --dataDir="$HOME/lodestar"
+                --dataDir="$HOME/.local/share/lodestar" \
+                $pubkey_args
             ;;
 
         nimbus)
-            log_info "Running Nimbus voluntary exit..."
             local nimbus_bin
-            nimbus_bin=$(command -v nimbus_beacon_node 2>/dev/null || \
-                         find "$HOME/nimbus" -name "nimbus_beacon_node" -type f 2>/dev/null | head -1 || true)
+            nimbus_bin=$(find "$HOME/nimbus/build" -name "nimbus_beacon_node" -type f 2>/dev/null | head -1 || true)
             if [[ -z "$nimbus_bin" ]]; then
                 log_error "Nimbus binary not found."
                 _print_manual_exit_instructions "$client" "$beacon_url"
                 return 1
             fi
-            "$nimbus_bin" deposits exit \
-                --rest-url="$beacon_url" \
-                --validator="$selection"
-            ;;
-
-        grandine)
-            # Grandine exit via keymanager API (EIP-3030 DELETE /keystores triggers exit)
-            log_warn "Grandine does not expose a standalone exit CLI."
-            _print_manual_exit_instructions "$client" "$beacon_url"
+            log_info "Running Nimbus voluntary exit..."
+            for sel in $selection; do
+                "$nimbus_bin" deposits exit \
+                    --rest-url="$beacon_url" \
+                    --validator="$sel"
+            done
             ;;
 
         *)
-            log_warn "Unknown client '${client}'. Showing manual instructions."
+            log_warn "Client '${client}' — showing manual exit instructions."
             _print_manual_exit_instructions "$client" "$beacon_url"
             ;;
     esac
@@ -330,19 +331,13 @@ _do_exit() {
 _print_manual_exit_instructions() {
     local client="$1"
     local beacon_url="$2"
-    echo ""
-    echo "  Manual exit steps for ${client}:"
-    echo ""
-    echo "  1. Query your validator index:"
-    echo "     curl -s '${beacon_url}/eth/v1/beacon/states/head/validators?status=active' | python3 -m json.tool"
-    echo ""
-    echo "  2. Sign and broadcast a voluntary exit via the keymanager API:"
-    echo "     POST ${beacon_url}/eth/v1/beacon/pool/voluntary_exits"
-    echo "     (Requires a signed VoluntaryExit message — use your client's CLI or ethdo)"
-    echo ""
-    echo "  3. Using ethdo (universal tool):"
-    echo "     ethdo validator exit --validator=<index_or_pubkey> --connection=${beacon_url} --passphrase=<wallet_passphrase>"
-    echo ""
+    printf "\n  Manual exit steps for %s:\n\n" "$client"
+    printf "  Option A — ethdo (works with all clients):\n"
+    printf "    ethdo validator exit --validator=<index_or_pubkey> \\\\\n"
+    printf "      --connection=%s\n\n" "$beacon_url"
+    printf "  Install ethdo:  go install github.com/wealdtech/ethdo@latest\n\n"
+    printf "  Option B — Beacon API (requires signed VoluntaryExit message):\n"
+    printf "    POST %s/eth/v1/beacon/pool/voluntary_exits\n\n" "$beacon_url"
 }
 
 # =============================================================================
@@ -352,125 +347,112 @@ _print_manual_exit_instructions() {
 cmd_consolidate() {
     local beacon_url
     beacon_url=$(detect_beacon_url)
+    local el_rpc="http://127.0.0.1:8545"
 
-    echo ""
+    printf "\n"
     log_info "=== EIP-7251 Validator Consolidation ==="
-    echo ""
+    printf "\n"
     cat <<'EOF'
-  Consolidation merges two validators into one, combining their balances.
-  The target validator will receive the source validator's stake.
+  Consolidation merges two validators, moving the source stake into the target.
+  After consolidation the source validator exits automatically.
 
   Prerequisites:
     • Both validators must have 0x01 withdrawal credentials pointing to an
-      Ethereum address you control (the "withdrawal address").
-    • The withdrawal address submits the consolidation transaction.
-    • A dynamic fee must be paid to the consolidation contract.
-    • After consolidation, the source validator is exited automatically.
+      Ethereum address YOU control (the withdrawal address sends the TX).
+    • A dynamic fee is paid to the consolidation contract.
 
   Contract: 0x00431F263cE400f4455c2dCf564e53007Ca4bbBb (mainnet)
 
 EOF
 
-    list_validators_interactive "$beacon_url" || return 1
+    local tmpfile
+    tmpfile=$(mktemp /tmp/vmgr_XXXXXX.json)
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmpfile'" EXIT
 
-    echo "  Enter the SOURCE validator pubkey (the one to be merged and exited):"
+    load_local_validators "$tmpfile" || return 0
+    print_local_validators "$tmpfile"
+
+    printf "  Enter the SOURCE validator pubkey (will be exited):\n"
     read -rp "  Source pubkey (0x...): " src_pubkey
-    echo ""
-    echo "  Enter the TARGET validator pubkey (the one that will receive the stake):"
+    printf "\n  Enter the TARGET validator pubkey (receives the stake):\n"
     read -rp "  Target pubkey (0x...): " tgt_pubkey
-    echo ""
+    printf "\n"
 
     if [[ -z "$src_pubkey" || -z "$tgt_pubkey" ]]; then
         log_warn "Both pubkeys are required. Aborting."
         return 0
     fi
 
-    # Normalize: ensure 0x prefix
+    # Normalise: ensure 0x prefix, strip spaces
+    src_pubkey="${src_pubkey// /}"
+    tgt_pubkey="${tgt_pubkey// /}"
     [[ "$src_pubkey" != 0x* ]] && src_pubkey="0x${src_pubkey}"
     [[ "$tgt_pubkey" != 0x* ]] && tgt_pubkey="0x${tgt_pubkey}"
 
-    # Query current fee from consolidation contract
-    local fee_hex=""
-    local el_rpc="http://127.0.0.1:8545"
+    # Query current fee from the consolidation contract (selector: fee() = 0x95600e7e)
+    local fee_hex
     fee_hex=$(curl -sf --max-time 5 \
         -X POST "$el_rpc" \
         -H "Content-Type: application/json" \
-        -d '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"'"${CONSOLIDATION_CONTRACT}"'","data":"0x95600e7e"},"latest"],"id":1}' \
-        2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('result','0x0'))" 2>/dev/null || true)
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"${CONSOLIDATION_CONTRACT}\",\"data\":\"0x95600e7e\"},\"latest\"],\"id\":1}" \
+        2>/dev/null | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('result', '0x0'))
+" 2>/dev/null || echo "0x0")
 
     local fee_dec=0
-    if [[ -n "$fee_hex" && "$fee_hex" != "0x" ]]; then
+    if [[ -n "$fee_hex" && "$fee_hex" != "0x" && "$fee_hex" != "0x0" ]]; then
         fee_dec=$(python3 -c "print(int('${fee_hex}', 16))" 2>/dev/null || echo 0)
     fi
     local fee_eth
     fee_eth=$(python3 -c "print(f'{${fee_dec} / 1e18:.8f}')" 2>/dev/null || echo "unknown")
 
-    echo "  Consolidation parameters:"
-    echo "    Source pubkey : ${src_pubkey}"
-    echo "    Target pubkey : ${tgt_pubkey}"
-    echo "    Contract      : ${CONSOLIDATION_CONTRACT}"
-    echo "    Required fee  : ~${fee_eth} ETH (${fee_dec} wei)"
-    echo ""
-
-    # Build the calldata: source_pubkey_bytes (48) + target_pubkey_bytes (48) = 96 bytes
+    # Calldata: source_pubkey_bytes (48) + target_pubkey_bytes (48) = 96 bytes total
     local src_hex="${src_pubkey#0x}"
     local tgt_hex="${tgt_pubkey#0x}"
     local calldata="0x${src_hex}${tgt_hex}"
 
-    echo "  Transaction calldata:"
-    echo "    ${calldata}"
-    echo ""
+    printf "  Consolidation parameters:\n"
+    printf "    Source  : %s\n" "$src_pubkey"
+    printf "    Target  : %s\n" "$tgt_pubkey"
+    printf "    Contract: %s\n" "$CONSOLIDATION_CONTRACT"
+    printf "    Fee     : ~%s ETH (%s wei)\n\n" "$fee_eth" "$fee_dec"
+    printf "  Calldata: %s\n\n" "$calldata"
 
-    if command -v cast &>/dev/null; then
-        echo "  Ready-to-run cast command (requires --private-key of the withdrawal address):"
-        echo ""
-        echo "    cast send ${CONSOLIDATION_CONTRACT} \\"
-        echo "      --value ${fee_dec}wei \\"
-        echo "      --data ${calldata} \\"
-        echo "      --rpc-url ${el_rpc} \\"
-        echo "      --private-key <YOUR_WITHDRAWAL_ADDRESS_PRIVATE_KEY>"
-        echo ""
-        echo "  Or, if using a hardware wallet via cast:"
-        echo "    cast send ${CONSOLIDATION_CONTRACT} \\"
-        echo "      --value ${fee_dec}wei \\"
-        echo "      --data ${calldata} \\"
-        echo "      --rpc-url ${el_rpc} \\"
-        echo "      --ledger"
-        echo ""
+    printf "  Command to run (requires the withdrawal address private key):\n\n"
+    printf "    cast send %s \\\\\n" "$CONSOLIDATION_CONTRACT"
+    printf "      --value %swei \\\\\n" "$fee_dec"
+    printf "      --data %s \\\\\n" "$calldata"
+    printf "      --rpc-url %s \\\\\n" "$el_rpc"
+    printf "      --private-key <WITHDRAWAL_ADDRESS_PRIVATE_KEY>\n\n"
 
-        if ! confirm_destructive "Consolidation permanently exits the source validator. Proceed with cast send?"; then
-            log_warn "Aborted. Run the cast command above manually when ready."
-            return 0
-        fi
-
-        read -rsp "  Private key of withdrawal address (input hidden): " priv_key
-        echo ""
-        if [[ -z "$priv_key" ]]; then
-            log_warn "No private key provided. Aborting."
-            return 0
-        fi
-
-        log_info "Submitting consolidation transaction..."
-        cast send "${CONSOLIDATION_CONTRACT}" \
-            --value "${fee_dec}wei" \
-            --data "${calldata}" \
-            --rpc-url "${el_rpc}" \
-            --private-key "${priv_key}"
-
-        log_info "Transaction submitted. Monitor the source validator status for an exit."
-    else
-        log_warn "'cast' (Foundry) is not installed. Run the transaction manually:"
-        echo ""
-        echo "  Install Foundry:  curl -L https://foundry.paradigm.xyz | bash && foundryup"
-        echo ""
-        echo "  Then run:"
-        echo "    cast send ${CONSOLIDATION_CONTRACT} \\"
-        echo "      --value ${fee_dec}wei \\"
-        echo "      --data ${calldata} \\"
-        echo "      --rpc-url ${el_rpc} \\"
-        echo "      --private-key <YOUR_WITHDRAWAL_ADDRESS_PRIVATE_KEY>"
-        echo ""
+    if ! command -v cast &>/dev/null; then
+        log_warn "'cast' not found. Install Foundry: curl -L https://foundry.paradigm.xyz | bash && foundryup"
+        return 0
     fi
+
+    if ! confirm_destructive "Consolidation permanently exits the source validator."; then
+        log_warn "Aborted. Run the cast command above manually when ready."
+        return 0
+    fi
+
+    read -rsp "  Private key of withdrawal address (hidden): " priv_key
+    printf "\n"
+    if [[ -z "$priv_key" ]]; then
+        log_warn "No private key provided. Aborting."
+        return 0
+    fi
+
+    log_info "Submitting consolidation transaction..."
+    cast send "${CONSOLIDATION_CONTRACT}" \
+        --value "${fee_dec}wei" \
+        --data "${calldata}" \
+        --rpc-url "${el_rpc}" \
+        --private-key "${priv_key}"
+
+    log_info "Transaction submitted. Monitor the source validator for a pending exit."
 }
 
 # =============================================================================
@@ -485,40 +467,25 @@ show_menu() {
     local vc_status
     vc_status=$(systemctl is-active validator 2>/dev/null || echo "inactive")
 
-    echo ""
-    echo "╔══════════════════════════════════════════════════════╗"
-    echo "║         Eth2 Quick Start — Validator Manager         ║"
-    echo "╚══════════════════════════════════════════════════════╝"
-    echo ""
+    printf "\n"
+    printf "╔══════════════════════════════════════════════════════╗\n"
+    printf "║         Eth2 Quick Start — Validator Manager         ║\n"
+    printf "╚══════════════════════════════════════════════════════╝\n\n"
     printf "  Client    : %s\n" "$client"
     printf "  Validator : %s\n" "$vc_status"
-    printf "  Beacon    : %s\n" "$beacon_url"
-    echo ""
-    echo "  [1] List active validators"
-    echo "  [2] Voluntary exit (irreversible)"
-    echo "  [3] Consolidate validators (EIP-7251)"
-    echo "  [q] Quit"
-    echo ""
+    printf "  Beacon    : %s\n\n" "$beacon_url"
+    printf "  [1] List local validators\n"
+    printf "  [2] Voluntary exit  (irreversible)\n"
+    printf "  [3] Consolidate validators  (EIP-7251)\n"
+    printf "  [q] Quit\n\n"
     read -rp "  Choice: " choice
 
     case "$choice" in
-        1)
-            "$SCRIPT_DIR/validator_list.sh"
-            ;;
-        2)
-            cmd_exit
-            ;;
-        3)
-            cmd_consolidate
-            ;;
-        q|Q|quit|exit)
-            echo "  Bye."
-            exit 0
-            ;;
-        *)
-            log_warn "Invalid choice: ${choice}"
-            show_menu
-            ;;
+        1) "$SCRIPT_DIR/validator_list.sh" ;;
+        2) cmd_exit ;;
+        3) cmd_consolidate ;;
+        q|Q|quit) printf "  Bye.\n"; exit 0 ;;
+        *) log_warn "Invalid choice: ${choice}"; show_menu ;;
     esac
 }
 
@@ -528,15 +495,9 @@ show_menu() {
 
 main() {
     case "$ACTION" in
-        exit)
-            cmd_exit
-            ;;
-        consolidate)
-            cmd_consolidate
-            ;;
-        "")
-            show_menu
-            ;;
+        exit)        cmd_exit ;;
+        consolidate) cmd_consolidate ;;
+        "")          show_menu ;;
     esac
 }
 


### PR DESCRIPTION
**Agent:** Claude Sonnet 4.6

**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary

Fixes all issues from the PR #173 review (bot + manual audit). No new features — this is a correctness and quality pass only.

- **P1** `validator_list.sh`: `json.loads(sys.argv[1])` was parsing the file path string as JSON instead of reading the file; fixed to `json.load(open(...))`
- **P1** `validator_manage.sh`: `list_validators_interactive()` fetched the entire mainnet validator set (~1M entries, always times out) instead of local validators only; replaced with delegation to `validator_list.sh --json` so only locally managed validators appear
- **P2** Lodestar keystore path corrected to `~/.local/share/lodestar/validators/keystores` (matches `lodestar.sh` install)
- **P2** Nimbus keystore path corrected to `~/.local/share/nimbus/validators` (matches `nimbus.sh` install)
- Dead `gwei_to_eth()` function removed
- `get_client_binary()` collapsed from 4 identical cases to one
- Lighthouse exit: removed silent fallback that would have exited ALL validators when `--pubkeys` was not recognised
- `echo -e` replaced with `printf` throughout
- Added `docs/VALIDATOR_MANAGEMENT.md`: usage, keystore paths per client, JSON schema, per-client exit commands, troubleshooting

## Original Request

> Review the work done and fix it up. We want a list of local validators and actions on local validators. We want documentation. We want it to be consistent with other tools. No AI slop or dead/useless code.

## Changes Made

- `install/utils/validator_list.sh` — P1 json.loads bug fix, dead code removal, corrected Lodestar + Nimbus paths
- `install/utils/validator_manage.sh` — P1 local-only validator query, simplified binary detection, safe exit per client, printf consistency
- `docs/VALIDATOR_MANAGEMENT.md` — new documentation

## Test plan

- [x] `shellcheck -x --exclude=SC2317,SC1091,SC1090,SC2034,SC2031,SC2181` passes on both scripts
- [x] `bash -n` syntax check passes
- [x] `print_table` Python block correctly reads the JSON file (not the path string)
- [x] `load_local_validators` count parsing verified with test data
- [x] `print_local_validators` renders a row with correct fields
- [x] `validator_list.sh --json` returns valid JSON with `error: no_keystores_found` when no keys present

🤖 Generated with [Claude Code](https://claude.com/claude-code)