### PR TITLE
Add validator helper flows and E2E coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,4 @@ Before marking any task complete, verify the change set against the repository's
 - New `install/utils` helpers should be wired into `scripts/eth2qs.sh`, documented in `docs/SCRIPTS.md`, and covered by at least one structure or Docker smoke test.
 - Validator exit helpers should reuse the local validator inventory path and delegate client-specific exit logic to `validator_manage.sh`.
 - Validator entry helpers should prefer an explicit command template when the deposit CLI is not installed locally so operators still get a usable offline checklist.
+- Withdrawal-change helpers should support a no-side-effect `--dry-run` preview and a fixture-backed smoke test path so agents can rehearse the workflow in the live geth + Prysm container before touching production keys.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,9 @@ Before marking any task complete, verify the change set against the repository's
 - Perform a security audit for any change that touches deployment, secrets, network exposure, or privilege boundaries.
 - Perform a regression review for any change that can alter install flows, service behavior, or generated configs.
 - If a required check could not run, say exactly what was skipped and why.
+
+## Meta Learnings
+
+- New `install/utils` helpers should be wired into `scripts/eth2qs.sh`, documented in `docs/SCRIPTS.md`, and covered by at least one structure or Docker smoke test.
+- Validator exit helpers should reuse the local validator inventory path and delegate client-specific exit logic to `validator_manage.sh`.
+- Validator entry helpers should prefer an explicit command template when the deposit CLI is not installed locally so operators still get a usable offline checklist.

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -55,6 +55,7 @@ Use `scripts/eth2qs.sh` as a stable command entrypoint for both humans and AI ag
 Validator helpers:
 - `./scripts/eth2qs.sh validator-exit` for the focused exit checklist and client-specific voluntary exit flow.
 - `./scripts/eth2qs.sh validator-create-0x02` for the 0x02 entry checklist and deposit CLI launcher.
+- `./scripts/eth2qs.sh validator-withdrawal-changes` for BLS-to-execution credential changes on `0x00` validators.
 - `./scripts/eth2qs.sh validator-manage` for the combined exit / consolidation menu.
 
 ## Environment Configuration (exports.sh)

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -52,6 +52,11 @@ Use `scripts/eth2qs.sh` as a stable command entrypoint for both humans and AI ag
 `monitor export --json` is the compact summary surface for bots, dashboards, cron jobs, or alert relays, and `monitor snapshot` writes a local history entry under `~/.eth2qs-monitor/`.
 `repair` is the bounded apply surface. It previews allowlisted targeted restarts by default and requires `--apply --confirm` before making changes.
 
+Validator helpers:
+- `./scripts/eth2qs.sh validator-exit` for the focused exit checklist and client-specific voluntary exit flow.
+- `./scripts/eth2qs.sh validator-create-0x02` for the 0x02 entry checklist and deposit CLI launcher.
+- `./scripts/eth2qs.sh validator-manage` for the combined exit / consolidation menu.
+
 ## Environment Configuration (exports.sh)
 
 Key variables:

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -55,7 +55,8 @@ Use `scripts/eth2qs.sh` as a stable command entrypoint for both humans and AI ag
 Validator helpers:
 - `./scripts/eth2qs.sh validator-exit` for the focused exit checklist and client-specific voluntary exit flow.
 - `./scripts/eth2qs.sh validator-create-0x02` for the 0x02 entry checklist and deposit CLI launcher.
-- `./scripts/eth2qs.sh validator-withdrawal-changes` for BLS-to-execution credential changes on `0x00` validators.
+- `./scripts/eth2qs.sh validator-withdrawal-changes --dry-run --generate --submit --yes` to preview BLS-to-execution credential changes on `0x00` validators without executing them.
+- `./scripts/eth2qs.sh validator-withdrawal-changes --generate --submit --yes` to generate and POST signed BLS-to-execution changes on `0x00` validators.
 - `./scripts/eth2qs.sh validator-manage` for the combined exit / consolidation menu.
 
 ## Environment Configuration (exports.sh)

--- a/docs/VALIDATOR_MANAGEMENT.md
+++ b/docs/VALIDATOR_MANAGEMENT.md
@@ -1,7 +1,7 @@
 # Validator Management
 
-Two standalone helper scripts for managing validators on this node.
-Both are also available through the unified `eth2qs.sh` wrapper.
+Several standalone helper scripts for managing validators on this node.
+They are also available through the unified `eth2qs.sh` wrapper.
 
 ---
 
@@ -16,13 +16,17 @@ Both are also available through the unified `eth2qs.sh` wrapper.
 ./scripts/eth2qs.sh validators --json
 ./install/utils/validator_list.sh --json
 
+# Go straight to voluntary exit flow
+./scripts/eth2qs.sh validator-exit
+./install/utils/validator_exit.sh
+
+# Go straight to 0x02 validator creation flow
+./scripts/eth2qs.sh validator-create-0x02
+./install/utils/validator_create_0x02.sh
+
 # Interactive management menu (exit / consolidate)
 ./scripts/eth2qs.sh validator-manage
 ./install/utils/validator_manage.sh
-
-# Go straight to voluntary exit flow
-./scripts/eth2qs.sh validator-manage --exit
-./install/utils/validator_manage.sh --exit
 
 # Go straight to consolidation flow (EIP-7251)
 ./scripts/eth2qs.sh validator-manage --consolidate
@@ -77,6 +81,29 @@ keystore files exist on this machine are shown.
 ```
 
 ---
+
+## `validator_exit.sh` — Focused Exit Flow
+
+This helper wraps the existing exit path, but it starts with a targeted checklist
+for legacy validators.
+
+1. Shows the current local validator inventory via `validator_list.sh`.
+2. Reminds you that `0x00` validators need credential upgrades before any
+   withdrawals can be swept.
+3. Hands off to `validator_manage.sh --exit` for the interactive client-specific
+   exit flow.
+
+## `validator_create_0x02.sh` — Compounding Entry Flow
+
+This helper is the matching entry path for modern validators.
+
+1. Prints the offline key-generation checklist.
+2. Shows the current local validator inventory so you can compare against the
+   node you are about to import into.
+3. Launches the local deposit CLI if available, or prints the exact command
+   template when you are running the tool manually.
+4. Reminds you to select compounding / `0x02` withdrawal credentials during the
+   deposit CLI prompts.
 
 ## `validator_manage.sh` — Operations
 

--- a/docs/VALIDATOR_MANAGEMENT.md
+++ b/docs/VALIDATOR_MANAGEMENT.md
@@ -24,9 +24,10 @@ They are also available through the unified `eth2qs.sh` wrapper.
 ./scripts/eth2qs.sh validator-create-0x02
 ./install/utils/validator_create_0x02.sh
 
-# Generate / submit BLS-to-execution changes for 0x00 validators
+# Preview / generate / submit BLS-to-execution changes for 0x00 validators
+./scripts/eth2qs.sh validator-withdrawal-changes --dry-run --generate --submit --yes
 ./scripts/eth2qs.sh validator-withdrawal-changes --generate --submit --yes
-./install/utils/validator_withdrawal_changes.sh --generate --submit --yes
+./install/utils/validator_withdrawal_changes.sh --dry-run --generate --submit --yes
 
 # Interactive management menu (exit / consolidate)
 ./scripts/eth2qs.sh validator-manage
@@ -47,6 +48,7 @@ They are also available through the unified `eth2qs.sh` wrapper.
 4. Queries the local beacon node API (`/eth/v1/beacon/states/head/validators`)
    filtered to those public keys only.
 5. Displays a table with validator index, pubkey, status, balance, withdrawal credential type, and effective balance.
+6. Emits inventory freshness metadata in the JSON output (`generated_at_utc`, `beacon_query_status`) so operators can tell when the snapshot was taken and whether the beacon query succeeded.
 
 **Nothing is read from the network validator set** — only validators whose
 keystore files exist on this machine are shown.
@@ -68,6 +70,8 @@ keystore files exist on this machine are shown.
 {
   "client": "lighthouse",
   "beacon_url": "http://127.0.0.1:5052",
+  "generated_at_utc": "2026-06-04T00:00:00Z",
+  "beacon_query_status": "ok",
   "validators": [
     {
       "index": "123456",
@@ -116,13 +120,15 @@ first step before a later voluntary exit if you want the validator to become
 withdrawable.
 
 1. Shows the current local validator inventory, including withdrawal credential
-   type.
+   type and inventory freshness metadata.
 2. Filters the inventory to the selected credential type (default `0x00`).
-3. Uses the official deposit CLI to generate signed BLS-to-execution change
+3. Supports `--dry-run` so operators can preview the exact signing and submit
+   commands without writing or POSTing anything.
+4. Uses the official deposit CLI to generate signed BLS-to-execution change
    JSON files from a withdrawal mnemonic and execution address.
-4. Optionally POSTs the generated JSON files to the local beacon node REST API
+5. Optionally POSTs the generated JSON files to the local beacon node REST API
    at `/eth/v1/beacon/pool/bls_to_execution_changes`.
-5. Works with the repo's Prysm + geth stack as long as the beacon REST API is
+6. Works with the repo's Prysm + geth stack as long as the beacon REST API is
    reachable from the node running the helper.
 
 ## `validator_manage.sh` — Operations

--- a/docs/VALIDATOR_MANAGEMENT.md
+++ b/docs/VALIDATOR_MANAGEMENT.md
@@ -24,6 +24,10 @@ They are also available through the unified `eth2qs.sh` wrapper.
 ./scripts/eth2qs.sh validator-create-0x02
 ./install/utils/validator_create_0x02.sh
 
+# Generate / submit BLS-to-execution changes for 0x00 validators
+./scripts/eth2qs.sh validator-withdrawal-changes --generate --submit --yes
+./install/utils/validator_withdrawal_changes.sh --generate --submit --yes
+
 # Interactive management menu (exit / consolidate)
 ./scripts/eth2qs.sh validator-manage
 ./install/utils/validator_manage.sh
@@ -42,8 +46,7 @@ They are also available through the unified `eth2qs.sh` wrapper.
 3. Extracts the public key from each keystore's JSON.
 4. Queries the local beacon node API (`/eth/v1/beacon/states/head/validators`)
    filtered to those public keys only.
-5. Displays a table with validator index, pubkey, status, balance, and
-   effective balance.
+5. Displays a table with validator index, pubkey, status, balance, withdrawal credential type, and effective balance.
 
 **Nothing is read from the network validator set** — only validators whose
 keystore files exist on this machine are shown.
@@ -104,6 +107,23 @@ This helper is the matching entry path for modern validators.
    template when you are running the tool manually.
 4. Reminds you to select compounding / `0x02` withdrawal credentials during the
    deposit CLI prompts.
+
+## `validator_withdrawal_changes.sh` — BLS-to-Execution Change Flow
+
+This helper generates and optionally submits signed BLS-to-execution change
+messages for validators that still use `0x00` withdrawal credentials. It is the
+first step before a later voluntary exit if you want the validator to become
+withdrawable.
+
+1. Shows the current local validator inventory, including withdrawal credential
+   type.
+2. Filters the inventory to the selected credential type (default `0x00`).
+3. Uses the official deposit CLI to generate signed BLS-to-execution change
+   JSON files from a withdrawal mnemonic and execution address.
+4. Optionally POSTs the generated JSON files to the local beacon node REST API
+   at `/eth/v1/beacon/pool/bls_to_execution_changes`.
+5. Works with the repo's Prysm + geth stack as long as the beacon REST API is
+   reachable from the node running the helper.
 
 ## `validator_manage.sh` — Operations
 
@@ -206,6 +226,11 @@ The scripts auto-detect the correct port from the `cl` systemd service.
 **"No validator data returned from beacon node"**
 - The beacon node may still be syncing. Check with `./scripts/eth2qs.sh doctor`.
 - Verify the beacon node is reachable: `curl -s http://127.0.0.1:5052/eth/v1/node/syncing`
+
+**Withdrawal change generation fails**
+- The helper needs the withdrawal mnemonic, the optional mnemonic password, and a valid execution address.
+- If you are using Prysm, make sure the beacon REST API is reachable from the node running the helper.
+- Use `--validators-json` with a fixture if you want to rehearse the flow without touching live keys.
 
 **Exit command fails with unknown flag**
 - Client versions change CLI flags. If the auto-detected command fails,

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -7,6 +7,18 @@ Use this file to preserve context across sessions.
 - Preserve valuable uncommitted work before syncing (stash or branch).
 - Use a fresh branch + fresh PR for each new task.
 
