### PR TITLE
Agent-grade validator management: list/filter/modify/deploy + MCP wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ logs/
 status/*.json
 
 .DS_store
+
+# Python bytecode cache
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Use one stable entrypoint for common workflows:
 ./scripts/eth2qs.sh monitor export --json
 ./scripts/eth2qs.sh repair
 ./scripts/eth2qs.sh restart --smart
+
+# Validator management (full guide: docs/VALIDATOR_MANAGEMENT.md)
+./scripts/eth2qs.sh validators --json --withdrawal-type 0x01 --min-balance 32
+./scripts/eth2qs.sh validator-deploy --num-validators 1 --withdrawal-type 0x02 --withdrawal-address 0xYourAddr
+./scripts/eth2qs.sh validator-exit
+./scripts/eth2qs.sh validator-withdrawal-changes          # 0x00 -> 0x01 (BLS-to-execution)
+./scripts/eth2qs.sh validator-manage --consolidate        # EIP-7251 (incl. 0x01 -> 0x02 compounding)
+./scripts/eth2qs.sh validator-manage --eip7002-exit       # EIP-7002 EL-triggered exit/withdrawal
 ```
 
 For agent integrations, the published skill source lives at `skills/eth2-quickstart/` and is intended to be used inside an `eth2-quickstart` checkout.
@@ -113,6 +121,7 @@ The MCP server can expose the core lifecycle directly: Phase 1 hardening, Phase 
 - For software freshness and repo drift, use `./scripts/eth2qs.sh update-check --json`.
 - For a compact bot/dashboard summary, use `./scripts/eth2qs.sh monitor export --json`.
 - For a bounded auto-repair preview/apply path, use `./scripts/eth2qs.sh repair` and `./scripts/eth2qs.sh repair --apply --confirm`.
+- For validator inventory + filtering from an agent, use the read-only MCP tool `eth2qs_validators` (filters: `min_balance`/`max_balance` ETH, `withdrawal_type` 0x00/0x01/0x02, `status`). Funds-affecting operations (exit, withdrawal-credential change, consolidation, EIP-7002 exit, deploy) are exposed read-only via `eth2qs_validator_op_preview`, which returns the exact node CLI command to run — they are **never executed via MCP**. Run those on the node CLI (they prompt for confirmation). Full guide: [`docs/VALIDATOR_MANAGEMENT.md`](docs/VALIDATOR_MANAGEMENT.md).
 - For the command surface and safety rules, start with [`skills/eth2-quickstart/SKILL.md`](skills/eth2-quickstart/SKILL.md)
 
 This is a repo-backed operations skill, not a standalone blockchain package.

--- a/docs/STANDALONE_HARDENING.md
+++ b/docs/STANDALONE_HARDENING.md
@@ -315,5 +315,5 @@ For issues or questions:
 
 - [Main Documentation](README.md)
 - [Workflow Documentation](WORKFLOW.md)
-- [Security Documentation](docs/verify_security.sh)
-- [Configuration Guide](docs/CONFIGURATION_GUIDE.md)
+- [Security Documentation](verify_security.sh)
+- [Configuration Guide](CONFIGURATION_GUIDE.md)

--- a/docs/VALIDATOR_MANAGEMENT.md
+++ b/docs/VALIDATOR_MANAGEMENT.md
@@ -36,6 +36,14 @@ They are also available through the unified `eth2qs.sh` wrapper.
 # Go straight to consolidation flow (EIP-7251)
 ./scripts/eth2qs.sh validator-manage --consolidate
 ./install/utils/validator_manage.sh --consolidate
+
+# Go straight to EIP-7002 exit/withdrawal flow
+./scripts/eth2qs.sh validator-manage --eip7002-exit
+./install/utils/validator_manage.sh --eip7002-exit
+
+# Go straight to withdrawal credential change flow
+./scripts/eth2qs.sh validator-manage --withdraw-change
+./install/utils/validator_manage.sh --withdraw-change
 ```
 
 ---
@@ -179,9 +187,9 @@ balances. The source validator exits; its stake moves to the target.
 - Both validators must have `0x01` withdrawal credentials pointing to an
   Ethereum address you control.
 - You need the private key of that withdrawal address to sign the transaction.
-- A dynamic fee is required (queried live from the contract).
+- A dynamic fee is required (queried live from the contract using `eth_call` with empty calldata).
 
-**Contract:** `0x00431F263cE400f4455c2dCf564e53007Ca4bbBb` (mainnet)
+**Contract:** `0x0000BBdDc7CE488642fb579F8B00f3a590007251` (mainnet)
 
 The consolidation flow:
 
@@ -195,7 +203,7 @@ The consolidation flow:
 
 ```bash
 # The script prints the exact command — copy and run it yourself:
-cast send 0x00431F263cE400f4455c2dCf564e53007Ca4bbBb \
+cast send 0x0000BBdDc7CE488642fb579F8B00f3a590007251 \
   --value <fee_wei>wei \
   --data 0x<source_pubkey_hex><target_pubkey_hex> \
   --rpc-url http://127.0.0.1:8545 \
@@ -206,6 +214,42 @@ curl -L https://foundry.paradigm.xyz | bash && foundryup
 ```
 
 ---
+
+### 3. EIP-7002 EL-triggered exit/withdrawal
+
+`validator_manage.sh --eip7002-exit` builds the EIP-7002 payload (`validator_pubkey || amount`) and prints the exact `cast send` command before execution.
+
+```bash
+cast send 0x00000961Ef480Eb55e80D19ad83579A64c007002 \
+  --value <fee_wei>wei \
+  --data 0x<validator_pubkey_hex><amount_u64_gwei_be_hex> \
+  --rpc-url http://127.0.0.1:8545 \
+  --from <WITHDRAWAL_ADDRESS>
+```
+
+`amount_u64_gwei_be_hex` is the withdrawal amount in gwei encoded as an 8-byte big-endian integer.
+`amount = 0` requests a full voluntary exit.
+
+### 4. Withdrawal credential change
+
+- `0x00 -> 0x01`: `ethdo validator credentials set`:
+
+```bash
+ethdo validator credentials set \
+  --validator <index_or_pubkey> \
+  --withdrawal-address <address> \
+  --connection http://127.0.0.1:5052
+```
+
+- `0x01 -> 0x02`: self-consolidation (source and target are the same pubkey) using `cast`.
+
+```bash
+cast send 0x0000BBdDc7CE488642fb579F8B00f3a590007251 \
+  --value <fee_wei>wei \
+  --data 0x<source_pubkey_hex><source_pubkey_hex> \
+  --rpc-url http://127.0.0.1:8545 \
+  --private-key <WITHDRAWAL_ADDRESS_PRIVATE_KEY>
+```
 
 ## Beacon API Ports by Client
 

--- a/docs/VALIDATOR_MANAGEMENT.md
+++ b/docs/VALIDATOR_MANAGEMENT.md
@@ -16,6 +16,16 @@ They are also available through the unified `eth2qs.sh` wrapper.
 ./scripts/eth2qs.sh validators --json
 ./install/utils/validator_list.sh --json
 
+# Filter by balance (ETH), withdrawal type (0x00 BLS / 0x01 execution / 0x02 compounding), or status
+./scripts/eth2qs.sh validators --json --min-balance 32 --withdrawal-type 0x01
+./scripts/eth2qs.sh validators --withdrawal-type 0x02            # compounding validators only
+./scripts/eth2qs.sh validators --max-balance 32 --status active_ongoing
+
+# Deploy validators + generate keys and deposit_data.json (0x01 or 0x02 compounding)
+# Set the keystore password via the ETHQS_KEYSTORE_PASSWORD env var (preferred) or interactive prompt.
+ETHQS_KEYSTORE_PASSWORD=... ./scripts/eth2qs.sh validator-deploy \
+  --num-validators 1 --withdrawal-type 0x02 --withdrawal-address 0xYourAddr --import-keys
+
 # Go straight to voluntary exit flow
 ./scripts/eth2qs.sh validator-exit
 ./install/utils/validator_exit.sh
@@ -250,6 +260,60 @@ cast send 0x0000BBdDc7CE488642fb579F8B00f3a590007251 \
   --rpc-url http://127.0.0.1:8545 \
   --private-key <WITHDRAWAL_ADDRESS_PRIVATE_KEY>
 ```
+
+## `validator_deploy.sh` — Key Generation & Deposit
+
+Generates validator keystores + `deposit_data.json` by wrapping
+[`ethstaker-deposit-cli`](https://github.com/eth-educators/ethstaker-deposit-cli),
+optionally imports the keys into the detected client, and **prints the deposit
+command for manual submission** (it never submits the on-chain deposit for you).
+
+```bash
+ETHQS_KEYSTORE_PASSWORD=... ./scripts/eth2qs.sh validator-deploy \
+  --num-validators 2 \
+  --withdrawal-type 0x02 \                 # 0x01 (execution address) or 0x02 (compounding)
+  --withdrawal-address 0xYourWithdrawalAddr \
+  --import-keys                            # optional: import into the running client
+```
+
+- Provide the keystore password via the `ETHQS_KEYSTORE_PASSWORD` env var or the
+  interactive prompt. The `--keystore-password` flag works but is discouraged
+  (visible in process listings / shell history).
+- Mnemonic and keys are never echoed; generated files are written `600` under
+  `$HOME/secrets`. **Back up the mnemonic offline before funding.**
+- `ethstaker-deposit-cli` and `ethdo` are installed by
+  `install/utils/install_dependencies.sh`; if absent, the script prints manual
+  install + command instructions instead of failing hard.
+
+## Filtering the validator list
+
+`validators` / `validator_list.sh` accept filters that apply to both the table
+and `--json` output:
+
+| Flag | Meaning |
+|------|---------|
+| `--min-balance <eth>` | Only validators with balance ≥ this (ETH) |
+| `--max-balance <eth>` | Only validators with balance ≤ this (ETH) |
+| `--withdrawal-type <t>` | `0x00` (BLS), `0x01` (execution address), `0x02` (compounding) |
+| `--status <substr>` | Status substring, e.g. `active_ongoing`, `exited` |
+
+The withdrawal type is matched against the prefix of each validator's
+`withdrawal_credentials`.
+
+## Agent access (MCP)
+
+For agents (Claude Code / Codex) the MCP server exposes:
+
+- **`eth2qs_validators(min_balance, max_balance, withdrawal_type, status)`** —
+  read-only validator inventory with the same filters as the CLI.
+- **`eth2qs_validator_op_preview(operation)`** — read-only; returns the exact node
+  CLI command for a funds-affecting operation (`exit`, `withdrawal-change`,
+  `consolidate`, `eip7002-exit`, `create-0x02`, `deploy`).
+
+**Funds-affecting validator operations are intentionally NOT executed via MCP.**
+They are irreversible and require secrets/keys, so they run only on the node CLI
+where they prompt for confirmation. The MCP surface lets an agent inspect and
+plan; a human (or the CLI) performs the actual mutation.
 
 ## Beacon API Ports by Client
 

--- a/exports.sh
+++ b/exports.sh
@@ -45,7 +45,7 @@ export SERVER_NAME="rpc.sharedtools.org"
 export FEE_RECIPIENT=0xa1feaF41d843d53d0F6bEd86a8cF592cE21C409e
 export GRAFITTI="SharedStake.org!"
 export MAX_PEERS=100 # You may want to reduce this if you have banwidth restrictions
-export PRYSM_CPURL="https://mainnet.checkpoint.sigp.io"
+export PRYSM_CPURL="https://beaconstate.ethstaker.cc"
 # Goerli link if needed for checkpoint sync https://goerli.checkpoint-sync.ethpandaops.io/
 export USE_PRYSM_MODERN=true
 export PRYSM_ALLOW_UNVERIFIED_BINARIES=1
@@ -134,10 +134,10 @@ export LODESTAR_REST_PORT=9596
 export GRANDINE_REST_PORT=5052
 
 # Client-specific checkpoint URLs (fallbacks if main fails)
-export TEKU_CHECKPOINT_URL="https://mainnet.checkpoint.sigp.io"
-export LODESTAR_CHECKPOINT_URL="https://mainnet.checkpoint.sigp.io"
-export LIGHTHOUSE_CHECKPOINT_URL="https://mainnet.checkpoint.sigp.io"
-export GRANDINE_CHECKPOINT_URL="https://mainnet.checkpoint.sigp.io"
+export TEKU_CHECKPOINT_URL="https://beaconstate.ethstaker.cc"
+export LODESTAR_CHECKPOINT_URL="https://beaconstate.ethstaker.cc"
+export LIGHTHOUSE_CHECKPOINT_URL="https://beaconstate.ethstaker.cc"
+export GRANDINE_CHECKPOINT_URL="https://beaconstate.ethstaker.cc"
 
 # ============================================================================
 # MEV Configuration

--- a/install/test/test_validator_filter.sh
+++ b/install/test/test_validator_filter.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Unit tests for install/utils/validator_filter.py (balance / withdrawal-type / status).
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FILTER="$PROJECT_ROOT/install/utils/validator_filter.py"
+
+PASS=0
+FAIL=0
+
+FIXTURE="$(mktemp /tmp/vfilter_XXXXXX.json)"
+trap 'rm -f "$FIXTURE"' EXIT
+cat > "$FIXTURE" <<'JSON'
+{"data":[
+  {"index":"1","balance":"32000000000","status":"active_ongoing","validator":{"pubkey":"0xaa","withdrawal_credentials":"0x010000000000000000000000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}},
+  {"index":"2","balance":"16000000000","status":"active_ongoing","validator":{"pubkey":"0xbb","withdrawal_credentials":"0x00bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}},
+  {"index":"3","balance":"2048000000000","status":"active_ongoing","validator":{"pubkey":"0xcc","withdrawal_credentials":"0x020000000000000000000000cccccccccccccccccccccccccccccccccccccccc"}},
+  {"index":"4","balance":"31000000000","status":"exited_unslashed","validator":{"pubkey":"0xdd","withdrawal_credentials":"0x010000000000000000000000dddddddddddddddddddddddddddddddddddddddd"}}
+]}
+JSON
+
+# count(expected, label, filter-args...)
+count() {
+    local expected="$1" label="$2"; shift 2
+    local got
+    got=$(python3 "$FILTER" "$FIXTURE" "$@" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["data"]))')
+    if [[ "$got" == "$expected" ]]; then
+        echo "PASS: $label (got $got)"; PASS=$((PASS+1))
+    else
+        echo "FAIL: $label (expected $expected, got $got)"; FAIL=$((FAIL+1))
+    fi
+}
+
+count 4 "no filter"
+count 2 "withdrawal-type 0x01" --withdrawal-type 0x01
+count 1 "withdrawal-type 0x00" --withdrawal-type 0x00
+count 1 "withdrawal-type 0x02" --withdrawal-type 0x02
+count 2 "min-balance 32"       --min-balance 32
+count 2 "max-balance 31"       --max-balance 31
+count 2 "min 17 max 100"       --min-balance 17 --max-balance 100
+count 1 "status exited"        --status exited
+count 1 "0x01 AND min 32"      --withdrawal-type 0x01 --min-balance 32
+count 0 "0x02 AND max 100"     --withdrawal-type 0x02 --max-balance 100
+
+# invalid withdrawal type rejected (exit 2)
+if python3 "$FILTER" "$FIXTURE" --withdrawal-type 0x99 >/dev/null 2>&1; then
+    echo "FAIL: invalid withdrawal-type should error"; FAIL=$((FAIL+1))
+else
+    echo "PASS: invalid withdrawal-type rejected"; PASS=$((PASS+1))
+fi
+
+echo "=== validator_filter: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/install/utils/install_dependencies.sh
+++ b/install/utils/install_dependencies.sh
@@ -110,6 +110,125 @@ apt_update() {
 }
 
 # =============================================================================
+# VALIDATOR TOOL INSTALLATION
+# =============================================================================
+
+# Install ethdo (validator management tool)
+# Graceful: if installation fails, script continues and prints manual instructions
+install_ethdo() {
+    log_info "Installing ethdo (validator management tool)..."
+
+    # Check if Go is available
+    if ! command -v go &>/dev/null; then
+        log_warn "Go not found. Skipping ethdo installation."
+        log_info "Manual install: go install github.com/wealdtech/ethdo@latest"
+        return 0
+    fi
+
+    # Check if already installed
+    if command -v ethdo &>/dev/null; then
+        log_info "ethdo already installed: $(ethdo --version 2>/dev/null || echo 'unknown')"
+        return 0
+    fi
+
+    # Install ethdo
+    if go install github.com/wealdtech/ethdo@latest &>/dev/null; then
+        # Ensure GOPATH/bin is in PATH
+        local go_bin
+        go_bin="$(go env GOPATH)/bin"
+        if [[ -d "$go_bin" ]] && [[ ":$PATH:" != *":$go_bin:"* ]]; then
+            export PATH="$go_bin:$PATH"
+            echo "export PATH=\"$go_bin:\$PATH\"" >> "$HOME/.bashrc" 2>/dev/null || true
+        fi
+        log_info "ethdo installed successfully"
+    else
+        log_warn "Failed to install ethdo via Go"
+        log_info "Manual install: go install github.com/wealdtech/ethdo@latest"
+    fi
+}
+
+# Install ethstaker-deposit-cli (validator key generation tool)
+# Graceful: if installation fails, script continues and prints manual instructions
+install_ethstaker_deposit_cli() {
+    log_info "Installing ethstaker-deposit-cli (validator key generation tool)..."
+
+    local deposit_cli_name="ethstaker-deposit-cli"
+    local venv_dir="$HOME/.${deposit_cli_name}-venv"
+    local repo_url="https://github.com/ethstaker/ethstaker-deposit-cli.git"
+
+    # Check if already installed
+    if [[ -d "$venv_dir" && -x "$venv_dir/bin/python" ]]; then
+        log_info "$deposit_cli_name already installed at $venv_dir"
+        return 0
+    fi
+
+    # Check Python requirements
+    if ! command -v python3 &>/dev/null; then
+        log_warn "python3 not found. Skipping $deposit_cli_name installation."
+        log_info "Manual install: git clone $repo_url && python3 -m venv venv && ./venv/bin/pip install -e ."
+        return 0
+    fi
+
+    if ! python3 -c "import venv" &>/dev/null; then
+        log_warn "python3-venv not found. Skipping $deposit_cli_name installation."
+        log_info "Manual install: sudo apt-get install python3-venv"
+        log_info "Then: git clone $repo_url && python3 -m venv venv && ./venv/bin/pip install -e ."
+        return 0
+    fi
+
+    # Create temporary directory for clone
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp_dir'" EXIT
+
+    log_info "Cloning $deposit_cli_name repository..."
+    if ! git clone --depth 1 "$repo_url" "$tmp_dir/repo" 2>/dev/null; then
+        log_warn "Failed to clone $deposit_cli_name repository"
+        log_info "Manual install: git clone $repo_url && python3 -m venv venv && ./venv/bin/pip install -e ."
+        return 0
+    fi
+
+    log_info "Creating virtual environment at $venv_dir..."
+    if ! python3 -m venv "$venv_dir" 2>/dev/null; then
+        log_warn "Failed to create virtual environment"
+        log_info "Manual install: git clone $repo_url && python3 -m venv venv && ./venv/bin/pip install -e ."
+        return 0
+    fi
+
+    log_info "Installing $deposit_cli_name..."
+    # shellcheck disable=SC1090
+    if ! source "$venv_dir/bin/activate" 2>/dev/null; then
+        log_warn "Failed to activate virtual environment"
+        return 0
+    fi
+
+    if ! pip install -e "$tmp_dir/repo" &>/dev/null; then
+        log_warn "Failed to install $deposit_cli_name"
+        deactivate 2>/dev/null || true
+        log_info "Manual install: git clone $repo_url && python3 -m venv venv && ./venv/bin/pip install -e ."
+        return 0
+    fi
+    deactivate 2>/dev/null || true
+
+    # Secure the venv directory
+    chmod 700 "$venv_dir"
+
+    log_info "$deposit_cli_name installed successfully at $venv_dir"
+}
+
+# Install validator tools (ethdo + ethstaker-deposit-cli)
+# Called from Phase 2 (user-level)
+install_validator_tools() {
+    log_info "Installing validator management tools..."
+
+    install_ethdo
+    install_ethstaker_deposit_cli
+
+    log_info "Validator tools installation complete"
+}
+
+# =============================================================================
 # INSTALLATION MODES
 # =============================================================================
 
@@ -164,7 +283,7 @@ install_phase1() {
 }
 
 # Phase 2: User-level tools only (runs as eth user from run_2.sh)
-# Installs Rust (per-user, in $HOME/.cargo). No sudo apt-get calls.
+# Installs Rust (per-user, in $HOME/.cargo) and validator tools. No sudo apt-get calls.
 install_phase2() {
     log_info "Installing Phase 2 user-level tools..."
 
@@ -181,6 +300,9 @@ install_phase2() {
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y > /dev/null 2>&1
         [[ -d "$HOME/.cargo/bin" ]] && export PATH="$HOME/.cargo/bin:${PATH:-}"
     fi
+
+    # Validator tools (ethdo + ethstaker-deposit-cli)
+    install_validator_tools
 
     log_info "Phase 2 user-level tools installed successfully!"
 }
@@ -221,6 +343,9 @@ install_production() {
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y > /dev/null 2>&1
         [[ -d "$HOME/.cargo/bin" ]] && export PATH="$HOME/.cargo/bin:${PATH:-}"
     fi
+
+    # Validator tools (ethdo + ethstaker-deposit-cli)
+    install_validator_tools
 
     # Time sync (skip in Docker)
     if ! is_docker && command -v timedatectl &>/dev/null; then

--- a/install/utils/validator_deploy.sh
+++ b/install/utils/validator_deploy.sh
@@ -1,0 +1,490 @@
+#!/bin/bash
+
+# Eth2 Quick Start — Validator Deploy
+# Generates validator keystores + deposit_data.json using ethstaker-deposit-cli
+# Optionally imports keystores into the locally-detected consensus client
+# Prints deposit command for manual on-chain submission (does NOT auto-submit)
+#
+# Usage: ./install/utils/validator_deploy.sh [options]
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../" && pwd)"
+
+# shellcheck source=../../lib/common_functions.sh
+source "$ROOT_DIR/lib/common_functions.sh"
+# shellcheck source=../../exports.sh
+if [[ -f "$ROOT_DIR/exports.sh" ]]; then
+    source "$ROOT_DIR/exports.sh" 2>/dev/null || true
+fi
+if [[ -f "$ROOT_DIR/config/user_config.env" ]]; then
+    # shellcheck source=/dev/null
+    source "$ROOT_DIR/config/user_config.env" 2>/dev/null || true
+fi
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+SECRETS_DIR="$HOME/secrets"
+DEPOSIT_CLI_NAME="ethstaker-deposit-cli"
+DEPOSIT_CLI_VENV_DIR="$HOME/.${DEPOSIT_CLI_NAME}-venv"
+DEPOSIT_CLI_REPO="https://github.com/ethstaker/ethstaker-deposit-cli.git"
+WITHDRAWAL_TYPE=""
+NUM_VALIDATORS=""
+WITHDRAWAL_ADDRESS=""
+KEYSTORE_PASSWORD=""
+OUTPUT_DIR=""
+IMPORT_KEYS=false
+NON_INTERACTIVE=false
+
+# =============================================================================
+# CLIENT DETECTION (reuse from validator_list.sh)
+# =============================================================================
+
+detect_client() {
+    local exec_start
+    exec_start=$(systemctl show validator --property=ExecStart --value 2>/dev/null || true)
+    if [[ -z "$exec_start" ]]; then
+        echo "unknown"
+        return
+    fi
+    if echo "$exec_start"   | grep -qi "lighthouse"; then echo "lighthouse"
+    elif echo "$exec_start" | grep -qi "prysm";      then echo "prysm"
+    elif echo "$exec_start" | grep -qi "teku";       then echo "teku"
+    elif echo "$exec_start" | grep -qi "lodestar";   then echo "lodestar"
+    elif echo "$exec_start" | grep -qi "nimbus";     then echo "nimbus"
+    elif echo "$exec_start" | grep -qi "grandine";   then echo "grandine"
+    else echo "unknown"
+    fi
+}
+
+get_client_keystore_dir() {
+    local client="$1"
+    case "$client" in
+        lighthouse)
+            echo "$HOME/.lighthouse/mainnet/validators"
+            ;;
+        prysm)
+            echo "$HOME/prysm"
+            ;;
+        teku)
+            echo "$HOME/.local/share/teku/validator/keys"
+            ;;
+        lodestar)
+            echo "$HOME/.local/share/lodestar/validators/keystores"
+            ;;
+        nimbus)
+            echo "$HOME/.local/share/nimbus/validators"
+            ;;
+        grandine)
+            echo "$HOME/.local/share/grandine/validator/keystores"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+# =============================================================================
+# CONFIRMATION HELPER
+# =============================================================================
+
+confirm_destructive() {
+    local message="$1"
+    if [[ "$NON_INTERACTIVE" == "true" ]]; then
+        return 0
+    fi
+    printf "\n${YELLOW}[WARNING]${NC} %s\n" "$message"
+    read -rp "  Continue? (yes/no): " confirm
+    if [[ "$confirm" != "yes" ]]; then
+        log_warn "Aborted by user."
+        exit 0
+    fi
+}
+
+# =============================================================================
+# DEPOSIT CLI INSTALLATION
+# =============================================================================
+
+install_deposit_cli() {
+    log_info "Installing $DEPOSIT_CLI_NAME..."
+
+    # Check if already installed
+    if [[ -d "$DEPOSIT_CLI_VENV_DIR" ]]; then
+        log_info "$DEPOSIT_CLI_NAME already installed at $DEPOSIT_CLI_VENV_DIR"
+        return 0
+    fi
+
+    # Install dependencies
+    if ! command -v python3 &>/dev/null; then
+        log_error "python3 not found. Please install Python 3.10+ first."
+        return 1
+    fi
+
+    if ! python3 -c "import venv" &>/dev/null; then
+        log_error "python3-venv not found. Install with: sudo apt-get install python3-venv"
+        return 1
+    fi
+
+    # Create temporary directory for clone
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmp_dir'" EXIT
+
+    log_info "Cloning $DEPOSIT_CLI_NAME repository..."
+    if ! git clone --depth 1 "$DEPOSIT_CLI_REPO" "$tmp_dir/repo" 2>/dev/null; then
+        log_error "Failed to clone $DEPOSIT_CLI_NAME repository"
+        return 1
+    fi
+
+    log_info "Creating virtual environment..."
+    python3 -m venv "$DEPOSIT_CLI_VENV_DIR"
+
+    log_info "Installing $DEPOSIT_CLI_NAME..."
+    # shellcheck disable=SC1090
+    source "$DEPOSIT_CLI_VENV_DIR/bin/activate"
+    if ! pip install -e "$tmp_dir/repo" &>/dev/null; then
+        log_error "Failed to install $DEPOSIT_CLI_NAME"
+        deactivate
+        return 1
+    fi
+    deactivate
+
+    log_info "$DEPOSIT_CLI_NAME installed successfully at $DEPOSIT_CLI_VENV_DIR"
+    return 0
+}
+
+check_deposit_cli() {
+    if [[ -d "$DEPOSIT_CLI_VENV_DIR" && -x "$DEPOSIT_CLI_VENV_DIR/bin/python" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+# =============================================================================
+# KEY GENERATION
+# =============================================================================
+
+generate_keys() {
+    local num_validators="$1"
+    local withdrawal_type="$2"
+    local withdrawal_address="$3"
+    local keystore_password="$4"
+    local output_dir="$5"
+
+    local output_subdir="$output_dir/validator_keys"
+    ensure_directory "$output_subdir"
+
+    local deposit_cmd=()
+    local cli_python="$DEPOSIT_CLI_VENV_DIR/bin/python"
+
+    if ! check_deposit_cli; then
+        log_error "$DEPOSIT_CLI_NAME not installed. Run with --install-deps first, or install manually:"
+        printf "\n  Manual installation:\n"
+        printf "    git clone %s /tmp/ethstaker-deposit-cli\n" "$DEPOSIT_CLI_REPO"
+        printf "    cd /tmp/ethstaker-deposit-cli\n"
+        printf "    python3 -m venv venv\n"
+        printf "    ./venv/bin/pip install -e .\n"
+        printf "    ./venv/bin/python -m ethstaker_deposit --non_interactive new-mnemonic --help\n\n"
+        return 1
+    fi
+
+    # Build command based on withdrawal type
+    deposit_cmd=(
+        "$cli_python" -m ethstaker_deposit
+        --non_interactive
+        new-mnemonic
+        --num_validators "$num_validators"
+        --chain mainnet
+        --keystore_password "$keystore_password"
+        --folder "$output_dir"
+    )
+
+    case "$withdrawal_type" in
+        0x01)
+            if [[ -z "$withdrawal_address" ]]; then
+                log_error "0x01 (execution withdrawal) requires --withdrawal-address"
+                return 1
+            fi
+            deposit_cmd+=(--withdrawal_address "$withdrawal_address")
+            ;;
+        0x02)
+            if [[ -z "$withdrawal_address" ]]; then
+                log_error "0x02 (compounding) requires --withdrawal-address"
+                return 1
+            fi
+            deposit_cmd+=(
+                --withdrawal_address "$withdrawal_address"
+                --compounding
+                --amount 32
+            )
+            ;;
+        *)
+            log_error "Invalid withdrawal type: $withdrawal_type (must be 0x01 or 0x02)"
+            return 1
+            ;;
+    esac
+
+    log_info "Generating $num_validators validator key(s) with withdrawal type $withdrawal_type..."
+    log_info "Output directory: $output_subdir"
+
+    # Run deposit CLI (capture output but don't echo mnemonic)
+    if ! "${deposit_cmd[@]}" > "$output_dir/generation.log" 2>&1; then
+        log_error "Key generation failed. Check $output_dir/generation.log for details."
+        return 1
+    fi
+
+    # Secure the output directory
+    chmod 700 "$output_subdir"
+    find "$output_subdir" -type f -exec chmod 600 {} \;
+
+    log_info "Keys generated successfully in $output_subdir"
+    return 0
+}
+
+# =============================================================================
+# KEY IMPORT
+# =============================================================================
+
+import_keys_to_client() {
+    local client="$1"
+    local keystore_dir="$2"
+    local password="$3"
+
+    local client_keystore_dir
+    client_keystore_dir=$(get_client_keystore_dir "$client")
+
+    if [[ -z "$client_keystore_dir" ]]; then
+        log_warn "Unknown client '$client'. Cannot auto-import keys."
+        log_info "Manual import required. Copy keystores from $keystore_dir to your client's keystore directory."
+        return 0
+    fi
+
+    if [[ "$client" == "unknown" ]]; then
+        log_warn "No validator client detected. Cannot auto-import keys."
+        log_info "Manual import required. Copy keystores from $keystore_dir to your client's keystore directory."
+        return 0
+    fi
+
+    log_info "Importing keys to $client client at $client_keystore_dir"
+
+    ensure_directory "$client_keystore_dir"
+
+    # Copy keystores
+    if ! cp -r "$keystore_dir"/* "$client_keystore_dir"/ 2>/dev/null; then
+        log_error "Failed to copy keystores to $client_keystore_dir"
+        return 1
+    fi
+
+    # Set permissions
+    chmod 700 "$client_keystore_dir"
+    find "$client_keystore_dir" -type f -exec chmod 600 {} \;
+
+    log_info "Keys imported successfully. Restart validator service to activate."
+    log_info "  sudo systemctl restart validator"
+}
+
+# =============================================================================
+# DEPOSIT COMMAND PRINTING
+# =============================================================================
+
+print_deposit_command() {
+    local deposit_data_file="$1"
+
+    if [[ ! -f "$deposit_data_file" ]]; then
+        log_error "deposit_data file not found: $deposit_data_file"
+        return 1
+    fi
+
+    printf "\n"
+    log_info "=== Deposit Command ==="
+    printf "\n"
+    cat <<'EOF'
+  To stake your validators, visit the Ethereum Launchpad:
+  https://launchpad.ethereum.org/
+
+  Upload the deposit_data.json file and follow the instructions.
+  Your deposit_data file is located at:
+
+EOF
+    printf "    %s\n\n" "$deposit_data_file"
+
+    cat <<'EOF'
+  IMPORTANT:
+  - Double-check the deposit contract address on the Launchpad
+  - Verify you are on the correct network (mainnet)
+  - Keep your mnemonic and keystore password secure
+  - Never share your mnemonic or private keys
+
+EOF
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+print_usage() {
+    cat <<'EOF'
+Usage: ./install/utils/validator_deploy.sh [options]
+
+Options:
+  --num-validators <N>           Number of validators to generate [required]
+  --withdrawal-type <type>       Withdrawal type: 0x01 (execution address) or 0x02 (compounding) [required]
+  --withdrawal-address <addr>    Execution withdrawal address (required for 0x01 and 0x02)
+  --keystore-password <pwd>      Password for keystore encryption [required]
+  --output-dir <dir>             Output directory for keystores [default: $HOME/secrets/validator_keys_<timestamp>]
+  --import-keys                  Import generated keys into detected consensus client
+  --install-deps                 Install ethstaker-deposit-cli if not present
+  --non-interactive              Skip confirmation prompts
+  --help, -h                     Show this help message
+
+Examples:
+  # Generate 1 validator with execution withdrawal (0x01)
+  ./validator_deploy.sh --num-validators 1 --withdrawal-type 0x01 \\
+    --withdrawal-address 0x1234... --keystore-password mypass --install-deps
+
+  # Generate 2 compounding validators (0x02) and import keys
+  ./validator_deploy.sh --num-validators 2 --withdrawal-type 0x02 \\
+    --withdrawal-address 0x1234... --keystore-password mypass --import-keys --install-deps
+
+EOF
+}
+
+main() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --num-validators)
+                [[ $# -ge 2 ]] || { echo "Error: --num-validators requires a value" >&2; exit 2; }
+                NUM_VALIDATORS="$2"
+                shift
+                ;;
+            --withdrawal-type)
+                [[ $# -ge 2 ]] || { echo "Error: --withdrawal-type requires a value" >&2; exit 2; }
+                WITHDRAWAL_TYPE="$2"
+                case "$WITHDRAWAL_TYPE" in
+                    0x01|0x02) ;;
+                    *) echo "Error: --withdrawal-type must be 0x01 or 0x02" >&2; exit 2 ;;
+                esac
+                shift
+                ;;
+            --withdrawal-address)
+                [[ $# -ge 2 ]] || { echo "Error: --withdrawal-address requires a value" >&2; exit 2; }
+                WITHDRAWAL_ADDRESS="$2"
+                shift
+                ;;
+            --keystore-password)
+                [[ $# -ge 2 ]] || { echo "Error: --keystore-password requires a value" >&2; exit 2; }
+                KEYSTORE_PASSWORD="$2"
+                log_warn "Passing --keystore-password on the command line is visible in process listings and shell history. Prefer the ETHQS_KEYSTORE_PASSWORD env var or the interactive prompt."
+                shift
+                ;;
+            --output-dir)
+                [[ $# -ge 2 ]] || { echo "Error: --output-dir requires a value" >&2; exit 2; }
+                OUTPUT_DIR="$2"
+                shift
+                ;;
+            --import-keys)
+                IMPORT_KEYS=true
+                ;;
+            --install-deps)
+                install_deposit_cli
+                exit $?
+                ;;
+            --non-interactive)
+                NON_INTERACTIVE=true
+                ;;
+            --help|-h)
+                print_usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                print_usage
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    # Validate required arguments
+    if [[ -z "$NUM_VALIDATORS" ]]; then
+        log_error "--num-validators is required"
+        print_usage
+        exit 1
+    fi
+
+    if [[ -z "$WITHDRAWAL_TYPE" ]]; then
+        log_error "--withdrawal-type is required (0x01 or 0x02)"
+        print_usage
+        exit 1
+    fi
+
+    # Resolve keystore password securely: flag (discouraged) -> env var -> interactive prompt.
+    if [[ -z "$KEYSTORE_PASSWORD" && -n "${ETHQS_KEYSTORE_PASSWORD:-}" ]]; then
+        KEYSTORE_PASSWORD="$ETHQS_KEYSTORE_PASSWORD"
+    fi
+    if [[ -z "$KEYSTORE_PASSWORD" ]]; then
+        if [[ "$NON_INTERACTIVE" != "true" && -t 0 ]]; then
+            read -rs -p "Keystore password: " KEYSTORE_PASSWORD; echo
+            read -rs -p "Confirm keystore password: " _kp_confirm; echo
+            if [[ "$KEYSTORE_PASSWORD" != "$_kp_confirm" ]]; then
+                log_error "Passwords do not match"
+                exit 1
+            fi
+        else
+            log_error "Keystore password required: set ETHQS_KEYSTORE_PASSWORD, run interactively, or pass --keystore-password (discouraged; visible in process listings)."
+            exit 1
+        fi
+    fi
+
+    # Set default output directory
+    if [[ -z "$OUTPUT_DIR" ]]; then
+        local timestamp
+        timestamp=$(date +%Y%m%d_%H%M%S)
+        OUTPUT_DIR="$SECRETS_DIR/validator_keys_$timestamp"
+    fi
+
+    # Ensure secrets directory exists
+    ensure_directory "$SECRETS_DIR"
+    chmod 700 "$SECRETS_DIR"
+
+    # Confirmation
+    confirm_destructive "This will generate $NUM_VALIDATORS validator key(s) and store sensitive data in $OUTPUT_DIR"
+
+    # Generate keys
+    if ! generate_keys "$NUM_VALIDATORS" "$WITHDRAWAL_TYPE" "$WITHDRAWAL_ADDRESS" "$KEYSTORE_PASSWORD" "$OUTPUT_DIR"; then
+        log_error "Key generation failed"
+        exit 1
+    fi
+
+    local keystore_dir="$OUTPUT_DIR/validator_keys"
+    local deposit_data_file
+    deposit_data_file=$(find "$keystore_dir" -name "deposit_data*.json" | head -1)
+
+    if [[ -z "$deposit_data_file" ]]; then
+        log_error "deposit_data.json not found in $keystore_dir"
+        exit 1
+    fi
+
+    # Import keys if requested
+    if [[ "$IMPORT_KEYS" == "true" ]]; then
+        local client
+        client=$(detect_client)
+        if ! import_keys_to_client "$client" "$keystore_dir" "$KEYSTORE_PASSWORD"; then
+            log_warn "Key import failed, but keys were generated successfully"
+        fi
+    fi
+
+    # Print deposit command
+    print_deposit_command "$deposit_data_file"
+
+    log_info "Validator deployment complete!"
+    log_info "Keystore directory: $keystore_dir"
+    log_info "Mnemonic and secrets are stored in: $OUTPUT_DIR"
+    log_warn "Keep your mnemonic and password secure. Never share them."
+}
+
+main "$@"

--- a/install/utils/validator_deploy.sh
+++ b/install/utils/validator_deploy.sh
@@ -231,11 +231,22 @@ generate_keys() {
     log_info "Generating $num_validators validator key(s) with withdrawal type $withdrawal_type..."
     log_info "Output directory: $output_subdir"
 
+    # NOTE: ethstaker-deposit-cli's --non_interactive mode takes --keystore_password
+    # as an argument, so the value is briefly visible in the child process command
+    # line (e.g. `ps`) for the duration of key generation. This is a limitation of
+    # the upstream tool's non-interactive interface; the mnemonic itself is never
+    # echoed and all generated files are locked to 600 below.
+
+    # Lock down the output dir + generation log up front: the log can capture
+    # secret material emitted by the deposit CLI.
+    chmod 700 "$output_dir" 2>/dev/null || true
     # Run deposit CLI (capture output but don't echo mnemonic)
     if ! "${deposit_cmd[@]}" > "$output_dir/generation.log" 2>&1; then
+        chmod 600 "$output_dir/generation.log" 2>/dev/null || true
         log_error "Key generation failed. Check $output_dir/generation.log for details."
         return 1
     fi
+    chmod 600 "$output_dir/generation.log" 2>/dev/null || true
 
     # Secure the output directory
     chmod 700 "$output_subdir"

--- a/install/utils/validator_filter.py
+++ b/install/utils/validator_filter.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Filter a beacon-node validators payload by balance, withdrawal type, status.
+
+Reads a JSON object {"data": [ <validator entry>, ... ]} from a file argument
+(or stdin if "-"), applies the filters, and writes the same shape to stdout.
+
+Withdrawal type matches the prefix of validator.withdrawal_credentials:
+  0x00 = BLS, 0x01 = execution address, 0x02 = compounding (EIP-7251).
+Balances are compared in ETH (entry "balance" is gwei).
+
+Used by validator_list.sh and covered by install/test/test_validator_filter.sh.
+"""
+import argparse
+import json
+import sys
+
+
+def keep(v, min_b, max_b, wtype, status):
+    bal = int(v.get("balance", 0)) / 1e9
+    if min_b is not None and bal < min_b:
+        return False
+    if max_b is not None and bal > max_b:
+        return False
+    if wtype:
+        cred = (v.get("validator", {}).get("withdrawal_credentials", "") or "").lower()
+        if not cred.startswith(wtype):
+            return False
+    if status and status not in (v.get("status", "") or "").lower():
+        return False
+    return True
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("path", help="input JSON file, or - for stdin")
+    p.add_argument("--min-balance", type=float, default=None)
+    p.add_argument("--max-balance", type=float, default=None)
+    p.add_argument("--withdrawal-type", default=None)
+    p.add_argument("--status", default=None)
+    args = p.parse_args()
+
+    wtype = args.withdrawal_type.lower() if args.withdrawal_type else None
+    if wtype and wtype not in ("0x00", "0x01", "0x02"):
+        print("withdrawal-type must be 0x00, 0x01, or 0x02", file=sys.stderr)
+        return 2
+    status = args.status.lower() if args.status else None
+
+    src = sys.stdin if args.path == "-" else open(args.path)
+    with src as f:
+        raw = json.load(f)
+
+    raw["data"] = [
+        v for v in raw.get("data", [])
+        if keep(v, args.min_balance, args.max_balance, wtype, status)
+    ]
+    json.dump(raw, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/install/utils/validator_list.sh
+++ b/install/utils/validator_list.sh
@@ -24,12 +24,40 @@ fi
 
 JSON_OUTPUT=false
 BEACON_QUERY_STATUS="ok"
+MIN_BALANCE=""
+MAX_BALANCE=""
+WITHDRAWAL_TYPE=""
+STATUS_FILTER=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --json) JSON_OUTPUT=true ;;
+        --min-balance)
+            [[ $# -ge 2 ]] || { echo "Error: --min-balance requires a value (ETH)" >&2; exit 2; }
+            MIN_BALANCE="$2"; shift ;;
+        --max-balance)
+            [[ $# -ge 2 ]] || { echo "Error: --max-balance requires a value (ETH)" >&2; exit 2; }
+            MAX_BALANCE="$2"; shift ;;
+        --withdrawal-type)
+            [[ $# -ge 2 ]] || { echo "Error: --withdrawal-type requires a value (0x00|0x01|0x02)" >&2; exit 2; }
+            WITHDRAWAL_TYPE="${2,,}"
+            case "$WITHDRAWAL_TYPE" in
+                0x00|0x01|0x02) ;;
+                *) echo "Error: --withdrawal-type must be 0x00, 0x01, or 0x02" >&2; exit 2 ;;
+            esac
+            shift ;;
+        --status)
+            [[ $# -ge 2 ]] || { echo "Error: --status requires a value (e.g. active_ongoing)" >&2; exit 2; }
+            STATUS_FILTER="$2"; shift ;;
         --help|-h)
-            echo "Usage: ./install/utils/validator_list.sh [--json]"
-            echo "  --json    Machine-readable JSON output"
+            cat <<'EOF'
+Usage: ./install/utils/validator_list.sh [options]
+  --json                     Machine-readable JSON output
+  --min-balance <eth>        Only validators with balance >= this (ETH)
+  --max-balance <eth>        Only validators with balance <= this (ETH)
+  --withdrawal-type <type>   Filter by withdrawal credentials prefix: 0x00 (BLS),
+                             0x01 (execution address), 0x02 (compounding)
+  --status <substr>          Filter by status substring (e.g. active_ongoing)
+EOF
             exit 0
             ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
@@ -266,6 +294,24 @@ main() {
     trap "rm -f '$tmpfile'" EXIT
 
     query_beacon_validators "$beacon_url" "$tmpfile" "${pubkeys[@]}"
+
+    # Apply optional filters (balance / withdrawal type / status) to the beacon
+    # data in place, so both table and JSON output reflect the same filtered set.
+    if [[ -n "$MIN_BALANCE" || -n "$MAX_BALANCE" || -n "$WITHDRAWAL_TYPE" || -n "$STATUS_FILTER" ]]; then
+        local filter_args=()
+        [[ -n "$MIN_BALANCE" ]]     && filter_args+=(--min-balance "$MIN_BALANCE")
+        [[ -n "$MAX_BALANCE" ]]     && filter_args+=(--max-balance "$MAX_BALANCE")
+        [[ -n "$WITHDRAWAL_TYPE" ]] && filter_args+=(--withdrawal-type "$WITHDRAWAL_TYPE")
+        [[ -n "$STATUS_FILTER" ]]   && filter_args+=(--status "$STATUS_FILTER")
+        local filter_err
+        if filter_err=$(python3 "$SCRIPT_DIR/validator_filter.py" "$tmpfile" "${filter_args[@]}" 2>&1 1>"${tmpfile}.f"); then
+            mv "${tmpfile}.f" "$tmpfile"
+        else
+            rm -f "${tmpfile}.f"
+            log_error "Validator filter failed (filters not applied): ${filter_err}"
+            exit 1
+        fi
+    fi
 
     if [[ "$JSON_OUTPUT" == "true" ]]; then
         python3 - "$tmpfile" "$client" "$beacon_url" "$generated_at_utc" "$BEACON_QUERY_STATUS" <<'PYEOF'

--- a/install/utils/validator_manage.sh
+++ b/install/utils/validator_manage.sh
@@ -464,6 +464,17 @@ EOF
     [[ "$src_pubkey" != 0x* ]] && src_pubkey="0x${src_pubkey}"
     [[ "$tgt_pubkey" != 0x* ]] && tgt_pubkey="0x${tgt_pubkey}"
 
+    # Validate exact BLS pubkey format (0x + 96 hex) before building calldata,
+    # so a malformed input can't produce a bad request that wastes the fee.
+    if [[ ! "$src_pubkey" =~ ^0x[0-9A-Fa-f]{96}$ ]]; then
+        log_warn "Invalid source pubkey format. Expected 0x + 96 hex chars."
+        return 0
+    fi
+    if [[ ! "$tgt_pubkey" =~ ^0x[0-9A-Fa-f]{96}$ ]]; then
+        log_warn "Invalid target pubkey format. Expected 0x + 96 hex chars."
+        return 0
+    fi
+
     # Query current fee from the consolidation contract (empty calldata returns fee)
     local fee_dec
     fee_dec=$(query_system_contract_fee "$CONSOLIDATION_CONTRACT" "$el_rpc")

--- a/install/utils/validator_manage.sh
+++ b/install/utils/validator_manage.sh
@@ -8,6 +8,8 @@
 #   ./install/utils/validator_manage.sh            # interactive menu
 #   ./install/utils/validator_manage.sh --exit     # go straight to exit flow
 #   ./install/utils/validator_manage.sh --consolidate
+#   ./install/utils/validator_manage.sh --eip7002-exit
+#   ./install/utils/validator_manage.sh --withdraw-change
 #
 # WARNING: Voluntary exit is IRREVERSIBLE.
 
@@ -28,7 +30,8 @@ if [[ -f "$ROOT_DIR/config/user_config.env" ]]; then
 fi
 
 # EIP-7251 consolidation request contract (mainnet)
-CONSOLIDATION_CONTRACT="0x00431F263cE400f4455c2dCf564e53007Ca4bbBb"
+CONSOLIDATION_CONTRACT="0x0000BBdDc7CE488642fb579F8B00f3a590007251"
+WITHDRAWAL_CONTRACT="0x00000961Ef480Eb55e80D19ad83579A64c007002"
 
 ACTION=""
 
@@ -36,6 +39,8 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --exit)        ACTION="exit" ;;
         --consolidate) ACTION="consolidate" ;;
+        --eip7002-exit) ACTION="eip7002_exit" ;;
+        --withdraw-change) ACTION="withdraw_change" ;;
         --help|-h)
             cat <<'EOF'
 Usage: ./install/utils/validator_manage.sh [options]
@@ -43,6 +48,9 @@ Usage: ./install/utils/validator_manage.sh [options]
 Options:
   --exit          Initiate voluntary exit for one or more local validators
   --consolidate   Consolidate two local validators via EIP-7251
+  --eip7002-exit  Trigger EIP-7002 exit/withdrawal
+  --withdraw-change
+                  Switch validator withdrawal credentials (0x00->0x01 and 0x01->0x02)
   --help          Show this help
 
 Without options, an interactive menu is shown.
@@ -171,6 +179,56 @@ confirm_destructive() {
     printf "  %bThis action CANNOT be undone.%b\n\n" "${RED}" "${NC}"
     read -rp "  Type 'yes' to confirm: " answer
     [[ "$answer" == "yes" ]]
+}
+
+normalize_hex_input() {
+    local value="$1"
+    value="${value// /}"
+    [[ -z "$value" ]] && return 0
+    [[ "$value" == 0x* ]] || value="0x${value}"
+    printf "%s" "$value"
+}
+
+query_system_contract_fee() {
+    local contract="$1"
+    local el_rpc="$2"
+    local response
+    local fee_hex="0x0"
+
+    response=$(curl -sf --max-time 5 \
+        -X POST "$el_rpc" \
+        -H "Content-Type: application/json" \
+        -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"${contract}\",\"data\":\"0x\"},\"latest\"],\"id\":1}") || { echo "0"; return 0; }
+
+    fee_hex=$(printf "%s" "$response" | \
+        python3 -c "import json, sys; d = json.load(sys.stdin); print(d.get('result', '0x0'))" 2>/dev/null || true)
+
+    [[ -z "$fee_hex" || "$fee_hex" == "null" ]] && fee_hex="0x0"
+
+    python3 -c "print(int('${fee_hex}', 16))" 2>/dev/null || echo 0
+}
+
+get_validator_pubkey() {
+    local data_file="$1"
+    local selector="$2"
+
+    python3 - "$data_file" "$selector" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+selector = sys.argv[2].strip().lower()
+
+for v in data.get("validators", []):
+    index = str(v.get("index", ""))
+    pubkey = (v.get("validator", {}).get("pubkey", "") or "").lower()
+    if selector == index.lower() or selector == pubkey:
+        print(pubkey)
+        sys.exit(0)
+
+sys.exit(1)
+PY
 }
 
 # =============================================================================
@@ -377,7 +435,7 @@ cmd_consolidate() {
       Ethereum address YOU control (the withdrawal address sends the TX).
     • A dynamic fee is paid to the consolidation contract.
 
-  Contract: 0x00431F263cE400f4455c2dCf564e53007Ca4bbBb (mainnet)
+  Contract: 0x0000BBdDc7CE488642fb579F8B00f3a590007251 (mainnet)
 
 EOF
 
@@ -406,24 +464,11 @@ EOF
     [[ "$src_pubkey" != 0x* ]] && src_pubkey="0x${src_pubkey}"
     [[ "$tgt_pubkey" != 0x* ]] && tgt_pubkey="0x${tgt_pubkey}"
 
-    # Query current fee from the consolidation contract (selector: fee() = 0x95600e7e)
-    local fee_hex
-    fee_hex=$(curl -sf --max-time 5 \
-        -X POST "$el_rpc" \
-        -H "Content-Type: application/json" \
-        -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"${CONSOLIDATION_CONTRACT}\",\"data\":\"0x95600e7e\"},\"latest\"],\"id\":1}" \
-        2>/dev/null | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-print(d.get('result', '0x0'))
-" 2>/dev/null || echo "0x0")
-
-    local fee_dec=0
-    if [[ -n "$fee_hex" && "$fee_hex" != "0x" && "$fee_hex" != "0x0" ]]; then
-        fee_dec=$(python3 -c "print(int('${fee_hex}', 16))" 2>/dev/null || echo 0)
-    fi
+    # Query current fee from the consolidation contract (empty calldata returns fee)
+    local fee_dec
+    fee_dec=$(query_system_contract_fee "$CONSOLIDATION_CONTRACT" "$el_rpc")
     local fee_eth
-    fee_eth=$(python3 -c "print(f'{${fee_dec} / 1e18:.8f}')" 2>/dev/null || echo "unknown")
+    fee_eth=$(python3 -c "print(${fee_dec} / 1e18)")
 
     # Calldata: source_pubkey_bytes (48) + target_pubkey_bytes (48) = 96 bytes total
     local src_hex="${src_pubkey#0x}"
@@ -472,6 +517,234 @@ print(d.get('result', '0x0'))
 }
 
 # =============================================================================
+# EIP-7002 EL-TRIGGERED EXIT/WITHDRAWAL
+# =============================================================================
+
+cmd_eip7002_exit() {
+    local el_rpc="http://127.0.0.1:8545"
+    local amount_hex
+    local src_pubkey
+    local amount_gwei
+    local withdrawal_addr
+    local fee_dec
+    local fee_eth
+    local calldata
+
+    printf "\n"
+    log_info "=== EIP-7002 Withdrawal/Exit Trigger ==="
+    printf "\n"
+    cat <<'EOF'
+  This flow submits an EL-triggered withdrawal/exit via the official 7002 contract.
+
+  Request payload format:
+    validator_pubkey (48-byte) || amount (8-byte big-endian gwei)
+
+  Amount = 0 indicates full exit.
+
+  Contract: 0x00000961Ef480Eb55e80D19ad83579A64c007002 (mainnet)
+
+EOF
+
+    printf "  Enter the validator pubkey (0x...): "
+    read -r src_pubkey
+    printf "\n"
+    printf "  Enter amount in gwei (0 = full exit): "
+    read -r amount_gwei
+    printf "\n"
+    printf "  Enter the withdrawal address sender (for --from): "
+    read -r withdrawal_addr
+
+    src_pubkey=$(normalize_hex_input "$src_pubkey")
+    if [[ -z "$src_pubkey" || ! "$src_pubkey" =~ ^0x[0-9A-Fa-f]{96}$ ]]; then
+        log_warn "Invalid source pubkey format. Expected 0x + 96 hex chars."
+        return 0
+    fi
+    if [[ -z "$withdrawal_addr" || ! "$withdrawal_addr" =~ ^0x[0-9A-Fa-f]{40}$ ]]; then
+        log_warn "Invalid withdrawal address."
+        return 0
+    fi
+    if [[ -z "$amount_gwei" ]]; then
+        amount_gwei=0
+    fi
+    if [[ ! "$amount_gwei" =~ ^[0-9]+$ ]]; then
+        log_warn "Amount must be a decimal non-negative integer (gwei)."
+        return 0
+    fi
+
+    amount_hex=$(python3 -c "
+import sys
+amount = int(sys.argv[1])
+if amount < 0 or amount >= (1 << 64):
+    raise ValueError
+print(f'{amount:016x}')
+" "$amount_gwei" 2>/dev/null) || {
+        log_warn "Amount must be a u64 gwei value (0 <= amount < 2^64)."
+        return 0
+    }
+
+    fee_dec=$(query_system_contract_fee "$WITHDRAWAL_CONTRACT" "$el_rpc")
+    fee_eth=$(python3 -c "print(${fee_dec} / 1e18)")
+    calldata="0x${src_pubkey#0x}${amount_hex}"
+
+    printf "\n  Command to run:\n\n"
+    printf "    cast send %s \\\n" "$WITHDRAWAL_CONTRACT"
+    printf "      --value %swei \\\n" "$fee_dec"
+    printf "      --data %s \\\n" "$calldata"
+    printf "      --rpc-url %s \\\n" "$el_rpc"
+    printf "      --from %s\n\n" "$withdrawal_addr"
+    printf "  Estimated fee: ~%s ETH (%s wei)\n\n" "$fee_eth" "$fee_dec"
+
+    if ! command -v cast &>/dev/null; then
+        log_warn "'cast' not found. Install Foundry: curl -L https://foundry.paradigm.xyz | bash && foundryup"
+        return 0
+    fi
+
+    if ! confirm_destructive "This action submits an irreversible EL-triggered withdrawal/exit."; then
+        log_warn "Aborted."
+        return 0
+    fi
+
+    cast send "$WITHDRAWAL_CONTRACT" \
+        --value "${fee_dec}wei" \
+        --data "${calldata}" \
+        --rpc-url "$el_rpc" \
+        --from "$withdrawal_addr"
+}
+
+# =============================================================================
+# WITHDRAWAL-CREDENTIAL CHANGE
+# =============================================================================
+
+cmd_withdraw_change() {
+    local beacon_url
+    beacon_url=$(detect_beacon_url)
+    local el_rpc="http://127.0.0.1:8545"
+    local selection
+    local flow
+
+    printf "\n"
+    log_info "=== Withdrawal Credential Change ==="
+    printf "\n"
+    cat <<'EOF'
+  Select one validator and perform one of:
+    1) 0x00 -> 0x01 (BLS-to-execution credential change via ethdo)
+    2) 0x01 -> 0x02 (self-consolidation, source == target)
+
+EOF
+
+    local tmpfile
+    tmpfile=$(mktemp /tmp/vmgr_XXXXXX.json)
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmpfile'" EXIT
+
+    load_local_validators "$tmpfile" || return 0
+    print_local_validators "$tmpfile"
+
+    printf "  Enter validator index or pubkey to update:\n"
+    read -rp "  Selection: " selection
+    if [[ -z "$selection" ]]; then
+        log_warn "No selection made. Aborting."
+        return 0
+    fi
+
+    printf "\n  Choose flow:\n"
+    printf "  [1] 0x00 -> 0x01 (ethdo credentials set)\n"
+    printf "  [2] 0x01 -> 0x02 (self-consolidation)\n"
+    read -rp "  Choice: " flow
+
+    case "$flow" in
+        1)
+            local withdrawal_addr
+            printf "\n  Enter new withdrawal address (0x...): "
+            read -rp "" withdrawal_addr
+            if [[ ! "$withdrawal_addr" =~ ^0x[0-9A-Fa-f]{40}$ ]]; then
+                log_warn "Invalid withdrawal address."
+                return 0
+            fi
+            if ! command -v ethdo &>/dev/null; then
+                log_warn "'ethdo' not found. Install with: go install github.com/wealdtech/ethdo@latest"
+                return 0
+            fi
+
+            printf "\n  Command to run:\n\n"
+            printf "    ethdo validator credentials set --validator %s --withdrawal-address %s --connection %s\n\n" \
+                "$selection" "$withdrawal_addr" "$beacon_url"
+
+            if ! confirm_destructive "BLS-to-execution credential update cannot be reverted automatically."; then
+                log_warn "Aborted."
+                return 0
+            fi
+
+            log_info "Submitting withdrawal credentials update..."
+            ethdo validator credentials set \
+                --validator "$selection" \
+                --withdrawal-address "$withdrawal_addr" \
+                --connection "$beacon_url"
+            ;;
+        2)
+            local source_pubkey
+            local fee_dec
+            local fee_eth
+            local calldata
+            local priv_key
+
+            if [[ "$selection" == [0-9]* ]]; then
+                source_pubkey=$(get_validator_pubkey "$tmpfile" "$selection") || {
+                    log_warn "Could not resolve validator pubkey from selection: $selection"
+                    return 0
+                }
+            else
+                source_pubkey=$(normalize_hex_input "$selection")
+            fi
+            if [[ -z "$source_pubkey" || ! "$source_pubkey" =~ ^0x[0-9A-Fa-f]{96}$ ]]; then
+                log_warn "Source pubkey could not be normalized to 0x + 96 hex chars."
+                return 0
+            fi
+
+            fee_dec=$(query_system_contract_fee "$CONSOLIDATION_CONTRACT" "$el_rpc")
+            fee_eth=$(python3 -c "print(${fee_dec} / 1e18)")
+            calldata="0x${source_pubkey#0x}${source_pubkey#0x}"
+
+            printf "\n  Self-consolidation command to run (source == target):\n\n"
+            printf "    cast send %s \\\n" "$CONSOLIDATION_CONTRACT"
+            printf "      --value %swei \\\n" "$fee_dec"
+            printf "      --data %s \\\n" "$calldata"
+            printf "      --rpc-url %s \\\n" "$el_rpc"
+            printf "      --private-key <WITHDRAWAL_ADDRESS_PRIVATE_KEY>\n\n"
+            printf "  Estimated fee: ~%s ETH (%s wei)\n\n" "$fee_eth" "$fee_dec"
+
+            if ! command -v cast &>/dev/null; then
+                log_warn "'cast' not found. Install Foundry: curl -L https://foundry.paradigm.xyz | bash && foundryup"
+                return 0
+            fi
+
+            if ! confirm_destructive "Self-consolidation upgrades 0x01 withdrawal credentials to 0x02 and exits the source validator."; then
+                log_warn "Aborted."
+                return 0
+            fi
+
+            read -rsp "  Private key of withdrawal address (hidden): " priv_key
+            printf "\n"
+            if [[ -z "$priv_key" ]]; then
+                log_warn "No private key provided. Aborting."
+                return 0
+            fi
+
+            log_info "Submitting self-consolidation transaction..."
+            cast send "$CONSOLIDATION_CONTRACT" \
+                --value "${fee_dec}wei" \
+                --data "${calldata}" \
+                --rpc-url "$el_rpc" \
+                --private-key "$priv_key"
+            ;;
+        *)
+            log_warn "Invalid choice: $flow"
+            return 0
+            ;;
+    esac
+}
+
+# =============================================================================
 # INTERACTIVE MENU
 # =============================================================================
 
@@ -493,6 +766,8 @@ show_menu() {
     printf "  [1] List local validators\n"
     printf "  [2] Voluntary exit  (irreversible)\n"
     printf "  [3] Consolidate validators  (EIP-7251)\n"
+    printf "  [4] EIP-7002 exit / withdrawal\n"
+    printf "  [5] Withdrawal credential change\n"
     printf "  [q] Quit\n\n"
     read -rp "  Choice: " choice
 
@@ -500,6 +775,8 @@ show_menu() {
         1) "$SCRIPT_DIR/validator_list.sh" ;;
         2) cmd_exit ;;
         3) cmd_consolidate ;;
+        4) cmd_eip7002_exit ;;
+        5) cmd_withdraw_change ;;
         q|Q|quit) printf "  Bye.\n"; exit 0 ;;
         *) log_warn "Invalid choice: ${choice}"; show_menu ;;
     esac
@@ -513,6 +790,8 @@ main() {
     case "$ACTION" in
         exit)        cmd_exit ;;
         consolidate) cmd_consolidate ;;
+        eip7002_exit) cmd_eip7002_exit ;;
+        withdraw_change) cmd_withdraw_change ;;
         "")          show_menu ;;
     esac
 }

--- a/install/utils/validator_manage.sh
+++ b/install/utils/validator_manage.sh
@@ -518,11 +518,10 @@ EOF
     fi
 
     log_info "Submitting consolidation transaction..."
-    cast send "${CONSOLIDATION_CONTRACT}" \
+    ETH_PRIVATE_KEY="${priv_key}" cast send "${CONSOLIDATION_CONTRACT}" \
         --value "${fee_dec}wei" \
         --data "${calldata}" \
-        --rpc-url "${el_rpc}" \
-        --private-key "${priv_key}"
+        --rpc-url "${el_rpc}"
 
     log_info "Transaction submitted. Monitor the source validator for a pending exit."
 }
@@ -680,6 +679,9 @@ EOF
             printf "\n  Command to run:\n\n"
             printf "    ethdo validator credentials set --validator %s --withdrawal-address %s --connection %s\n\n" \
                 "$selection" "$withdrawal_addr" "$beacon_url"
+            printf "  Note: ethdo needs the validator MNEMONIC to sign this change; it will\n"
+            printf "  prompt for it interactively (or accepts --mnemonic). Never paste the\n"
+            printf "  mnemonic into shell history or scripts.\n\n"
 
             if ! confirm_destructive "BLS-to-execution credential update cannot be reverted automatically."; then
                 log_warn "Aborted."
@@ -742,11 +744,10 @@ EOF
             fi
 
             log_info "Submitting self-consolidation transaction..."
-            cast send "$CONSOLIDATION_CONTRACT" \
+            ETH_PRIVATE_KEY="${priv_key}" cast send "$CONSOLIDATION_CONTRACT" \
                 --value "${fee_dec}wei" \
                 --data "${calldata}" \
-                --rpc-url "$el_rpc" \
-                --private-key "$priv_key"
+                --rpc-url "$el_rpc"
             ;;
         *)
             log_warn "Invalid choice: $flow"

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,15 @@ Important constraints:
 - [Safety reference](https://github.com/chimera-defi/eth2-quickstart/blob/master/skills/eth2-quickstart/references/safety.md): Confirmation boundaries and secret-preservation rules.
 - [Sizing reference](https://github.com/chimera-defi/eth2-quickstart/blob/master/skills/eth2-quickstart/references/sizing.md): Host sizing guidance before install.
 
+## Validator Management
+
+Agent-usable validator operations (mainnet, post-Pectra). Full guide: [Validator management](https://github.com/chimera-defi/eth2-quickstart/blob/master/docs/VALIDATOR_MANAGEMENT.md).
+
+- List + filter: `./scripts/eth2qs.sh validators --json [--min-balance N] [--max-balance N] [--withdrawal-type 0x00|0x01|0x02] [--status S]`. Read-only MCP tool: `eth2qs_validators(min_balance, max_balance, withdrawal_type, status)`.
+- Deploy + keygen (0x01 or 0x02 compounding): `./scripts/eth2qs.sh validator-deploy` (wraps ethstaker-deposit-cli; generates keys + deposit_data.json, prints the deposit command, no auto-submit). Provide the keystore password via the `ETHQS_KEYSTORE_PASSWORD` env var, not the CLI flag.
+- Modify (CLI only — irreversible, funds-affecting): `validator-exit`, `validator-withdrawal-changes` (0x00→0x01), `validator-manage --consolidate` (EIP-7251, incl. 0x01→0x02), `validator-manage --eip7002-exit` (EIP-7002).
+- Agent safety: funds-affecting operations are NOT executed via MCP. The read-only MCP tool `eth2qs_validator_op_preview(operation)` returns the exact node CLI command to run; execution + confirmation happen on the node CLI.
+
 ## Optional
 
 - [Full agent context](https://raw.githubusercontent.com/chimera-defi/eth2-quickstart/master/llms-full.txt): Expanded agent-facing summary of install, operation, cleanup, and sharing paths.

--- a/mcp_server/eth2qs_mcp_server.py
+++ b/mcp_server/eth2qs_mcp_server.py
@@ -39,6 +39,8 @@ from mcp_server.eth2qs_mcp_tools import (  # noqa: E402
     stats_json,
     stop,
     update_check_json,
+    validators_list,
+    validator_op_preview,
 )
 
 try:
@@ -207,6 +209,33 @@ def eth2qs_cleanup_host_dry_run() -> dict:
 def eth2qs_monad_install(confirm: bool = False, confirmation_token: str = "") -> dict:
     """Run the explicit Monad install path. Requires confirm=true and confirmation_token='apply'."""
     return monad_install(confirm=confirm, confirmation_token=confirmation_token)
+
+
+@mcp.tool(name="eth2qs_validators")
+def eth2qs_validators(
+    min_balance: float | None = None,
+    max_balance: float | None = None,
+    withdrawal_type: str | None = None,
+    status: str | None = None,
+) -> dict:
+    """Read-only: list local validators with index/status/balance/withdrawal
+    credentials. Optional filters: min_balance/max_balance (ETH),
+    withdrawal_type (0x00 BLS / 0x01 execution / 0x02 compounding), status substring."""
+    return validators_list(
+        min_balance=min_balance,
+        max_balance=max_balance,
+        withdrawal_type=withdrawal_type,
+        status=status,
+    )
+
+
+@mcp.tool(name="eth2qs_validator_op_preview")
+def eth2qs_validator_op_preview(operation: str) -> dict:
+    """Read-only: return the exact node CLI command for a funds-affecting validator
+    operation (exit, withdrawal-change, consolidate, eip7002-exit, create-0x02,
+    deploy). These are NOT executed via MCP (irreversible, need secrets); run the
+    returned command on the node CLI where it prompts for confirmation."""
+    return validator_op_preview(operation=operation)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/mcp_server/eth2qs_mcp_tools.py
+++ b/mcp_server/eth2qs_mcp_tools.py
@@ -251,6 +251,69 @@ def monad_install(*, confirm: bool = False, confirmation_token: str = "") -> Dic
     return _eth2qs("monad-install")
 
 
+def _validate_withdrawal_type(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    v = value.lower()
+    if v not in ("0x00", "0x01", "0x02"):
+        raise ValueError("withdrawal_type must be 0x00, 0x01, or 0x02")
+    return v
+
+
+def validators_list(
+    *,
+    min_balance: Optional[float] = None,
+    max_balance: Optional[float] = None,
+    withdrawal_type: Optional[str] = None,
+    status: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Read-only: list local validators (index, status, balance, withdrawal
+    credentials), optionally filtered by balance (ETH), withdrawal type
+    (0x00/0x01/0x02), or status substring."""
+    args = ["validators", "--json"]
+    if min_balance is not None:
+        args += ["--min-balance", str(float(min_balance))]
+    if max_balance is not None:
+        args += ["--max-balance", str(float(max_balance))]
+    wt = _validate_withdrawal_type(withdrawal_type)
+    if wt:
+        args += ["--withdrawal-type", wt]
+    if status:
+        args += ["--status", str(status)]
+    return _eth2qs(*args)
+
+
+VALIDATOR_OPS = {
+    "exit": "validator-exit",
+    "withdrawal-change": "validator-withdrawal-changes",
+    "consolidate": "validator-manage --consolidate",
+    "eip7002-exit": "validator-manage --eip7002-exit",
+    "create-0x02": "validator-create-0x02",
+    "deploy": "validator-deploy",
+}
+
+
+def validator_op_preview(*, operation: str) -> Dict[str, Any]:
+    """Read-only: returns the exact node CLI command for a funds-affecting
+    validator operation. These operations are intentionally NOT executed via
+    MCP — they are irreversible and require secrets/keys; run them on the node
+    CLI where they prompt for confirmation interactively."""
+    if operation not in VALIDATOR_OPS:
+        raise ValueError("operation must be one of: " + ", ".join(sorted(VALIDATOR_OPS)))
+    return {
+        "operation": operation,
+        "preview": True,
+        "executed": False,
+        "note": (
+            "Irreversible/funds-affecting validator operations are not executed "
+            "via MCP. Run the command below on the node; it prompts for "
+            "confirmation (and any secrets) interactively."
+        ),
+        "cli_command": f"./scripts/eth2qs.sh {VALIDATOR_OPS[operation]}",
+        "wrapper": str(eth2qs_path()),
+    }
+
+
 TOOL_NAMES = (
     "eth2qs_info",
     "eth2qs_help",
@@ -276,6 +339,8 @@ TOOL_NAMES = (
     "eth2qs_clean_data_dry_run",
     "eth2qs_cleanup_host_dry_run",
     "eth2qs_monad_install",
+    "eth2qs_validators",
+    "eth2qs_validator_op_preview",
 )
 
 
@@ -303,6 +368,8 @@ def server_info() -> Dict[str, Any]:
                 "eth2qs_logs",
                 "eth2qs_clean_data_dry_run",
                 "eth2qs_cleanup_host_dry_run",
+                "eth2qs_validators",
+                "eth2qs_validator_op_preview",
             ],
             "mutating_confirm_required": [
                 "eth2qs_ensure_apply",
@@ -339,6 +406,8 @@ def server_info() -> Dict[str, Any]:
                 "confirmation_token": "apply",
             },
             "eth2qs_repair_apply": {"confirm": True, "confirmation_token": "apply"},
+            "eth2qs_validators": {"withdrawal_type": "0x01", "min_balance": 32},
+            "eth2qs_validator_op_preview": {"operation": "exit"},
             "eth2qs_clean_data_dry_run": {},
         },
     }

--- a/scripts/eth2qs.sh
+++ b/scripts/eth2qs.sh
@@ -39,10 +39,12 @@ Operations:
   update-all [args...]    Comprehensive updater
 
 Validator:
-  validators [--json]               List active validators with index, status, and balance
+  validators [--json] [--min-balance N] [--max-balance N] [--withdrawal-type 0x00|0x01|0x02] [--status S]
+                                   List active validators (filter by balance / withdrawal type / status)
   validator-exit                   Exit local validators using the managed exit flow
   validator-create-0x02            Create modern compounding validators with 0x02 credentials
-  validator-manage [--exit|--consolidate]   Manage validators: voluntary exits or EIP-7251 consolidations
+  validator-deploy [opts]          Generate validator keys + deposit_data.json (0x01 or 0x02), import, print deposit cmd
+  validator-manage [--exit|--consolidate|--eip7002-exit|--withdraw-change]   Manage validators: exits, EIP-7251/7002, credential changes
   validator-withdrawal-changes      Generate or submit BLS-to-execution changes for 0x00 validators
 
 Utility:
@@ -166,6 +168,9 @@ case "$cmd" in
         ;;
     validator-create-0x02)
         run_cmd "$ROOT_DIR/install/utils/validator_create_0x02.sh" "$@"
+        ;;
+    validator-deploy)
+        run_cmd "$ROOT_DIR/install/utils/validator_deploy.sh" "$@"
         ;;
     validator-manage)
         run_cmd "$ROOT_DIR/install/utils/validator_manage.sh" "$@"

--- a/skills/eth2-quickstart/references/commands.md
+++ b/skills/eth2-quickstart/references/commands.md
@@ -11,11 +11,14 @@ Canonical command surface:
 - Run Phase 2 install: `./scripts/eth2qs.sh phase2 --execution=geth --consensus=prysm --mev=mev-boost`
 - Run explicit Monad install: `./scripts/eth2qs.sh monad-install`
 - List active validators on the current node: `./scripts/eth2qs.sh validators --json`
-- Show validator inventory freshness and withdrawal status in the JSON output: `./scripts/eth2qs.sh validators --json`
+- Filter validators by balance / withdrawal type / status: `./scripts/eth2qs.sh validators --json --min-balance 32 --withdrawal-type 0x01 --status active_ongoing` (withdrawal-type: 0x00 BLS / 0x01 execution / 0x02 compounding)
+- Read-only validator listing for agents (MCP): tool `eth2qs_validators(min_balance, max_balance, withdrawal_type, status)`
+- Deploy validators + generate keys/deposit data (0x01 or 0x02): `./scripts/eth2qs.sh validator-deploy --num-validators 1 --withdrawal-type 0x02 --withdrawal-address 0xYourAddr` (set keystore password via `ETHQS_KEYSTORE_PASSWORD`; prints the deposit command, no auto-submit)
 - Focused exit checklist / client-specific voluntary exit flow: `./scripts/eth2qs.sh validator-exit`
 - Preview, generate, or submit BLS-to-execution changes for 0x00 validators: `./scripts/eth2qs.sh validator-withdrawal-changes --dry-run --generate --submit --yes`
 - Focused 0x02 compounding validator creation flow: `./scripts/eth2qs.sh validator-create-0x02`
-- Combined validator menu for exits and consolidations: `./scripts/eth2qs.sh validator-manage`
+- Combined validator menu (exit / consolidate / EIP-7002 exit / withdrawal-credential change): `./scripts/eth2qs.sh validator-manage [--exit|--consolidate|--eip7002-exit|--withdraw-change]`
+- Agent preview of a funds-affecting validator op (MCP, returns the CLI command, never executes): tool `eth2qs_validator_op_preview(operation)` where operation is exit|withdrawal-change|consolidate|eip7002-exit|create-0x02|deploy
 - Health/status: `./scripts/eth2qs.sh doctor --json`
 - Monitoring/triage: `./scripts/eth2qs.sh stats --json`
 - Structured service debug: `./scripts/eth2qs.sh debug --json --service cl`

--- a/test/validator_fork_test.sh
+++ b/test/validator_fork_test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Validator system-contract verification against mainnet (live RPC or Foundry fork).
+#
+# Guards the "wrong system-contract address" bug class (e.g. a consolidation
+# address with no code) and confirms the EIP-7002 / EIP-7251 fee mechanism the
+# validator_manage.sh flows depend on. Network-gated: skips cleanly if cast or
+# the RPC is unavailable.
+#
+# Usage: ETH_RPC_URL=<url> ./test/validator_fork_test.sh
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RPC="${ETH_RPC_URL:-https://rpc.sharedtools.org/rpc}"
+CAST="${CAST_BIN:-$HOME/.foundry/bin/cast}"
+[[ -x "$CAST" ]] || CAST="$(command -v cast 2>/dev/null || true)"
+
+# Canonical mainnet (post-Pectra) system contracts.
+DEPOSIT_CONTRACT="0x00000000219ab540356cBB839Cbe05303d7705Fa"
+EIP7002_CONTRACT="0x00000961Ef480Eb55e80D19ad83579A64c007002"   # triggerable withdrawals/exits
+EIP7251_CONTRACT="0x0000BBdDc7CE488642fb579F8B00f3a590007251"   # consolidation
+
+PASS=0; FAIL=0
+ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
+bad()  { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+if [[ -z "$CAST" ]]; then
+    echo "SKIP: cast (Foundry) not found; install via foundryup. Skipping fork test."
+    exit 0
+fi
+if ! $CAST chain-id --rpc-url "$RPC" >/dev/null 2>&1; then
+    echo "SKIP: RPC $RPC unreachable; skipping fork test."
+    exit 0
+fi
+
+CHAIN_ID="$($CAST chain-id --rpc-url "$RPC" 2>/dev/null || echo 0)"
+echo "RPC=$RPC chain-id=$CHAIN_ID"
+if [[ "$CHAIN_ID" == "1" ]]; then ok "RPC is mainnet (chain-id 1)"; else bad "expected mainnet chain-id 1, got $CHAIN_ID"; fi
+
+has_code() {
+    local code
+    code="$($CAST code "$1" --rpc-url "$RPC" 2>/dev/null || echo 0x)"
+    [[ -n "$code" && "$code" != "0x" ]]
+}
+
+# 1) Canonical system contracts must have code.
+for pair in "deposit:$DEPOSIT_CONTRACT" "EIP-7002:$EIP7002_CONTRACT" "EIP-7251:$EIP7251_CONTRACT"; do
+    name="${pair%%:*}"; addr="${pair#*:}"
+    if has_code "$addr"; then ok "$name contract has code ($addr)"; else bad "$name contract has NO code ($addr)"; fi
+done
+
+# 2) Fee mechanism: empty-calldata eth_call returns the current fee (uint256 wei).
+for pair in "EIP-7002:$EIP7002_CONTRACT" "EIP-7251:$EIP7251_CONTRACT"; do
+    name="${pair%%:*}"; addr="${pair#*:}"
+    fee="$($CAST call "$addr" --rpc-url "$RPC" 2>/dev/null || true)"
+    if [[ -n "$fee" && "$fee" =~ ^0x[0-9a-fA-F]+$ ]]; then
+        ok "$name fee query (empty calldata) returns a value: $((fee)) wei"
+    else
+        bad "$name fee query returned no value (got '$fee')"
+    fi
+done
+
+# 3) Regression guard: every 0x-address referenced in validator_manage.sh as a
+#    system contract must have code on mainnet (catches the 0x00431F26... class).
+MANAGE="$PROJECT_ROOT/install/utils/validator_manage.sh"
+if [[ -f "$MANAGE" ]]; then
+    mapfile -t addrs < <(grep -oE '0x[0-9a-fA-F]{40}' "$MANAGE" | sort -u)
+    for addr in "${addrs[@]}"; do
+        if has_code "$addr"; then
+            ok "validator_manage address has code: $addr"
+        else
+            bad "validator_manage references address with NO code: $addr"
+        fi
+    done
+fi
+
+echo "=== validator_fork_test: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Makes validator management fully usable **from an agent** (MCP + CLI) and verifies the prysm/geth path + helper scripts. Builds on the existing validator scripts (list/exit/withdrawal-changes/create-0x02/manage) — fixing real bugs, adding filtering + deposit, and exposing everything to the MCP agent surface.

### Verified
- **prysm + geth** Docker E2E: **30/30 pass**.
- Helper scripts: python suite **29/29**, MCP server contract **25/25**, skill-command-mapping **24/24**, full `bash -n` sweep clean.
- MCP/CLI agent surface smoke-tested end-to-end.

### List + filter (the ask)
- `validators` now filters by `--min-balance`/`--max-balance` (ETH), `--withdrawal-type 0x00|0x01|0x02`, `--status` (table + `--json`), via a reusable `validator_filter.py` (unit test: 11 cases). Filter errors surface instead of silently returning unfiltered data.

### Modify (fixes + additions)
- **Bug fixed:** consolidation used `0x00431F26…` which has **no code on mainnet**; corrected to canonical **EIP-7251 `0x0000BBdD…7251`**, added **EIP-7002 `0x…007002`**. Fee now read via **empty-calldata** `eth_call` (the old function-selector query was wrong).
- Added **EIP-7002 EL-triggered exit/withdrawal** (`pubkey48 + amount8` BE gwei) and **withdrawal-credential change** (0x00→0x01 via `ethdo`; 0x01→0x02 via EIP-7251 self-consolidation). Strict `0x`+96-hex pubkey validation. Every broadcast is preview-first + `confirm_destructive`-gated.

### Deploy + keygen
- New `validator_deploy.sh` wraps `ethstaker-deposit-cli` → keystores + `deposit_data.json` for **0x01 or 0x02 (compounding)**, optional client import, prints the deposit command (no auto-submit). Password via `ETHQS_KEYSTORE_PASSWORD` env or prompt (flag discouraged + warned); secrets 600, mnemonic never echoed. Pinned `ethdo` + `ethstaker-deposit-cli` install added.

### Agent connectors (MCP)
- New read-only `eth2qs_validators` (list + filters) and `eth2qs_validator_op_preview` (returns the exact node CLI command for each mutation, **never executes / no secrets**). Irreversible funds ops stay on the CLI by design.

### Testing — Foundry mainnet fork
- `test/validator_fork_test.sh` (fork `rpc.sharedtools.org`, chain-id 1) asserts deposit/EIP-7002/EIP-7251 have code + the empty-calldata fee, and **regression-guards** that every system-contract address in `validator_manage.sh` has on-chain code.

## Review notes (advisor pass, codex)
- All broadcast paths confirm-gated; MCP validator tools read-only — confirmed sound.
- Residual P2: `ethstaker-deposit-cli --non_interactive` takes the keystore password as an arg, so it's briefly visible in the child process's `ps` line (upstream-tool limitation; documented in-script).

## Test plan
- [x] geth+prysm E2E 30/30; python 29/29; MCP 25/25; mapping 24/24; fork test 8/8; filter 11/11; withdrawal-changes regression 3/3
- [ ] Maintainer: review the MCP safety posture (read-only + preview-only mutations) and the keystore-password handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)