+## Latest Update (Withdrawal credential changes and safe rehearsal path, 2026-06-04)
+
+- Added a dedicated BLS-to-execution helper for `0x00` validators: `./scripts/eth2qs.sh validator-withdrawal-changes`.
+- The local validator inventory now shows withdrawal credential type so agents can see `0x00`, `0x01`, and `0x02` at a glance before taking action.
+- The helper is designed for safe rehearsal with `--validators-json`, stubbed deposit CLI, and stubbed beacon POSTs before live usage.
+- The tested flow for this branch now includes: `bash test/ci_test_run_2.sh`, `bash test/run_e2e.sh --phase=2`, and a fixture-driven helper test that stubs signing/submission.
+- Repo guidance updates:
+  - added validator withdrawal-change routing to `skills/eth2-quickstart/SKILL.md`
+  - added the command to `skills/eth2-quickstart/references/commands.md`
+  - added durable learning notes to `skills/eth2-quickstart/references/improvement.md`
+
+
 ## Latest Update (Validator lifecycle helpers and local geth/Prysm E2E, 2026-06-04)
 
 - Added focused validator lifecycle wrappers on top of the shared inventory surface:

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -3,6 +3,16 @@
 Use this file to preserve context across sessions.
 
 ## Active Defaults
+## Latest Update (Withdrawal helper dry-run and live Prysm/geth smoke, 2026-06-04)
+
+- Added a dry-run path to `./scripts/eth2qs.sh validator-withdrawal-changes` so operators can preview the exact signing and submission commands without writing or POSTing anything.
+- The validator inventory now includes freshness metadata in JSON (`generated_at_utc`, `beacon_query_status`) so agents can tell when the snapshot was taken and whether the beacon query succeeded.
+- Added a fixture-backed smoke test for the withdrawal helper and wired it into the phase-2 E2E flow so the helper is exercised in the live Prysm + geth container.
+- Repo guidance updates:
+  - tightened the validator management docs for dry-run usage and inventory freshness
+  - added the new dry-run command to the script reference and agent skill command list
+  - recorded the rehearsal pattern in the skill improvement notes
+
 - Start new work from latest `origin/master`.
 - Preserve valuable uncommitted work before syncing (stash or branch).
 - Use a fresh branch + fresh PR for each new task.

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -7,6 +7,26 @@ Use this file to preserve context across sessions.
 - Preserve valuable uncommitted work before syncing (stash or branch).
 - Use a fresh branch + fresh PR for each new task.
 
+## Latest Update (Validator lifecycle helpers and local geth/Prysm E2E, 2026-06-04)
+
+- Added focused validator lifecycle wrappers on top of the shared inventory surface:
+  - `./scripts/eth2qs.sh validators --json` lists active validators with index, status, and balance.
+  - `./scripts/eth2qs.sh validator-exit` prints the 0x00/0x01 exit checklist and hands off to the managed voluntary-exit flow.
+  - `./scripts/eth2qs.sh validator-create-0x02` prints the 0x02 compounding checklist and can launch a local deposit CLI with `--compounding`.
+  - `./scripts/eth2qs.sh validator-manage` remains the combined exit / consolidation menu.
+- Reused the local validator inventory path in both the exit and compounding helpers so operators see the current node state before taking action.
+- Validated the helper flow locally with the repo's existing E2E tooling on Geth + Prysm:
+  - `bash test/ci_test_run_2.sh`
+  - `bash test/run_e2e.sh --phase=2`
+  - `bash -n install/utils/validator_exit.sh install/utils/validator_create_0x02.sh scripts/eth2qs.sh test/ci_test_run_2.sh test/docker_test.sh test/validate_nginx_config.sh`
+  - `shellcheck -x --exclude=SC2317,SC1091,SC1090,SC2034,SC2031,SC2181 install/utils/validator_exit.sh install/utils/validator_create_0x02.sh scripts/eth2qs.sh test/ci_test_run_2.sh test/docker_test.sh test/validate_nginx_config.sh`
+- Repo guidance updates:
+  - added validator helper routing to `skills/eth2-quickstart/SKILL.md`
+  - added the validator commands to `skills/eth2-quickstart/references/commands.md`
+  - added a durable learning note to `skills/eth2-quickstart/references/improvement.md`
+- Review note:
+  - the PR commit-message rule failed only because of an earlier non-conventional commit subject; rebasing and renaming it to `fix(validators): pass compounding flag to deposit CLI` fixed the gate locally.
+
 ## Latest Update (Batteries-included Caddy guardrails pass, 2026-04-20)
 
 - Upgraded Caddy install behavior to make edge guardrails batteries-included by default:

--- a/install/test/fixtures/validator_withdrawal_changes_inventory.json
+++ b/install/test/fixtures/validator_withdrawal_changes_inventory.json
@@ -1,0 +1,38 @@
+{
+  "client": "prysm",
+  "beacon_url": "http://127.0.0.1:5052",
+  "generated_at_utc": "2026-06-04T00:00:00Z",
+  "beacon_query_status": "ok",
+  "validators": [
+    {
+      "index": "101",
+      "balance": "32000000000",
+      "status": "active_ongoing",
+      "validator": {
+        "pubkey": "0xaaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999",
+        "withdrawal_credentials": "0x00aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "effective_balance": "32000000000"
+      }
+    },
+    {
+      "index": "102",
+      "balance": "33000000000",
+      "status": "active_ongoing",
+      "validator": {
+        "pubkey": "0xbbbbccccddddeeeeffff0000111122223333444455556666777788889999aaaa",
+        "withdrawal_credentials": "0x01bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "effective_balance": "32000000000"
+      }
+    },
+    {
+      "index": "103",
+      "balance": "34000000000",
+      "status": "active_ongoing",
+      "validator": {
+        "pubkey": "0xccccddddeeeeffff0000111122223333444455556666777788889999aaaabbbb",
+        "withdrawal_credentials": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "effective_balance": "32000000000"
+      }
+    }
+  ]
+}

--- a/install/test/test_validator_withdrawal_changes.sh
+++ b/install/test/test_validator_withdrawal_changes.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+# shellcheck disable=SC2317
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TEST_COUNT=0
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_test() {
+    local test_name="$1"
+    local test_func="$2"
+
+    TEST_COUNT=$((TEST_COUNT + 1))
+    echo ""
+    echo "=== Test $TEST_COUNT: $test_name ==="
+
+    if "$test_func"; then
+        echo "PASS: $test_name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "FAIL: $test_name"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+setup_fake_env() {
+    local temp_root
+    temp_root="$(mktemp -d)"
+    mkdir -p "$temp_root/bin"
+
+    cat > "$temp_root/validators.json" <<'JSON'
+{
+  "client": "prysm",
+  "beacon_url": "http://127.0.0.1:5052",
+  "validators": [
+    {
+      "index": "101",
+      "balance": "32000000000",
+      "status": "active_ongoing",
+      "validator": {
+        "pubkey": "0xaaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999",
+        "withdrawal_credentials": "0x00aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "effective_balance": "32000000000"
+      }
+    },
+    {
+      "index": "102",
+      "balance": "33000000000",
+      "status": "active_ongoing",
+      "validator": {
+        "pubkey": "0xbbbbccccddddeeeeffff0000111122223333444455556666777788889999aaaa",
+        "withdrawal_credentials": "0x01bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "effective_balance": "32000000000"
+      }
+    },
+    {
+      "index": "103",
+      "balance": "34000000000",
+      "status": "active_ongoing",
+      "validator": {
+        "pubkey": "0xccccddddeeeeffff0000111122223333444455556666777788889999aaaabbbb",
+        "withdrawal_credentials": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "effective_balance": "32000000000"
+      }
+    }
+  ]
+}
+JSON
+
+    cat > "$temp_root/bin/deposit.sh" <<'EOF'
+#!/bin/bash
+set -Eeuo pipefail
+: "${MOCK_DEPOSIT_LOG:?missing MOCK_DEPOSIT_LOG}"
+echo "[MOCK] deposit.sh $*" >> "$MOCK_DEPOSIT_LOG"
+out_dir=""
+indices=""
+for arg in "$@"; do
+    case "$arg" in
+        --bls_to_execution_changes_folder=*) out_dir="${arg#*=}" ;;
+        --validator_indices=*) indices="${arg#*=}" ;;
+    esac
+done
+mkdir -p "$out_dir"
+python3 - "$out_dir" "$indices" <<'PYEOF'
+import os, sys
+out_dir, indices = sys.argv[1:3]
+for idx in [i for i in indices.split(',') if i]:
+    with open(os.path.join(out_dir, f'bls_to_execution_change-{idx}.json'), 'w') as fh:
+        fh.write('{"mock": true, "index": "%s"}\n' % idx)
+PYEOF
+EOF
+
+    cat > "$temp_root/bin/curl" <<'EOF'
+#!/bin/bash
+set -Eeuo pipefail
+: "${MOCK_CURL_LOG:?missing MOCK_CURL_LOG}"
+echo "[MOCK] curl $*" >> "$MOCK_CURL_LOG"
+exit 0
+EOF
+
+    chmod +x "$temp_root/bin/deposit.sh" "$temp_root/bin/curl"
+
+    cat > "$temp_root/mnemonic.txt" <<'EOF'
+abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
+EOF
+    cat > "$temp_root/password.txt" <<'EOF'
+correct horse battery staple
+EOF
+
+    printf '%s\n' "$temp_root"
+}
+
+assert_contains() {
+    local needle="$1"
+    local file="$2"
+    grep -qF -- "$needle" "$file"
+}
+
+# shellcheck disable=SC2317
+test_inventory_shows_withdrawal_types() {
+    local temp_root output
+    temp_root="$(setup_fake_env)"
+
+    output="$(PATH="$temp_root/bin:$PATH" "$PROJECT_ROOT/install/utils/validator_withdrawal_changes.sh" --validators-json "$temp_root/validators.json" --credential-type all)"
+
+    printf '%s\n' "$output" | grep -q "WCred"
+    printf '%s\n' "$output" | grep -q "0x00"
+    printf '%s\n' "$output" | grep -q "0x01"
+    printf '%s\n' "$output" | grep -q "0x02"
+
+    rm -rf "$temp_root"
+}
+
+# shellcheck disable=SC2317
+test_generate_and_submit_0x00_changes() {
+    local temp_root output deposit_log curl_log out_dir
+    temp_root="$(setup_fake_env)"
+    deposit_log="$temp_root/deposit.log"
+    curl_log="$temp_root/curl.log"
+    out_dir="$temp_root/generated"
+
+    output="$(MOCK_DEPOSIT_LOG="$deposit_log" MOCK_CURL_LOG="$curl_log" PATH="$temp_root/bin:$PATH" "$PROJECT_ROOT/install/utils/validator_withdrawal_changes.sh" \
+        --validators-json "$temp_root/validators.json" \
+        --credential-type 0x00 \
+        --generate \
+        --submit \
+        --yes \
+        --withdrawal-address 0x1111111111111111111111111111111111111111 \
+        --mnemonic-file "$temp_root/mnemonic.txt" \
+        --mnemonic-password-file "$temp_root/password.txt" \
+        --out-dir "$out_dir" \
+        --deposit-tool deposit-sh \
+        --beacon-url http://127.0.0.1:5052)"
+
+    assert_contains "0x00" "$deposit_log"
+    assert_contains "generate-bls-to-execution-change" "$deposit_log"
+    assert_contains "--validator_indices=101" "$deposit_log"
+    assert_contains "--execution_address=0x1111111111111111111111111111111111111111" "$deposit_log"
+    test -f "$out_dir/bls_to_execution_change-101.json"
+    assert_contains "/eth/v1/beacon/pool/bls_to_execution_changes" "$curl_log"
+
+    printf '%s\n' "$output" | grep -q "Submitting bls_to_execution_change-101.json"
+
+    rm -rf "$temp_root"
+}
+
+echo "=========================================="
+echo "Validator Withdrawal Change Test Suite"
+echo "=========================================="
+
+run_test "inventory shows withdrawal types" test_inventory_shows_withdrawal_types
+run_test "generate and submit 0x00 changes" test_generate_and_submit_0x00_changes
+
+echo ""
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo "Total tests: $TEST_COUNT"
+echo "Passed: $PASS_COUNT"
+echo "Failed: $FAIL_COUNT"
+
+if [[ $FAIL_COUNT -eq 0 ]]; then
+    echo ""
+    echo "All tests passed!"
+    exit 0
+fi
+
+exit 1

--- a/install/test/test_validator_withdrawal_changes.sh
+++ b/install/test/test_validator_withdrawal_changes.sh
@@ -32,44 +32,7 @@ setup_fake_env() {
     temp_root="$(mktemp -d)"
     mkdir -p "$temp_root/bin"
 
-    cat > "$temp_root/validators.json" <<'JSON'
-{
-  "client": "prysm",
-  "beacon_url": "http://127.0.0.1:5052",
-  "validators": [
-    {
-      "index": "101",
-      "balance": "32000000000",
-      "status": "active_ongoing",
-      "validator": {
-        "pubkey": "0xaaaabbbbccccddddeeeeffff0000111122223333444455556666777788889999",
-        "withdrawal_credentials": "0x00aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "effective_balance": "32000000000"
-      }
-    },
-    {
-      "index": "102",
-      "balance": "33000000000",
-      "status": "active_ongoing",
-      "validator": {
-        "pubkey": "0xbbbbccccddddeeeeffff0000111122223333444455556666777788889999aaaa",
-        "withdrawal_credentials": "0x01bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "effective_balance": "32000000000"
-      }
-    },
-    {
-      "index": "103",
-      "balance": "34000000000",
-      "status": "active_ongoing",
-      "validator": {
-        "pubkey": "0xccccddddeeeeffff0000111122223333444455556666777788889999aaaabbbb",
-        "withdrawal_credentials": "0x02cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-        "effective_balance": "32000000000"
-      }
-    }
-  ]
-}
-JSON
+    cp "$SCRIPT_DIR/fixtures/validator_withdrawal_changes_inventory.json" "$temp_root/validators.json"
 
     cat > "$temp_root/bin/deposit.sh" <<'EOF'
 #!/bin/bash
@@ -118,6 +81,34 @@ assert_contains() {
     local needle="$1"
     local file="$2"
     grep -qF -- "$needle" "$file"
+}
+
+assert_file_empty() {
+    local file="$1"
+    [[ ! -e "$file" || ! -s "$file" ]]
+}
+
+# shellcheck disable=SC2317
+test_dry_run_reports_without_invoking_tools() {
+    local temp_root output deposit_log curl_log
+    temp_root="$(setup_fake_env)"
+    deposit_log="$temp_root/deposit.log"
+    curl_log="$temp_root/curl.log"
+
+    output="$(PATH="$temp_root/bin:$PATH" "$PROJECT_ROOT/install/utils/validator_withdrawal_changes.sh"         --validators-json "$temp_root/validators.json"         --credential-type 0x00         --dry-run         --generate         --submit         --yes         --withdrawal-address 0x1111111111111111111111111111111111111111         --mnemonic-file "$temp_root/mnemonic.txt"         --mnemonic-password-file "$temp_root/password.txt"         --out-dir "$temp_root/generated"         --deposit-tool deposit-sh         --beacon-url http://127.0.0.1:5052)"
+
+    printf '%s
+' "$output" | grep -q "Dry run: no files will be written or submitted."
+    printf '%s
+' "$output" | grep -q "Would affect 1 validator(s): 101"
+    printf '%s
+' "$output" | grep -q "generate-bls-to-execution-change"
+    printf '%s
+' "$output" | grep -q "bls_to_execution_change-101.json"
+    assert_file_empty "$deposit_log"
+    assert_file_empty "$curl_log"
+
+    rm -rf "$temp_root"
 }
 
 # shellcheck disable=SC2317
@@ -172,6 +163,7 @@ echo "=========================================="
 echo "Validator Withdrawal Change Test Suite"
 echo "=========================================="
 
+run_test "dry run reports without invoking tools" test_dry_run_reports_without_invoking_tools
 run_test "inventory shows withdrawal types" test_inventory_shows_withdrawal_types
 run_test "generate and submit 0x00 changes" test_generate_and_submit_0x00_changes
 

--- a/install/utils/validator_create_0x02.sh
+++ b/install/utils/validator_create_0x02.sh
@@ -91,6 +91,7 @@ print_command_preview() {
         launcher="$launcher_detected"
     fi
     local cmd=("$launcher" "$MODE")
+    cmd+=("--compounding")
     cmd+=("--num_validators=$NUM_VALIDATORS")
     cmd+=("--mnemonic_language=$MNEMONIC_LANGUAGE")
     cmd+=("--chain=$CHAIN")
@@ -145,6 +146,7 @@ launch_deposit_tool() {
 
     local args=()
     args+=("$MODE")
+    args+=("--compounding")
     args+=("--num_validators=$NUM_VALIDATORS")
     args+=("--mnemonic_language=$MNEMONIC_LANGUAGE")
     args+=("--chain=$CHAIN")

--- a/install/utils/validator_create_0x02.sh
+++ b/install/utils/validator_create_0x02.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+
+# Eth2 Quick Start — 0x02 Validator Creation Helper
+# Focused operator checklist and launcher for modern compounding validators.
+# The script prints the checklist, shows the current local validator inventory,
+# and can launch the official deposit CLI if one is available.
+#
+# Usage:
+#   ./install/utils/validator_create_0x02.sh
+#   ./install/utils/validator_create_0x02.sh --launch
+#   ./scripts/eth2qs.sh validator-create-0x02 --launch
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../" && pwd)"
+
+# shellcheck source=../../lib/common_functions.sh
+source "$ROOT_DIR/lib/common_functions.sh"
+# shellcheck source=../../exports.sh
+if [[ -f "$ROOT_DIR/exports.sh" ]]; then
+    source "$ROOT_DIR/exports.sh" 2>/dev/null || true
+fi
+if [[ -f "$ROOT_DIR/config/user_config.env" ]]; then
+    # shellcheck source=/dev/null
+    source "$ROOT_DIR/config/user_config.env" 2>/dev/null || true
+fi
+
+LAUNCH=false
+TOOL="auto"
+MODE="new-mnemonic"
+CHAIN="mainnet"
+FOLDER="$ROOT_DIR/validator_keys"
+NUM_VALIDATORS=1
+MNEMONIC_LANGUAGE="English"
+EXECUTION_ADDRESS=""
+
+usage() {
+    cat <<'EOF'
+Usage: ./install/utils/validator_create_0x02.sh [options]
+
+Options:
+  --launch                    Launch the detected deposit CLI interactively.
+  --tool <auto|deposit|deposit-sh>
+                              Select the deposit tool launcher.
+  --mode <new-mnemonic|existing-mnemonic>
+                              Select the deposit CLI subcommand.
+  --chain <name>              Chain name passed to the deposit CLI (default: mainnet).
+  --folder <path>             Output folder for keystores and deposit data.
+  --num-validators <n>        Number of validators to create (default: 1).
+  --mnemonic-language <lang>   Mnemonic language passed to the deposit CLI.
+  --execution-address <addr>   Withdrawal address / execution address.
+  --help                      Show this help.
+
+This helper prints the offline key-generation checklist and, when launched,
+starts the official deposit CLI so you can select 0x02 / compounding
+withdrawal credentials during the CLI prompts.
+EOF
+}
+
+show_entry_checklist() {
+    cat <<'EOF'
+
+=== 0x02 Validator Entry Checklist ===
+
+- Use an offline or otherwise isolated machine for key generation.
+- Generate a new mnemonic unless you intentionally want to derive from a
+  secure existing mnemonic.
+- Use a withdrawal address you control and can recover.
+- Choose compounding / 0x02 withdrawal credentials in the deposit tool.
+- Save the keystore passwords, mnemonic backup, and deposit_data file securely.
+- Verify the deposit contract address before sending ETH.
+- After deposit, import the keystores into the validator client on the node.
+
+EOF
+}
+
+show_local_inventory() {
+    if [[ ! -x "$SCRIPT_DIR/validator_list.sh" ]]; then
+        return 0
+    fi
+
+    log_info "Current local validator inventory:"
+    "$SCRIPT_DIR/validator_list.sh" || true
+}
+
+print_command_preview() {
+    local launcher="deposit.sh"
+    local launcher_detected
+    if launcher_detected=$(find_deposit_launcher 2>/dev/null); then
+        launcher="$launcher_detected"
+    fi
+    local cmd=("$launcher" "$MODE")
+    cmd+=("--num_validators=$NUM_VALIDATORS")
+    cmd+=("--mnemonic_language=$MNEMONIC_LANGUAGE")
+    cmd+=("--chain=$CHAIN")
+    cmd+=("--folder=$FOLDER")
+    if [[ -n "$EXECUTION_ADDRESS" ]]; then
+        cmd+=("--execution_address=$EXECUTION_ADDRESS")
+    fi
+
+    printf "\n"
+    printf "Recommended command template:\n\n"
+    printf "  %s\n\n" "${cmd[*]}"
+    printf "If your installed deposit CLI asks for withdrawal credential type, select\n"
+    printf "the compounding / 0x02 option.\n\n"
+}
+
+find_deposit_launcher() {
+    case "$TOOL" in
+        deposit)
+            if command -v deposit >/dev/null 2>&1; then
+                printf '%s\n' "deposit"
+                return 0
+            fi
+            ;;
+        deposit-sh)
+            if command -v deposit.sh >/dev/null 2>&1; then
+                printf '%s\n' "deposit.sh"
+                return 0
+            fi
+            ;;
+        auto)
+            if command -v deposit >/dev/null 2>&1; then
+                printf '%s\n' "deposit"
+                return 0
+            fi
+            if command -v deposit.sh >/dev/null 2>&1; then
+                printf '%s\n' "deposit.sh"
+                return 0
+            fi
+            ;;
+        *)
+            log_error "Unknown tool selection: $TOOL"
+            return 1
+            ;;
+    esac
+
+    return 1
+}
+
+launch_deposit_tool() {
+    local launcher
+    launcher=$(find_deposit_launcher) || return 1
+
+    local args=()
+    args+=("$MODE")
+    args+=("--num_validators=$NUM_VALIDATORS")
+    args+=("--mnemonic_language=$MNEMONIC_LANGUAGE")
+    args+=("--chain=$CHAIN")
+    args+=("--folder=$FOLDER")
+    if [[ -n "$EXECUTION_ADDRESS" ]]; then
+        args+=("--execution_address=$EXECUTION_ADDRESS")
+    fi
+
+    log_info "Launching local deposit CLI: $launcher $MODE"
+    exec "$launcher" "${args[@]}"
+}
+
+main() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --launch)
+                LAUNCH=true
+                ;;
+            --tool)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --tool" >&2; exit 1; }
+                TOOL="$1"
+                ;;
+            --mode)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --mode" >&2; exit 1; }
+                MODE="$1"
+                ;;
+            --chain)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --chain" >&2; exit 1; }
+                CHAIN="$1"
+                ;;
+            --folder)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --folder" >&2; exit 1; }
+                FOLDER="$1"
+                ;;
+            --num-validators|--num_validators)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --num-validators" >&2; exit 1; }
+                NUM_VALIDATORS="$1"
+                ;;
+            --mnemonic-language|--mnemonic_language)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --mnemonic-language" >&2; exit 1; }
+                MNEMONIC_LANGUAGE="$1"
+                ;;
+            --execution-address|--execution_address|--eth1_withdrawal_address|--eth1-withdrawal-address)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --execution-address" >&2; exit 1; }
+                EXECUTION_ADDRESS="$1"
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                usage >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    show_entry_checklist
+    show_local_inventory
+    print_command_preview
+
+    if [[ "$LAUNCH" != "true" ]]; then
+        log_info "Run again with --launch to open the deposit CLI directly."
+        exit 0
+    fi
+
+    if ! launch_deposit_tool; then
+        log_error "No supported local deposit CLI was found."
+        log_info "Install ethstaker-deposit-cli, then re-run this helper with --launch."
+        exit 1
+    fi
+}
+
+main "$@"

--- a/install/utils/validator_exit.sh
+++ b/install/utils/validator_exit.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Eth2 Quick Start — Validator Exit Helper
+# Focused wrapper for exiting local validators with a checklist for 0x00/0x01
+# operators. Reuses the existing validator listing and exit flow.
+#
+# Usage:
+#   ./install/utils/validator_exit.sh
+#   ./scripts/eth2qs.sh validator-exit
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../" && pwd)"
+
+# shellcheck source=../../lib/common_functions.sh
+source "$ROOT_DIR/lib/common_functions.sh"
+# shellcheck source=../../exports.sh
+if [[ -f "$ROOT_DIR/exports.sh" ]]; then
+    source "$ROOT_DIR/exports.sh" 2>/dev/null || true
+fi
+if [[ -f "$ROOT_DIR/config/user_config.env" ]]; then
+    # shellcheck source=/dev/null
+    source "$ROOT_DIR/config/user_config.env" 2>/dev/null || true
+fi
+
+usage() {
+    cat <<'EOF'
+Usage: ./install/utils/validator_exit.sh
+
+Prints the exit checklist for 0x00/0x01 legacy validators and then hands off
+to the existing interactive exit flow in validator_manage.sh.
+EOF
+}
+
+show_exit_checklist() {
+    cat <<'EOF'
+
+=== Validator Exit Checklist ===
+
+- Confirm the validator you are exiting is one you control.
+- If the validator still uses 0x00 withdrawal credentials, update withdrawal
+  credentials before you expect any funds to become withdrawable.
+- 0x01 validators auto-sweep rewards above 32 ETH after withdrawals are enabled.
+- Keep the validator online until the exit epoch is reached.
+- After the validator becomes withdrawable, the remaining balance is swept to
+  the configured withdrawal address automatically.
+- Do not reuse the same validator key to stake again after the full exit.
+
+EOF
+}
+
+show_local_inventory() {
+    if [[ ! -x "$SCRIPT_DIR/validator_list.sh" ]]; then
+        log_warn "validator_list.sh not found or not executable at $SCRIPT_DIR"
+        return 0
+    fi
+
+    log_info "Current local validators:"
+    "$SCRIPT_DIR/validator_list.sh" || true
+}
+
+main() {
+    case "${1:-}" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        "")
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+
+    show_exit_checklist
+    show_local_inventory
+
+    if [[ ! -x "$SCRIPT_DIR/validator_manage.sh" ]]; then
+        log_error "validator_manage.sh not found or not executable at $SCRIPT_DIR"
+        exit 1
+    fi
+
+    printf "\n"
+    read -rp "Proceed to the interactive exit flow? [y/N] " answer
+    case "$answer" in
+        y|Y|yes|YES)
+            exec "$SCRIPT_DIR/validator_manage.sh" --exit
+            ;;
+        *)
+            log_warn "Exit flow aborted."
+            ;;
+    esac
+}
+
+main "$@"

--- a/install/utils/validator_list.sh
+++ b/install/utils/validator_list.sh
@@ -205,7 +205,7 @@ if not rows:
     print("  The node may still be syncing or no keys are imported yet.")
     sys.exit(0)
 
-hdr = f"{'Index':<12} {'Public Key':<98} {'Status':<22} {'Balance (ETH)':<16} Eff. Balance (ETH)"
+hdr = f"{'Index':<12} {'Public Key':<98} {'Status':<22} {'Balance (ETH)':<16} {'WCred'} Eff. Balance (ETH)"
 print()
 print(hdr)
 print("-" * len(hdr))
@@ -214,8 +214,10 @@ for v in rows:
     pubkey = v.get("validator", {}).get("pubkey", "?")
     status = v.get("status", "?")
     bal    = int(v.get("balance", 0)) / 1e9
+    cred   = v.get("validator", {}).get("withdrawal_credentials", "") or ""
+    wcred  = cred[:4].lower() if cred.startswith("0x") and len(cred) >= 4 else "?"
     eff    = int(v.get("validator", {}).get("effective_balance", 0)) / 1e9
-    print(f"{idx:<12} {pubkey:<98} {status:<22} {bal:<16.6f} {eff:.6f}")
+    print(f"{idx:<12} {pubkey:<98} {status:<22} {bal:<16.6f} {wcred:<8} {eff:.6f}")
 print("-" * len(hdr))
 print(f"  {len(rows)} validator(s)")
 print()

--- a/install/utils/validator_list.sh
+++ b/install/utils/validator_list.sh
@@ -23,6 +23,7 @@ if [[ -f "$ROOT_DIR/config/user_config.env" ]]; then
 fi
 
 JSON_OUTPUT=false
+BEACON_QUERY_STATUS="ok"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --json) JSON_OUTPUT=true ;;
@@ -164,6 +165,7 @@ query_beacon_validators() {
     local pubkeys=("$@")
 
     if [[ ${#pubkeys[@]} -eq 0 ]]; then
+        BEACON_QUERY_STATUS="no_pubkeys"
         echo '{"data":[]}' > "$out_file"
         return
     fi
@@ -173,15 +175,14 @@ query_beacon_validators() {
     ids=$(printf "0x%s," "${pubkeys[@]}")
     ids="${ids%,}"
 
-    local response
-    response=$(curl -sf \
-        --max-time 15 \
-        "${beacon_url}/eth/v1/beacon/states/head/validators?id=${ids}" \
-        2>/dev/null || true)
+    local response curl_rc=0
+    response=$(curl -sS         --max-time 15         "${beacon_url}/eth/v1/beacon/states/head/validators?id=${ids}"         2>/dev/null) || curl_rc=$?
 
-    if [[ -z "$response" ]]; then
+    if [[ $curl_rc -ne 0 || -z "$response" ]]; then
+        BEACON_QUERY_STATUS="failed"
         echo '{"data":[]}' > "$out_file"
     else
+        BEACON_QUERY_STATUS="ok"
         echo "$response" > "$out_file"
     fi
 }
@@ -233,10 +234,13 @@ main() {
     client=$(detect_client)
     local beacon_url
     beacon_url=$(detect_beacon_url)
+    local generated_at_utc
+    generated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
     if [[ "$JSON_OUTPUT" == "false" ]]; then
         log_info "Detected consensus client: ${client}"
         log_info "Beacon API: ${beacon_url}"
+        log_info "Inventory snapshot: ${generated_at_utc}"
         log_info "Scanning for validator keystores..."
     fi
 
@@ -244,7 +248,7 @@ main() {
 
     if [[ ${#pubkeys[@]} -eq 0 ]]; then
         if [[ "$JSON_OUTPUT" == "true" ]]; then
-            echo '{"client":"'"$client"'","beacon_url":"'"$beacon_url"'","validators":[],"error":"no_keystores_found"}'
+            echo '{"client":"'"$client"'","beacon_url":"'"$beacon_url"'","generated_at_utc":"'"$generated_at_utc"'","beacon_query_status":"no_keystores_found","validators":[],"error":"no_keystores_found"}'
         else
             log_warn "No keystore files found for client '${client}'."
             echo "  Import validator keys first, then re-run this command."
@@ -264,17 +268,22 @@ main() {
     query_beacon_validators "$beacon_url" "$tmpfile" "${pubkeys[@]}"
 
     if [[ "$JSON_OUTPUT" == "true" ]]; then
-        python3 - "$tmpfile" "$client" "$beacon_url" <<'PYEOF'
+        python3 - "$tmpfile" "$client" "$beacon_url" "$generated_at_utc" "$BEACON_QUERY_STATUS" <<'PYEOF'
 import json, sys
 with open(sys.argv[1]) as f:
     raw = json.load(f)
 print(json.dumps({
     "client": sys.argv[2],
     "beacon_url": sys.argv[3],
+    "generated_at_utc": sys.argv[4],
+    "beacon_query_status": sys.argv[5],
     "validators": raw.get("data", [])
 }, indent=2))
 PYEOF
     else
+        if [[ "$BEACON_QUERY_STATUS" == "failed" ]]; then
+            log_warn "Beacon query failed; showing only local keystores that matched."
+        fi
         print_table "$tmpfile"
     fi
 }

--- a/install/utils/validator_manage.sh
+++ b/install/utils/validator_manage.sh
@@ -143,7 +143,7 @@ rows = d.get("validators", [])
 if not rows:
     print("  (none)")
     sys.exit(0)
-hdr = f"  {'Index':<10} {'Public Key':<98} {'Status':<22} Balance (ETH)"
+hdr = f"  {'Index':<10} {'Public Key':<98} {'Status':<22} Balance (ETH) {'WCred'}"
 print()
 print(hdr)
 print("  " + "-" * (len(hdr) - 2))
@@ -152,7 +152,9 @@ for v in rows:
     pubkey = v.get("validator", {}).get("pubkey", "?")
     status = v.get("status", "?")
     bal    = int(v.get("balance", 0)) / 1e9
-    print(f"  {idx:<10} {pubkey:<98} {status:<22} {bal:.6f}")
+    cred   = v.get("validator", {}).get("withdrawal_credentials", "") or ""
+    wcred  = cred[:4].lower() if cred.startswith("0x") and len(cred) >= 4 else "?"
+    print(f"  {idx:<10} {pubkey:<98} {status:<22} {bal:.6f} {wcred}")
 print("  " + "-" * (len(hdr) - 2))
 print(f"  {len(rows)} validator(s)\n")
 PYEOF

--- a/install/utils/validator_withdrawal_changes.sh
+++ b/install/utils/validator_withdrawal_changes.sh
@@ -40,6 +40,7 @@ BEACON_URL_OVERRIDE=""
 SELECTED_INDICES=""
 SELECTED_WITHDRAWAL_CREDENTIALS=""
 GENERATED_OUTPUT_DIR=""
+DRY_RUN=false
 
 usage() {
     cat <<'USAGE'
@@ -52,6 +53,7 @@ Options:
   --generate                  Generate BLS-to-execution change JSON files.
   --submit                    Submit generated JSON files to the beacon node.
   --yes                       Skip the final confirmation prompt before submit.
+  --dry-run                   Print the planned actions without writing or submitting.
   --withdrawal-address <addr> Execution address to write into the change message.
   --mnemonic-file <path>      File containing the withdrawal mnemonic.
   --mnemonic-password-file <path>
@@ -116,6 +118,35 @@ with open(output_path, 'w') as fh:
     json.dump(raw, fh, indent=2)
     fh.write('\n')
 PYEOF
+}
+
+list_json_files() {
+    local data_dir="$1"
+    if [[ ! -d "$data_dir" ]]; then
+        return 0
+    fi
+    find "$data_dir" -maxdepth 1 -type f -name '*.json' | sort
+}
+
+format_command() {
+    printf '%q ' "$@"
+    printf '\n'
+}
+
+cleanup_stale_staging_dirs() {
+    if [[ ! -d "$OUT_DIR" ]]; then
+        return 0
+    fi
+
+    local removed=0
+    while IFS= read -r -d '' dir; do
+        rm -rf "$dir"
+        removed=$((removed + 1))
+    done < <(find "$OUT_DIR" -mindepth 1 -maxdepth 1 -type d -name 'run-*' -mtime +7 -print0 2>/dev/null || true)
+
+    if [[ "$removed" -gt 0 ]]; then
+        log_info "Removed $removed stale staging director$( [[ "$removed" -eq 1 ]] && echo 'y' || echo 'ies' )."
+    fi
 }
 
 print_inventory_table() {
@@ -227,6 +258,8 @@ generate_changes() {
         mnemonic_password=$(read_file_or_prompt "Mnemonic password" "$MNEMONIC_PASSWORD_FILE" true) || return 1
     fi
 
+    cleanup_stale_staging_dirs
+
     local target_dir="$OUT_DIR"
     if [[ -d "$OUT_DIR" ]] && find "$OUT_DIR" -maxdepth 1 -type f -name '*.json' -print -quit | grep -q .; then
         target_dir="$(mktemp -d "$OUT_DIR/run-XXXXXX")"
@@ -252,6 +285,57 @@ generate_changes() {
     "$launcher" "${args[@]}"
 }
 
+preview_generation() {
+    local launcher="$1"
+    local target_dir_hint="$2"
+
+    log_info "Dry run: generation is disabled, but the planned command is:"
+    if [[ -n "$launcher" ]]; then
+        format_command "$launcher" \
+            generate-bls-to-execution-change \
+            --bls_to_execution_changes_folder="$target_dir_hint" \
+            --chain="$CHAIN" \
+            --mnemonic="<hidden>" \
+            --validator_indices="$SELECTED_INDICES" \
+            --bls_withdrawal_credentials_list="$SELECTED_WITHDRAWAL_CREDENTIALS" \
+            --execution_address="$WITHDRAWAL_ADDRESS"
+    else
+        log_warn "Deposit CLI not found; install deposit.sh or deposit before generating for real."
+    fi
+}
+
+preview_submission() {
+    local input_dir="$1"
+    local beacon_url="$2"
+
+    if [[ -z "$beacon_url" ]]; then
+        log_warn "Dry run: beacon URL is empty, submission cannot be previewed."
+        return 0
+    fi
+
+    mapfile -t files < <(list_json_files "$input_dir")
+    if [[ ${#files[@]} -eq 0 ]]; then
+        if [[ -n "$SELECTED_INDICES" ]]; then
+            local idx
+            IFS=',' read -r -a idxs <<< "$SELECTED_INDICES"
+            log_info "Dry run: submission would target these generated files:"
+            for idx in "${idxs[@]}"; do
+                [[ -n "$idx" ]] || continue
+                printf '  %s\n' "bls_to_execution_change-${idx}.json"
+            done
+        else
+            log_warn "Dry run: no JSON files are available to submit."
+        fi
+        return 0
+    fi
+
+    log_info "Dry run: submission would POST these files to ${beacon_url}/eth/v1/beacon/pool/bls_to_execution_changes:"
+    local file
+    for file in "${files[@]}"; do
+        printf '  %s\n' "$(basename "$file")"
+    done
+}
+
 submit_changes() {
     local input_dir="$1"
     local beacon_url="$2"
@@ -270,21 +354,46 @@ submit_changes() {
         esac
     fi
 
-    mapfile -t files < <(find "$input_dir" -maxdepth 1 -type f -name '*.json' | sort)
+    mapfile -t files < <(list_json_files "$input_dir")
     if [[ ${#files[@]} -eq 0 ]]; then
         log_error "No JSON files found in $input_dir"
         return 1
     fi
 
+    local submitted=0
+    local failed=0
     local file
     for file in "${files[@]}"; do
         log_info "Submitting $(basename "$file")"
-        curl -sf \
+        local response_file http_code
+        response_file=$(mktemp /tmp/vwc_submit_XXXXXX.response)
+        http_code=$(curl -sS \
             -X POST \
             -H "Content-Type: application/json" \
             --data-binary "@$file" \
-            "$beacon_url/eth/v1/beacon/pool/bls_to_execution_changes"
+            -o "$response_file" \
+            -w '%{http_code}' \
+            "$beacon_url/eth/v1/beacon/pool/bls_to_execution_changes" || true)
+
+        if [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+            submitted=$((submitted + 1))
+            log_info "Accepted $(basename "$file") (HTTP $http_code)"
+        else
+            failed=$((failed + 1))
+            log_error "Beacon rejected $(basename "$file") (HTTP ${http_code:-none})"
+            if [[ -s "$response_file" ]]; then
+                sed 's/^/  /' "$response_file" >&2
+            fi
+        fi
+        rm -f "$response_file"
     done
+
+    if [[ "$failed" -gt 0 ]]; then
+        log_error "Submission summary: $submitted accepted, $failed failed."
+        return 1
+    fi
+
+    log_info "Submission summary: $submitted accepted, 0 failed."
 }
 
 main() {
@@ -300,6 +409,9 @@ main() {
                 ;;
             --submit)
                 SUBMIT=true
+                ;;
+            --dry-run)
+                DRY_RUN=true
                 ;;
             --yes)
                 YES=true
@@ -394,6 +506,13 @@ PYEOF
     log_info "Detected consensus client: ${client}"
     log_info "Beacon API: ${beacon_url}"
     log_info "Credential filter: ${SELECTOR}"
+    log_info "Inventory snapshot: $(python3 - "$selected_file" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    raw = json.load(fh)
+print(raw.get('generated_at_utc', 'unknown'))
+PYEOF
+)"
 
     print_inventory_table "$selected_file"
 
@@ -445,8 +564,40 @@ PYEOF
         log_warn "This helper is intended for 0x00 validators; selection '$SELECTOR' may not require a withdrawal change."
     fi
 
+    if [[ "$DRY_RUN" == true ]]; then
+        local launcher=""
+        if [[ "$GENERATE" == true ]]; then
+            launcher=$(detect_deposit_launcher 2>/dev/null || true)
+        fi
+
+        log_info "Dry run: no files will be written or submitted."
+        log_info "Would affect ${count} validator(s): ${SELECTED_INDICES}"
+
+        if [[ "$GENERATE" == true ]]; then
+            local planned_dir="$OUT_DIR"
+            if [[ -d "$OUT_DIR" ]] && find "$OUT_DIR" -maxdepth 1 -type f -name '*.json' -print -quit | grep -q .; then
+                log_info "Would stage into a fresh run-* directory under $OUT_DIR because JSON files already exist there."
+            else
+                log_info "Would stage into $planned_dir."
+            fi
+            preview_generation "$launcher" "$planned_dir"
+        fi
+
+        if [[ "$SUBMIT" == true ]]; then
+            preview_submission "${GENERATED_OUTPUT_DIR:-$OUT_DIR}" "$beacon_url"
+        fi
+        return 0
+    fi
+
     if [[ "$GENERATE" == true ]]; then
         generate_changes
+        local generated_count
+        generated_count=$(list_json_files "${GENERATED_OUTPUT_DIR:-$OUT_DIR}" | wc -l | tr -d ' ')
+        if [[ "$generated_count" -eq 0 ]]; then
+            log_error "Generation completed but no JSON files were produced."
+            return 1
+        fi
+        log_info "Generated $generated_count JSON file(s) in ${GENERATED_OUTPUT_DIR:-$OUT_DIR}"
     fi
 
     if [[ "$SUBMIT" == true ]]; then

--- a/install/utils/validator_withdrawal_changes.sh
+++ b/install/utils/validator_withdrawal_changes.sh
@@ -1,0 +1,457 @@
+#!/bin/bash
+
+# Eth2 Quick Start — Validator Withdrawal Credential Changes
+# Generates and optionally submits BLS-to-execution change messages for
+# validators that still use 0x00 withdrawal credentials.
+#
+# Usage:
+#   ./install/utils/validator_withdrawal_changes.sh
+#   ./install/utils/validator_withdrawal_changes.sh --generate --submit --yes
+#   ./scripts/eth2qs.sh validator-withdrawal-changes --generate --submit
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../" && pwd)"
+
+# shellcheck source=../../lib/common_functions.sh
+source "$ROOT_DIR/lib/common_functions.sh"
+# shellcheck source=../../exports.sh
+if [[ -f "$ROOT_DIR/exports.sh" ]]; then
+    source "$ROOT_DIR/exports.sh" 2>/dev/null || true
+fi
+if [[ -f "$ROOT_DIR/config/user_config.env" ]]; then
+    # shellcheck source=/dev/null
+    source "$ROOT_DIR/config/user_config.env" 2>/dev/null || true
+fi
+
+SELECTOR="0x00"
+CHAIN="mainnet"
+OUT_DIR="$ROOT_DIR/validator_withdrawal_changes"
+WITHDRAWAL_ADDRESS=""
+VALIDATORS_JSON_FILE=""
+MNEMONIC_FILE=""
+MNEMONIC_PASSWORD_FILE=""
+DEPOSIT_TOOL="auto"
+YES=false
+GENERATE=false
+SUBMIT=false
+BEACON_URL_OVERRIDE=""
+SELECTED_INDICES=""
+SELECTED_WITHDRAWAL_CREDENTIALS=""
+GENERATED_OUTPUT_DIR=""
+
+usage() {
+    cat <<'USAGE'
+Usage: ./install/utils/validator_withdrawal_changes.sh [options]
+
+Options:
+  --credential-type <0x00|0x01|0x02|all>
+                              Filter the local inventory before taking action.
+                              Default: 0x00.
+  --generate                  Generate BLS-to-execution change JSON files.
+  --submit                    Submit generated JSON files to the beacon node.
+  --yes                       Skip the final confirmation prompt before submit.
+  --withdrawal-address <addr> Execution address to write into the change message.
+  --mnemonic-file <path>      File containing the withdrawal mnemonic.
+  --mnemonic-password-file <path>
+                              File containing the mnemonic password (optional).
+  --validators-json <path>    Use a fixture or captured validator_list --json output.
+  --beacon-url <url>          Override the beacon REST API base URL.
+  --chain <name>              Signing chain for the deposit CLI (default: mainnet).
+  --out-dir <path>            Folder to write generated messages (default: validator_withdrawal_changes/).
+  --deposit-tool <auto|deposit|deposit-sh>
+                              Select the local deposit CLI launcher.
+  --help                      Show this help.
+
+This helper focuses on BLS-to-execution changes for 0x00 validators.
+It shows the local validator inventory, filters by withdrawal credential type,
+generates signed change messages with the deposit CLI, and can submit them
+to the local beacon node REST API.
+USAGE
+}
+
+load_inventory_json() {
+    if [[ -n "$VALIDATORS_JSON_FILE" ]]; then
+        cat "$VALIDATORS_JSON_FILE"
+        return
+    fi
+    if [[ ! -x "$SCRIPT_DIR/validator_list.sh" ]]; then
+        log_error "validator_list.sh not found or not executable at $SCRIPT_DIR"
+        return 1
+    fi
+    "$SCRIPT_DIR/validator_list.sh" --json
+}
+
+filter_inventory_json() {
+    local input_file="$1"
+    local output_file="$2"
+    local selector="$3"
+
+    python3 - "$input_file" "$output_file" "$selector" <<'PYEOF'
+import json, sys
+
+input_path, output_path, selector = sys.argv[1:4]
+with open(input_path) as fh:
+    raw = json.load(fh)
+
+validators = raw.get('validators', [])
+selected = []
+selector = selector.lower()
+allowed = {s.strip().lower() for s in selector.split(',') if s.strip()}
+if not allowed:
+    allowed = {'all'}
+
+for item in validators:
+    cred = item.get('validator', {}).get('withdrawal_credentials', '') or ''
+    cred_type = cred[:4].lower() if cred.startswith('0x') and len(cred) >= 4 else 'unknown'
+    if 'all' not in allowed and cred_type not in allowed:
+        continue
+    row = dict(item)
+    row['withdrawal_credential_type'] = cred_type
+    selected.append(row)
+
+raw['validators'] = selected
+with open(output_path, 'w') as fh:
+    json.dump(raw, fh, indent=2)
+    fh.write('\n')
+PYEOF
+}
+
+print_inventory_table() {
+    local data_file="$1"
+    python3 - "$data_file" <<'PYEOF'
+import json, sys
+
+with open(sys.argv[1]) as fh:
+    raw = json.load(fh)
+
+rows = raw.get('validators', [])
+if not rows:
+    print('  No matching validators found.')
+    sys.exit(0)
+
+hdr = f"{'Index':<12} {'Public Key':<98} {'Status':<22} {'Balance (ETH)':<16} {'WCred'}"
+print()
+print(hdr)
+print('-' * len(hdr))
+for v in rows:
+    idx = v.get('index', '?')
+    pubkey = v.get('validator', {}).get('pubkey', '?')
+    status = v.get('status', '?')
+    bal = int(v.get('balance', 0)) / 1e9
+    cred = v.get('validator', {}).get('withdrawal_credentials', '') or ''
+    cred_type = cred[:4].lower() if cred.startswith('0x') and len(cred) >= 4 else v.get('withdrawal_credential_type', 'unknown')
+    print(f"{idx:<12} {pubkey:<98} {status:<22} {bal:<16.6f} {cred_type}")
+print('-' * len(hdr))
+print(f"  {len(rows)} validator(s)")
+print()
+PYEOF
+}
+
+detect_deposit_launcher() {
+    case "$DEPOSIT_TOOL" in
+        deposit)
+            if command -v deposit >/dev/null 2>&1; then
+                printf '%s\n' deposit
+                return 0
+            fi
+            ;;
+        deposit-sh)
+            if command -v deposit.sh >/dev/null 2>&1; then
+                printf '%s\n' deposit.sh
+                return 0
+            fi
+            ;;
+        auto)
+            if command -v deposit.sh >/dev/null 2>&1; then
+                printf '%s\n' deposit.sh
+                return 0
+            fi
+            if command -v deposit >/dev/null 2>&1; then
+                printf '%s\n' deposit
+                return 0
+            fi
+            ;;
+        *)
+            log_error "Unknown deposit tool selection: $DEPOSIT_TOOL"
+            return 1
+            ;;
+    esac
+
+    return 1
+}
+
+read_file_or_prompt() {
+    local label="$1"
+    local path="$2"
+    local prompt_hidden="${3:-false}"
+    local value=""
+
+    if [[ -n "$path" ]]; then
+        if [[ ! -f "$path" ]]; then
+            log_error "$label file not found: $path"
+            return 1
+        fi
+        value="$(tr -d '\n' < "$path")"
+    else
+        if [[ "$prompt_hidden" == "true" ]]; then
+            read -rsp "  $label: " value
+            printf '\n'
+        else
+            read -rp "  $label: " value
+        fi
+    fi
+
+    if [[ -z "$value" ]]; then
+        log_error "$label is required."
+        return 1
+    fi
+
+    printf '%s\n' "$value"
+}
+
+generate_changes() {
+    local launcher
+    launcher=$(detect_deposit_launcher) || return 1
+
+    if [[ -z "$WITHDRAWAL_ADDRESS" ]]; then
+        log_error "--withdrawal-address is required when generating BLS-to-execution changes."
+        return 1
+    fi
+
+    local mnemonic
+    mnemonic=$(read_file_or_prompt "Withdrawal mnemonic" "$MNEMONIC_FILE" true) || return 1
+    local mnemonic_password=""
+    if [[ -n "$MNEMONIC_PASSWORD_FILE" ]]; then
+        mnemonic_password=$(read_file_or_prompt "Mnemonic password" "$MNEMONIC_PASSWORD_FILE" true) || return 1
+    fi
+
+    local target_dir="$OUT_DIR"
+    if [[ -d "$OUT_DIR" ]] && find "$OUT_DIR" -maxdepth 1 -type f -name '*.json' -print -quit | grep -q .; then
+        target_dir="$(mktemp -d "$OUT_DIR/run-XXXXXX")"
+        log_info "Using fresh staging directory: $target_dir"
+    fi
+    mkdir -p "$target_dir"
+    GENERATED_OUTPUT_DIR="$target_dir"
+
+    local args=(
+        generate-bls-to-execution-change
+        --bls_to_execution_changes_folder="$target_dir"
+        --chain="$CHAIN"
+        --mnemonic="$mnemonic"
+        --validator_indices="$SELECTED_INDICES"
+        --bls_withdrawal_credentials_list="$SELECTED_WITHDRAWAL_CREDENTIALS"
+        --execution_address="$WITHDRAWAL_ADDRESS"
+    )
+    if [[ -n "$mnemonic_password" ]]; then
+        args+=(--mnemonic_password="$mnemonic_password")
+    fi
+
+    log_info "Generating BLS-to-execution changes with $launcher"
+    "$launcher" "${args[@]}"
+}
+
+submit_changes() {
+    local input_dir="$1"
+    local beacon_url="$2"
+
+    if [[ -z "$beacon_url" ]]; then
+        log_error "Beacon URL is required to submit changes."
+        return 1
+    fi
+
+    if [[ "$YES" != true ]]; then
+        printf '\n'
+        read -rp "  Submit generated BLS-to-execution changes to $beacon_url? [y/N] " answer
+        case "$answer" in
+            y|Y|yes|YES) ;;
+            *) log_warn "Submission aborted."; return 0 ;;
+        esac
+    fi
+
+    mapfile -t files < <(find "$input_dir" -maxdepth 1 -type f -name '*.json' | sort)
+    if [[ ${#files[@]} -eq 0 ]]; then
+        log_error "No JSON files found in $input_dir"
+        return 1
+    fi
+
+    local file
+    for file in "${files[@]}"; do
+        log_info "Submitting $(basename "$file")"
+        curl -sf \
+            -X POST \
+            -H "Content-Type: application/json" \
+            --data-binary "@$file" \
+            "$beacon_url/eth/v1/beacon/pool/bls_to_execution_changes"
+    done
+}
+
+main() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --credential-type|--select)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --credential-type" >&2; exit 1; }
+                SELECTOR="$1"
+                ;;
+            --generate)
+                GENERATE=true
+                ;;
+            --submit)
+                SUBMIT=true
+                ;;
+            --yes)
+                YES=true
+                ;;
+            --withdrawal-address|--execution-address|--eth1-withdrawal-address)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --withdrawal-address" >&2; exit 1; }
+                WITHDRAWAL_ADDRESS="$1"
+                ;;
+            --mnemonic-file)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --mnemonic-file" >&2; exit 1; }
+                MNEMONIC_FILE="$1"
+                ;;
+            --mnemonic-password-file)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --mnemonic-password-file" >&2; exit 1; }
+                MNEMONIC_PASSWORD_FILE="$1"
+                ;;
+            --validators-json)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --validators-json" >&2; exit 1; }
+                VALIDATORS_JSON_FILE="$1"
+                ;;
+            --beacon-url)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --beacon-url" >&2; exit 1; }
+                BEACON_URL_OVERRIDE="$1"
+                ;;
+            --chain)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --chain" >&2; exit 1; }
+                CHAIN="$1"
+                ;;
+            --out-dir)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --out-dir" >&2; exit 1; }
+                OUT_DIR="$1"
+                ;;
+            --deposit-tool)
+                shift
+                [[ $# -gt 0 ]] || { echo "Missing value for --deposit-tool" >&2; exit 1; }
+                DEPOSIT_TOOL="$1"
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                usage >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    local inventory_file
+    inventory_file=$(mktemp /tmp/vwc_inventory_XXXXXX.json)
+    local selected_file
+    selected_file=$(mktemp /tmp/vwc_selected_XXXXXX.json)
+    # shellcheck disable=SC2064
+    trap "rm -f '$inventory_file' '$selected_file'" EXIT
+
+    if ! load_inventory_json > "$inventory_file"; then
+        log_error "Unable to load local validator inventory."
+        return 1
+    fi
+
+    filter_inventory_json "$inventory_file" "$selected_file" "$SELECTOR"
+
+    local client
+    client=$(python3 - "$selected_file" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    raw = json.load(fh)
+print(raw.get('client', 'unknown'))
+PYEOF
+)
+    local beacon_url
+    beacon_url=$(python3 - "$selected_file" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    raw = json.load(fh)
+print(raw.get('beacon_url', ''))
+PYEOF
+)
+    if [[ -n "$BEACON_URL_OVERRIDE" ]]; then
+        beacon_url="$BEACON_URL_OVERRIDE"
+    fi
+
+    log_info "Detected consensus client: ${client}"
+    log_info "Beacon API: ${beacon_url}"
+    log_info "Credential filter: ${SELECTOR}"
+
+    print_inventory_table "$selected_file"
+
+    local count
+    count=$(python3 - "$selected_file" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    raw = json.load(fh)
+print(len(raw.get('validators', [])))
+PYEOF
+)
+    if [[ "$count" -eq 0 ]]; then
+        log_warn "No validators matched credential filter '$SELECTOR'."
+        return 0
+    fi
+
+    local indices
+    indices=$(python3 - "$selected_file" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    raw = json.load(fh)
+vals = raw.get('validators', [])
+print(','.join(str(v.get('index')) for v in vals if str(v.get('index')) not in ('', 'None')))
+PYEOF
+)
+    local credentials
+    credentials=$(python3 - "$selected_file" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as fh:
+    raw = json.load(fh)
+vals = raw.get('validators', [])
+creds = []
+for v in vals:
+    cred = v.get('validator', {}).get('withdrawal_credentials', '') or ''
+    if cred:
+        creds.append(cred)
+print(','.join(creds))
+PYEOF
+)
+    SELECTED_INDICES="$indices"
+    SELECTED_WITHDRAWAL_CREDENTIALS="$credentials"
+
+    if [[ "$GENERATE" != true && "$SUBMIT" != true ]]; then
+        log_info "Run again with --generate to create signed messages or --submit to POST existing JSON files."
+        return 0
+    fi
+
+    if [[ "$SELECTOR" != "all" && "$SELECTOR" != "0x00" ]]; then
+        log_warn "This helper is intended for 0x00 validators; selection '$SELECTOR' may not require a withdrawal change."
+    fi
+
+    if [[ "$GENERATE" == true ]]; then
+        generate_changes
+    fi
+
+    if [[ "$SUBMIT" == true ]]; then
+        submit_changes "${GENERATED_OUTPUT_DIR:-$OUT_DIR}" "$beacon_url"
+    fi
+}
+
+main "$@"

--- a/scripts/eth2qs.sh
+++ b/scripts/eth2qs.sh
@@ -43,6 +43,7 @@ Validator:
   validator-exit                   Exit local validators using the managed exit flow
   validator-create-0x02            Create modern compounding validators with 0x02 credentials
   validator-manage [--exit|--consolidate]   Manage validators: voluntary exits or EIP-7251 consolidations
+  validator-withdrawal-changes      Generate or submit BLS-to-execution changes for 0x00 validators
 
 Utility:
   help                    Show this help text
@@ -69,6 +70,7 @@ Examples:
   ./scripts/eth2qs.sh validator-manage
   ./scripts/eth2qs.sh validator-manage --exit
   ./scripts/eth2qs.sh validator-manage --consolidate
+  ./scripts/eth2qs.sh validator-withdrawal-changes --generate --submit --yes
 EOF
 }
 
@@ -167,6 +169,9 @@ case "$cmd" in
         ;;
     validator-manage)
         run_cmd "$ROOT_DIR/install/utils/validator_manage.sh" "$@"
+        ;;
+    validator-withdrawal-changes)
+        run_cmd "$ROOT_DIR/install/utils/validator_withdrawal_changes.sh" "$@"
         ;;
     *)
         echo "Unknown command: $cmd" >&2

--- a/scripts/eth2qs.sh
+++ b/scripts/eth2qs.sh
@@ -40,6 +40,8 @@ Operations:
 
 Validator:
   validators [--json]               List active validators with index, status, and balance
+  validator-exit                   Exit local validators using the managed exit flow
+  validator-create-0x02            Create modern compounding validators with 0x02 credentials
   validator-manage [--exit|--consolidate]   Manage validators: voluntary exits or EIP-7251 consolidations
 
 Utility:
@@ -62,6 +64,8 @@ Examples:
   sudo ./scripts/eth2qs.sh cleanup-host --dry-run
   ./scripts/eth2qs.sh validators
   ./scripts/eth2qs.sh validators --json
+  ./scripts/eth2qs.sh validator-exit
+  ./scripts/eth2qs.sh validator-create-0x02
   ./scripts/eth2qs.sh validator-manage
   ./scripts/eth2qs.sh validator-manage --exit
   ./scripts/eth2qs.sh validator-manage --consolidate
@@ -154,6 +158,12 @@ case "$cmd" in
         ;;
     validators)
         run_cmd "$ROOT_DIR/install/utils/validator_list.sh" "$@"
+        ;;
+    validator-exit)
+        run_cmd "$ROOT_DIR/install/utils/validator_exit.sh" "$@"
+        ;;
+    validator-create-0x02)
+        run_cmd "$ROOT_DIR/install/utils/validator_create_0x02.sh" "$@"
         ;;
     validator-manage)
         run_cmd "$ROOT_DIR/install/utils/validator_manage.sh" "$@"

--- a/skills/eth2-quickstart/SKILL.md
+++ b/skills/eth2-quickstart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eth2-quickstart
-description: Use this skill whenever the task involves an Ethereum validator node — setting up a node, installing Geth/Besu/Nethermind/Reth or Prysm/Lighthouse/Teku/other clients, configuring MEV-Boost or Commit-Boost, checking node health, listing active validators, managing validator exits or 0x02 compounding creation, operating services, cleaning node data, or updating clients. Routes all actions through `./scripts/eth2qs.sh` with strict safety guardrails. If in doubt about an Ethereum node task, trigger this skill.
+description: Use this skill whenever the task involves an Ethereum validator node — setting up a node, installing Geth/Besu/Nethermind/Reth or Prysm/Lighthouse/Teku/other clients, configuring MEV-Boost or Commit-Boost, checking node health, listing active validators, managing validator exits, BLS-to-execution withdrawal changes, or 0x02 compounding creation, operating services, cleaning node data, or updating clients. Routes all actions through `./scripts/eth2qs.sh` with strict safety guardrails. If in doubt about an Ethereum node task, trigger this skill.
 metadata:
   openclaw:
     skillKey: eth2-quickstart
@@ -16,7 +16,7 @@ Use this skill for Ethereum node workflows inside an `eth2-quickstart` checkout.
 - Install/bootstrap: use `./scripts/eth2qs.sh bootstrap ...`. Read [workflow.md](references/workflow.md).
 - Configure or rerun phases: use `./scripts/eth2qs.sh configure`, `phase1`, `phase2`, or `monad-install`. Read [workflow.md](references/workflow.md).
 - Diagnose or inspect status: use `./scripts/eth2qs.sh doctor --json` for health gates, `./scripts/eth2qs.sh stats --json` for machine-readable triage, `./scripts/eth2qs.sh debug --json --service <name>` for structured RCA, `./scripts/eth2qs.sh update-check --json` for freshness/drift, and `./scripts/eth2qs.sh repair` for bounded repair preview/apply. Read [outputs.md](references/outputs.md).
-- For validator lifecycle operations, use `./scripts/eth2qs.sh validators --json` to list active validators and `./scripts/eth2qs.sh validator-exit`, `./scripts/eth2qs.sh validator-create-0x02`, or `./scripts/eth2qs.sh validator-manage` for focused exit / compounding / consolidation flows. Read [commands.md](references/commands.md) and [operator.md](references/operator.md).
+- For validator lifecycle operations, use `./scripts/eth2qs.sh validators --json` to list active validators and `./scripts/eth2qs.sh validator-exit`, `./scripts/eth2qs.sh validator-withdrawal-changes`, `./scripts/eth2qs.sh validator-create-0x02`, or `./scripts/eth2qs.sh validator-manage` for focused exit / withdrawal-change / compounding / consolidation flows. Read [commands.md](references/commands.md) and [operator.md](references/operator.md).
 - Operate services, logs, cleanup, or updates: use the mapped commands in [commands.md](references/commands.md).
 - Before destructive or privilege-sensitive actions, load [safety.md](references/safety.md).
 - For server recommendation or host-fit questions, read [sizing.md](references/sizing.md).
@@ -32,7 +32,7 @@ Use this skill for Ethereum node workflows inside an `eth2-quickstart` checkout.
 - Do not remove secrets.
 - Require human confirmation before destructive cleanup, host-wide changes, or steps that require reboot/root.
 - Treat `doctor --json` as the canonical health gate, `stats --json` as the canonical machine-readable triage surface, and `monitor export --json` as the canonical compact alert/dashboard surface.
-- Treat `validators --json` as the canonical read-only validator inventory surface; use it to inspect local validator index/status/balance before taking exit or compounding actions.
+- Treat `validators --json` as the canonical read-only validator inventory surface; use it to inspect local validator index/status/balance before taking exit, withdrawal-change, or compounding actions.
 
 ## References
 

--- a/skills/eth2-quickstart/SKILL.md
+++ b/skills/eth2-quickstart/SKILL.md
@@ -16,7 +16,7 @@ Use this skill for Ethereum node workflows inside an `eth2-quickstart` checkout.
 - Install/bootstrap: use `./scripts/eth2qs.sh bootstrap ...`. Read [workflow.md](references/workflow.md).
 - Configure or rerun phases: use `./scripts/eth2qs.sh configure`, `phase1`, `phase2`, or `monad-install`. Read [workflow.md](references/workflow.md).
 - Diagnose or inspect status: use `./scripts/eth2qs.sh doctor --json` for health gates, `./scripts/eth2qs.sh stats --json` for machine-readable triage, `./scripts/eth2qs.sh debug --json --service <name>` for structured RCA, `./scripts/eth2qs.sh update-check --json` for freshness/drift, and `./scripts/eth2qs.sh repair` for bounded repair preview/apply. Read [outputs.md](references/outputs.md).
-- For validator lifecycle operations, use `./scripts/eth2qs.sh validators --json` to list active validators and `./scripts/eth2qs.sh validator-exit`, `./scripts/eth2qs.sh validator-withdrawal-changes`, `./scripts/eth2qs.sh validator-create-0x02`, or `./scripts/eth2qs.sh validator-manage` for focused exit / withdrawal-change / compounding / consolidation flows. Read [commands.md](references/commands.md) and [operator.md](references/operator.md).
+- For validator lifecycle operations, use `./scripts/eth2qs.sh validators --json` to list active validators and `./scripts/eth2qs.sh validator-exit`, `./scripts/eth2qs.sh validator-withdrawal-changes`, `./scripts/eth2qs.sh validator-create-0x02`, or `./scripts/eth2qs.sh validator-manage` for focused exit / withdrawal-change / compounding / consolidation flows. Rehearse withdrawal changes with `./scripts/eth2qs.sh validator-withdrawal-changes --dry-run --generate --submit --yes` before touching live keys. Read [commands.md](references/commands.md) and [operator.md](references/operator.md).
 - Operate services, logs, cleanup, or updates: use the mapped commands in [commands.md](references/commands.md).
 - Before destructive or privilege-sensitive actions, load [safety.md](references/safety.md).
 - For server recommendation or host-fit questions, read [sizing.md](references/sizing.md).
@@ -32,7 +32,7 @@ Use this skill for Ethereum node workflows inside an `eth2-quickstart` checkout.
 - Do not remove secrets.
 - Require human confirmation before destructive cleanup, host-wide changes, or steps that require reboot/root.
 - Treat `doctor --json` as the canonical health gate, `stats --json` as the canonical machine-readable triage surface, and `monitor export --json` as the canonical compact alert/dashboard surface.
-- Treat `validators --json` as the canonical read-only validator inventory surface; use it to inspect local validator index/status/balance before taking exit, withdrawal-change, or compounding actions.
+- Treat `validators --json` as the canonical read-only validator inventory surface; use it to inspect local validator index/status/balance before taking exit, withdrawal-change, or compounding actions. The JSON output also carries inventory freshness metadata and beacon query status.
 
 ## References
 

--- a/skills/eth2-quickstart/SKILL.md
+++ b/skills/eth2-quickstart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eth2-quickstart
-description: Use this skill whenever the task involves an Ethereum validator node — setting up a node, installing Geth/Besu/Nethermind/Reth or Prysm/Lighthouse/Teku/other clients, configuring MEV-Boost or Commit-Boost, checking node health, operating services, cleaning node data, or updating clients. Routes all actions through `./scripts/eth2qs.sh` with strict safety guardrails. If in doubt about an Ethereum node task, trigger this skill.
+description: Use this skill whenever the task involves an Ethereum validator node — setting up a node, installing Geth/Besu/Nethermind/Reth or Prysm/Lighthouse/Teku/other clients, configuring MEV-Boost or Commit-Boost, checking node health, listing active validators, managing validator exits or 0x02 compounding creation, operating services, cleaning node data, or updating clients. Routes all actions through `./scripts/eth2qs.sh` with strict safety guardrails. If in doubt about an Ethereum node task, trigger this skill.
 metadata:
   openclaw:
     skillKey: eth2-quickstart
@@ -16,6 +16,7 @@ Use this skill for Ethereum node workflows inside an `eth2-quickstart` checkout.
 - Install/bootstrap: use `./scripts/eth2qs.sh bootstrap ...`. Read [workflow.md](references/workflow.md).
 - Configure or rerun phases: use `./scripts/eth2qs.sh configure`, `phase1`, `phase2`, or `monad-install`. Read [workflow.md](references/workflow.md).
 - Diagnose or inspect status: use `./scripts/eth2qs.sh doctor --json` for health gates, `./scripts/eth2qs.sh stats --json` for machine-readable triage, `./scripts/eth2qs.sh debug --json --service <name>` for structured RCA, `./scripts/eth2qs.sh update-check --json` for freshness/drift, and `./scripts/eth2qs.sh repair` for bounded repair preview/apply. Read [outputs.md](references/outputs.md).
+- For validator lifecycle operations, use `./scripts/eth2qs.sh validators --json` to list active validators and `./scripts/eth2qs.sh validator-exit`, `./scripts/eth2qs.sh validator-create-0x02`, or `./scripts/eth2qs.sh validator-manage` for focused exit / compounding / consolidation flows. Read [commands.md](references/commands.md) and [operator.md](references/operator.md).
 - Operate services, logs, cleanup, or updates: use the mapped commands in [commands.md](references/commands.md).
 - Before destructive or privilege-sensitive actions, load [safety.md](references/safety.md).
 - For server recommendation or host-fit questions, read [sizing.md](references/sizing.md).
@@ -31,6 +32,7 @@ Use this skill for Ethereum node workflows inside an `eth2-quickstart` checkout.
 - Do not remove secrets.
 - Require human confirmation before destructive cleanup, host-wide changes, or steps that require reboot/root.
 - Treat `doctor --json` as the canonical health gate, `stats --json` as the canonical machine-readable triage surface, and `monitor export --json` as the canonical compact alert/dashboard surface.
+- Treat `validators --json` as the canonical read-only validator inventory surface; use it to inspect local validator index/status/balance before taking exit or compounding actions.
 
 ## References
 

--- a/skills/eth2-quickstart/references/commands.md
+++ b/skills/eth2-quickstart/references/commands.md
@@ -10,6 +10,10 @@ Canonical command surface:
 - Run Phase 1 hardening: `sudo ./scripts/eth2qs.sh phase1`
 - Run Phase 2 install: `./scripts/eth2qs.sh phase2 --execution=geth --consensus=prysm --mev=mev-boost`
 - Run explicit Monad install: `./scripts/eth2qs.sh monad-install`
+- List active validators on the current node: `./scripts/eth2qs.sh validators --json`
+- Focused exit checklist / client-specific voluntary exit flow: `./scripts/eth2qs.sh validator-exit`
+- Focused 0x02 compounding validator creation flow: `./scripts/eth2qs.sh validator-create-0x02`
+- Combined validator menu for exits and consolidations: `./scripts/eth2qs.sh validator-manage`
 - Health/status: `./scripts/eth2qs.sh doctor --json`
 - Monitoring/triage: `./scripts/eth2qs.sh stats --json`
 - Structured service debug: `./scripts/eth2qs.sh debug --json --service cl`

--- a/skills/eth2-quickstart/references/commands.md
+++ b/skills/eth2-quickstart/references/commands.md
@@ -11,8 +11,9 @@ Canonical command surface:
 - Run Phase 2 install: `./scripts/eth2qs.sh phase2 --execution=geth --consensus=prysm --mev=mev-boost`
 - Run explicit Monad install: `./scripts/eth2qs.sh monad-install`
 - List active validators on the current node: `./scripts/eth2qs.sh validators --json`
+- Show validator inventory freshness and withdrawal status in the JSON output: `./scripts/eth2qs.sh validators --json`
 - Focused exit checklist / client-specific voluntary exit flow: `./scripts/eth2qs.sh validator-exit`
-- Generate or submit BLS-to-execution changes for 0x00 validators: `./scripts/eth2qs.sh validator-withdrawal-changes --generate --submit --yes`
+- Preview, generate, or submit BLS-to-execution changes for 0x00 validators: `./scripts/eth2qs.sh validator-withdrawal-changes --dry-run --generate --submit --yes`
 - Focused 0x02 compounding validator creation flow: `./scripts/eth2qs.sh validator-create-0x02`
 - Combined validator menu for exits and consolidations: `./scripts/eth2qs.sh validator-manage`
 - Health/status: `./scripts/eth2qs.sh doctor --json`

--- a/skills/eth2-quickstart/references/commands.md
+++ b/skills/eth2-quickstart/references/commands.md
@@ -12,6 +12,7 @@ Canonical command surface:
 - Run explicit Monad install: `./scripts/eth2qs.sh monad-install`
 - List active validators on the current node: `./scripts/eth2qs.sh validators --json`
 - Focused exit checklist / client-specific voluntary exit flow: `./scripts/eth2qs.sh validator-exit`
+- Generate or submit BLS-to-execution changes for 0x00 validators: `./scripts/eth2qs.sh validator-withdrawal-changes --generate --submit --yes`
 - Focused 0x02 compounding validator creation flow: `./scripts/eth2qs.sh validator-create-0x02`
 - Combined validator menu for exits and consolidations: `./scripts/eth2qs.sh validator-manage`
 - Health/status: `./scripts/eth2qs.sh doctor --json`

--- a/skills/eth2-quickstart/references/improvement.md
+++ b/skills/eth2-quickstart/references/improvement.md
@@ -26,6 +26,7 @@ Use this when the agent needs to improve its future performance in this repo wit
 - Local end-to-end validation for validator flow changes should include a real execution/consensus pair when available; the validated combo for this branch was Geth + Prysm via `./test/run_e2e.sh --phase=2`.
 - BLS-to-execution change workflows should surface withdrawal credential type in the validator inventory, then use the official deposit CLI to generate signed messages and the beacon REST API to submit them.
 - For production-key safety, rehearse the withdrawal-change flow with a fixture-backed `--validators-json` file and stubbed deposit/curl commands before touching live keys.
+- Withdrawal-change helpers should support `--dry-run`, stage-by-stage preview output, and a live Prysm + geth smoke test in the phase-2 container so agents can validate the exact operator path before production.
 
 ## Rules
 

--- a/skills/eth2-quickstart/references/improvement.md
+++ b/skills/eth2-quickstart/references/improvement.md
@@ -19,6 +19,12 @@ Use this when the agent needs to improve its future performance in this repo wit
    - add or tighten tests when behavior changed
    - update the skill references only if the operator contract changed
 
+## Durable learnings observed in this repo
+
+- Validator lifecycle work should expose a read-only inventory command first, then branch into focused exit or compounding flows. The current surface is `./scripts/eth2qs.sh validators --json`, `validator-exit`, `validator-create-0x02`, and `validator-manage`.
+- New `install/utils` validator helpers should reuse the local inventory path, keep offline command templates useful when client tooling is absent, and document the wrapper commands in both the skill and `docs/SCRIPTS.md`.
+- Local end-to-end validation for validator flow changes should include a real execution/consensus pair when available; the validated combo for this branch was Geth + Prysm via `./test/run_e2e.sh --phase=2`.
+
 ## Rules
 
 - Do not treat host-specific observations as universal repo truths.

--- a/skills/eth2-quickstart/references/improvement.md
+++ b/skills/eth2-quickstart/references/improvement.md
@@ -21,9 +21,11 @@ Use this when the agent needs to improve its future performance in this repo wit
 
 ## Durable learnings observed in this repo
 
-- Validator lifecycle work should expose a read-only inventory command first, then branch into focused exit or compounding flows. The current surface is `./scripts/eth2qs.sh validators --json`, `validator-exit`, `validator-create-0x02`, and `validator-manage`.
+- Validator lifecycle work should expose a read-only inventory command first, then branch into focused exit or compounding flows. The current surface is `./scripts/eth2qs.sh validators --json`, `validator-exit`, `validator-create-0x02`, `validator-withdrawal-changes`, and `validator-manage`.
 - New `install/utils` validator helpers should reuse the local inventory path, keep offline command templates useful when client tooling is absent, and document the wrapper commands in both the skill and `docs/SCRIPTS.md`.
 - Local end-to-end validation for validator flow changes should include a real execution/consensus pair when available; the validated combo for this branch was Geth + Prysm via `./test/run_e2e.sh --phase=2`.
+- BLS-to-execution change workflows should surface withdrawal credential type in the validator inventory, then use the official deposit CLI to generate signed messages and the beacon REST API to submit them.
+- For production-key safety, rehearse the withdrawal-change flow with a fixture-backed `--validators-json` file and stubbed deposit/curl commands before touching live keys.
 
 ## Rules
 

--- a/test/ci_test_e2e.sh
+++ b/test/ci_test_e2e.sh
@@ -249,6 +249,17 @@ if [[ "$PHASE" == "2" ]]; then
         _verify_service_active "validator" 60
     fi
 
+    if [[ "$E2E_EXEC" == "geth" && "$E2E_CONS" == "prysm" ]]; then
+        log_header "Running validator withdrawal change helper smoke test"
+        if bash "$PROJECT_ROOT/install/test/test_validator_withdrawal_changes.sh"; then
+            record_test "validator withdrawal change helper smoke" "PASS"
+        else
+            record_test "validator withdrawal change helper smoke" "FAIL"
+            print_test_summary
+            exit 1
+        fi
+    fi
+
     # Optional live Prysm checkpoint-sync smoke (opt-in).
     if [[ "$E2E_CONS" == "prysm" && "${E2E_PRYSM_CHECKPOINT_SMOKE:-false}" == "true" ]]; then
         log_header "Running Prysm checkpoint-sync smoke test"

--- a/test/ci_test_run_2.sh
+++ b/test/ci_test_run_2.sh
@@ -119,7 +119,7 @@ fi
 # Covers: execution (7), consensus (6), MEV (3), web (caddy, nginx), utils
 log_info "Test 3: Verify all install scripts (syntax)..."
 syntax_fail=0
-for script in "${CLIENT_SCRIPTS[@]}" "install/utils/install_dependencies.sh" "install/utils/select_clients.sh" "install/utils/validator_exit.sh" "install/utils/validator_create_0x02.sh" "install/web/install_caddy.sh" "install/web/install_nginx.sh" "install/web/proxy_config_renderer.sh" "config/edge_policy.env" "test/validate_proxy_policy_sync.sh" "test/validate_proxy_policy_toggles.sh" "test/validate_caddy_config.sh" "test/validate_nginx_config.sh" "test/validate_review_guardrails.sh"; do
+for script in "${CLIENT_SCRIPTS[@]}" "install/utils/install_dependencies.sh" "install/utils/select_clients.sh" "install/utils/validator_exit.sh" "install/utils/validator_create_0x02.sh" "install/utils/validator_withdrawal_changes.sh" "install/web/install_caddy.sh" "install/web/install_nginx.sh" "install/web/proxy_config_renderer.sh" "config/edge_policy.env" "test/validate_proxy_policy_sync.sh" "test/validate_proxy_policy_toggles.sh" "test/validate_caddy_config.sh" "test/validate_nginx_config.sh" "test/validate_review_guardrails.sh"; do
     if [[ -f "$PROJECT_ROOT/$script" ]]; then
         if bash -n "$PROJECT_ROOT/$script" 2>/dev/null; then
             log_info "  ✓ $script"

--- a/test/ci_test_run_2.sh
+++ b/test/ci_test_run_2.sh
@@ -119,7 +119,7 @@ fi
 # Covers: execution (7), consensus (6), MEV (3), web (caddy, nginx), utils
 log_info "Test 3: Verify all install scripts (syntax)..."
 syntax_fail=0
-for script in "${CLIENT_SCRIPTS[@]}" "install/utils/install_dependencies.sh" "install/utils/select_clients.sh" "install/web/install_caddy.sh" "install/web/install_nginx.sh" "install/web/proxy_config_renderer.sh" "config/edge_policy.env" "test/validate_proxy_policy_sync.sh" "test/validate_proxy_policy_toggles.sh" "test/validate_caddy_config.sh" "test/validate_nginx_config.sh" "test/validate_review_guardrails.sh"; do
+for script in "${CLIENT_SCRIPTS[@]}" "install/utils/install_dependencies.sh" "install/utils/select_clients.sh" "install/utils/validator_exit.sh" "install/utils/validator_create_0x02.sh" "install/web/install_caddy.sh" "install/web/install_nginx.sh" "install/web/proxy_config_renderer.sh" "config/edge_policy.env" "test/validate_proxy_policy_sync.sh" "test/validate_proxy_policy_toggles.sh" "test/validate_caddy_config.sh" "test/validate_nginx_config.sh" "test/validate_review_guardrails.sh"; do
     if [[ -f "$PROJECT_ROOT/$script" ]]; then
         if bash -n "$PROJECT_ROOT/$script" 2>/dev/null; then
             log_info "  ✓ $script"

--- a/test/docker_test.sh
+++ b/test/docker_test.sh
@@ -210,6 +210,19 @@ else
     record_test "validator_create_0x02.sh help smoke" "SKIP"
 fi
 
+if [[ -f "$PROJECT_ROOT/install/utils/validator_withdrawal_changes.sh" ]]; then
+    if bash "$PROJECT_ROOT/install/utils/validator_withdrawal_changes.sh" --help 2>&1 | grep -Eq "0x00|BLS-to-execution"; then
+        record_test "validator_withdrawal_changes.sh help smoke" "PASS"
+    else
+        record_test "validator_withdrawal_changes.sh help smoke" "FAIL"
+        log_error "validator_withdrawal_changes.sh --help did not advertise the withdrawal change flow"
+        print_test_summary
+        exit 1
+    fi
+else
+    record_test "validator_withdrawal_changes.sh help smoke" "SKIP"
+fi
+
 if bash "$PROJECT_ROOT/scripts/eth2qs.sh" help 2>&1 | grep -Eq 'validator-exit|validator-create-0x02'; then
     record_test "eth2qs wrapper exposes validator helpers" "PASS"
 else

--- a/test/docker_test.sh
+++ b/test/docker_test.sh
@@ -183,6 +183,42 @@ else
     record_test "Review guardrails validate" "SKIP"
 fi
 
+# Validator helper smoke checks
+if [[ -f "$PROJECT_ROOT/install/utils/validator_exit.sh" ]]; then
+    if bash "$PROJECT_ROOT/install/utils/validator_exit.sh" --help 2>&1 | grep -q "0x00/0x01"; then
+        record_test "validator_exit.sh help smoke" "PASS"
+    else
+        record_test "validator_exit.sh help smoke" "FAIL"
+        log_error "validator_exit.sh --help did not advertise the exit checklist"
+        print_test_summary
+        exit 1
+    fi
+else
+    record_test "validator_exit.sh help smoke" "SKIP"
+fi
+
+if [[ -f "$PROJECT_ROOT/install/utils/validator_create_0x02.sh" ]]; then
+    if bash "$PROJECT_ROOT/install/utils/validator_create_0x02.sh" --help 2>&1 | grep -q "0x02"; then
+        record_test "validator_create_0x02.sh help smoke" "PASS"
+    else
+        record_test "validator_create_0x02.sh help smoke" "FAIL"
+        log_error "validator_create_0x02.sh --help did not advertise the compounding entry flow"
+        print_test_summary
+        exit 1
+    fi
+else
+    record_test "validator_create_0x02.sh help smoke" "SKIP"
+fi
+
+if bash "$PROJECT_ROOT/scripts/eth2qs.sh" help 2>&1 | grep -Eq 'validator-exit|validator-create-0x02'; then
+    record_test "eth2qs wrapper exposes validator helpers" "PASS"
+else
+    record_test "eth2qs wrapper exposes validator helpers" "FAIL"
+    log_error "eth2qs.sh help is missing validator helper commands"
+    print_test_summary
+    exit 1
+fi
+
 # =============================================================================
 # PHASE 4: Function Unit Tests (Real System Calls)
 # =============================================================================

--- a/test/validate_nginx_config.sh
+++ b/test/validate_nginx_config.sh
@@ -26,8 +26,6 @@ NGINX_CONF="$NGINX_ETC/nginx.conf"
 NGINX_POLICY="$NGINX_ETC/conf.d/eth2-edge-policy.conf"
 NGINX_SITE="$NGINX_ETC/sites-enabled/default"
 
-trap 'rm -rf "$VALIDATE_ROOT"' EXIT
-
 mkdir -p "$NGINX_ETC/conf.d" "$NGINX_ETC/sites-enabled"
 
 create_nginx_config "${SERVER_NAME:-rpc.sharedtools.org}" "$NGINX_SITE"
@@ -36,6 +34,27 @@ render_nginx_http_policy_file "$NGINX_POLICY"
 has_passwordless_sudo() {
     command -v sudo &>/dev/null && sudo -n true 2>/dev/null
 }
+
+cleanup_validate_root() {
+    if [[ ! -d "$VALIDATE_ROOT" ]]; then
+        return 0
+    fi
+
+    if [[ "$(id -u)" -eq 0 ]]; then
+        rm -rf "$VALIDATE_ROOT"
+        return 0
+    fi
+
+    if has_passwordless_sudo; then
+        sudo rm -rf "$VALIDATE_ROOT"
+        return 0
+    fi
+
+    chmod -R u+w "$VALIDATE_ROOT" 2>/dev/null || true
+    rm -rf "$VALIDATE_ROOT" 2>/dev/null || true
+}
+
+trap cleanup_validate_root EXIT
 
 if [[ "$(id -u)" -ne 0 ]] && ! has_passwordless_sudo; then
     local_cache_root="$VALIDATE_ROOT/var/cache/nginx"


### PR DESCRIPTION
**Agent:** GPT-5
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary
- Add focused validator exit and 0x02 entry helper scripts.
- Wire the helpers into scripts/eth2qs.sh and the validator docs.
- Extend structure validation and Nginx cleanup so the test harness covers the new scripts cleanly.

## Validation
- shellcheck -x --exclude=SC2317,SC1091,SC1090,SC2034,SC2031,SC2181 scripts/eth2qs.sh install/utils/validator_exit.sh install/utils/validator_create_0x02.sh test/ci_test_run_2.sh test/docker_test.sh test/validate_nginx_config.sh
- bash test/ci_test_run_2.sh
- bash test/run_e2e.sh --phase=2