### PR TITLE
feat(geth): prune pre-merge freezer history to reclaim disk

### DIFF
--- a/HANDOFF_diskcleanup.md
+++ b/HANDOFF_diskcleanup.md
@@ -1,0 +1,89 @@
+# Disk cleanup handoff — geth state bloat / freezer pruning
+
+_Last updated: 2026-06-16_
+
+## TL;DR
+
+- Root `/dev/md2` hit **99% full** (1.7T/1.8T, ~35G free). Geth datadir
+  `/home/eth/.ethereum/geth` is **~1.6T**.
+- `geth snapshot prune-state` **does not work and never will** on this node —
+  it's the wrong tool for our setup.
+- The fix is **`geth prune-history --history.chain postmerge`**, wrapped in
+  [`clean_geth_history.sh`](./clean_geth_history.sh).
+- There is **only one geth database**. A whole-disk scan found exactly one
+  `chaindata` + one `ancient`. No second/duplicate db.
+
+## Why `prune-state` fails
+
+Geth runs the **path-based state scheme (PBSS)**, not the old hash scheme.
+`geth snapshot prune-state` is the hash-scheme offline pruner; under PBSS geth
+exits with:
+
+```
+CRIT  Offline pruning is not required for path scheme
+```
+
+PBSS prunes live state **online/automatically**, so there is genuinely nothing
+for `prune-state` to do. Evidence the node is PBSS:
+`/home/eth/.ethereum/geth/triedb/merkle.journal` (~344M) and an `ancient/state`
+freezer dir.
+
+The stale `statebloom…bf.gz.tmp` (Oct 2023, ~196K) in the geth dir is a
+leftover from an old hash-scheme prune attempt from before the PBSS migration.
+Harmless; can be deleted.
+
+## Where the space actually goes
+
+| Component | Size | Touched by `prune-state`? | Touched by `prune-history`? |
+|---|---|---|---|
+| `ancient/chain` freezer (bodies + receipts, genesis→now) | **~1.2T** | ❌ never | ✅ pre-merge dropped |
+| live Pebble state db (`*.sst`, ~11.8k files) | ~374G | (PBSS self-prunes) | ❌ |
+
+So the dominant hog is the freezer, which only `prune-history` can shrink.
+
+## The fix
+
+`geth prune-history --history.chain postmerge` removes **pre-merge** block
+bodies + receipts (genesis → Sep 2022 merge), keeps headers and everything
+post-merge. A staking node does not need pre-merge history. Expected reclaim:
+**~500–800G**.
+
+### Run it (in screen, geth must be stopped — it's offline)
+
+```bash
+cd ~/eth2-quickstart
+screen -S geth-prune ./clean_geth_history.sh
+# detach: Ctrl-A then D   |   reattach: screen -r geth-prune
+```
+
+Or manually:
+
+```bash
+screen -S geth-prune
+sudo systemctl stop eth1
+geth prune-history --history.chain postmerge --datadir /home/eth/.ethereum
+#   ^ run as the eth user, NOT sudo (sudo would use /root/.ethereum)
+sudo systemctl start eth1
+# Ctrl-A then D to detach
+```
+
+The script then patches `/etc/systemd/system/eth1.service` to add
+`--history.chain postmerge` so the freezer stays pruned and pre-merge history
+isn't re-fetched. `install/execution/geth.sh` also sets this flag for fresh
+installs.
+
+### Caveats
+
+- **Offline + validator downtime**: geth is down for the duration (likely a few
+  hours on ~1.2T). The CL/validator misses attestations until geth restarts and
+  catches up the gap. Run in a low-duty window.
+- **One-way**: un-pruning means re-downloading history.
+- Does **not** shrink the ~374G live state. If that needs to come down to
+  ~130–150G, do a separate from-scratch snap re-sync (bigger downtime; not the
+  emergency). PBSS keeps live state self-pruned in normal operation.
+
+## Did NOT need
+
+- Re-syncing from scratch — rebuilds the same 1.2T freezer; only worth it for
+  the live-state reclaim, separately.
+- A second datadir cleanup — there is only one.

--- a/clean_geth_history.sh
+++ b/clean_geth_history.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+source ./exports.sh
+
+# ---------------------------------------------------------------------------
+# clean_geth_history.sh - reclaim disk by pruning geth's ancient freezer
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS (see HANDOFF_diskcleanup.md for the full story):
+#
+#   `geth snapshot prune-state` DOES NOT WORK on this node and never will.
+#   Our geth runs the path-based state scheme (PBSS), and geth refuses
+#   offline state pruning under PBSS:
+#       CRIT  Offline pruning is not required for path scheme
+#   PBSS prunes live state online/automatically, so there is nothing for
+#   prune-state to do.
+#
+#   The disk hog is the ANCIENT FREEZER (~1.2T of the ~1.6T geth dir):
+#   block bodies + receipts back to genesis. prune-state never touches that.
+#   The right tool is `geth prune-history`, which drops PRE-MERGE bodies
+#   and receipts (keeping headers + everything post-merge). A staking node
+#   does not need pre-merge history.
+#
+# WHAT THIS DOES:
+#   1. stops geth (eth1) - this is an OFFLINE op; the validator misses
+#      attestations until geth is back and caught up. Run in a low-duty window.
+#   2. runs `geth prune-history --history.chain postmerge` as the eth user
+#      (must match the datadir owner - do NOT sudo this, it would use the
+#       wrong /root/.ethereum datadir).
+#   3. patches /etc/systemd/system/eth1.service to add `--history.chain
+#      postmerge` so the freezer stays pruned and pre-merge history is not
+#      re-fetched (idempotent).
+#   4. restarts geth and reports disk reclaimed.
+#
+# Run inside screen/tmux - the prune on ~1.2T takes a while:
+#   screen -S geth-prune ./clean_geth_history.sh
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+GETH_DATADIR="${GETH_DATADIR:-$HOME/.ethereum}"
+SERVICE_FILE="/etc/systemd/system/eth1.service"
+
+echo "=== disk BEFORE ==="
+df -hT /
+du -sh "$GETH_DATADIR/geth/chaindata/ancient" 2>/dev/null || true
+
+echo "=== stopping geth (eth1) - validator will miss attestations until restart ==="
+sudo systemctl stop eth1
+
+echo "=== pruning pre-merge history from the freezer (this takes a while) ==="
+# NOTE: run as the eth user (no sudo) so it uses the eth-owned datadir.
+geth prune-history --history.chain postmerge --datadir "$GETH_DATADIR"
+
+echo "=== patching $SERVICE_FILE to keep history pruned (--history.chain postmerge) ==="
+if ! grep -q -- '--history.chain' "$SERVICE_FILE"; then
+  # append the flag to the geth ExecStart line
+  sudo sed -i -E 's#(ExecStart\s*=\s*/usr/bin/geth)#\1 --history.chain postmerge#' "$SERVICE_FILE"
+  sudo systemctl daemon-reload
+  echo "added --history.chain postmerge to ExecStart"
+else
+  echo "--history.chain already present, leaving service file as-is"
+fi
+
+echo "=== restarting geth (eth1) ==="
+sudo systemctl start eth1
+
+echo "=== disk AFTER ==="
+df -hT /
+du -sh "$GETH_DATADIR/geth/chaindata/ancient" 2>/dev/null || true
+
+echo "Done. Tail geth with: sudo journalctl -fu eth1"
+echo "Confirm CL reconnects to EL once geth finishes catching up the gap."

--- a/clean_geth_history.sh
+++ b/clean_geth_history.sh
@@ -36,6 +36,14 @@ source ./exports.sh
 
 set -euo pipefail
 
+# If run as root (e.g. via sudo) without an explicit GETH_DATADIR, $HOME resolves
+# to /root and the default datadir would be /root/.ethereum — the wrong location.
+# Derive the correct path from LOGIN_UNAME (set in exports.sh) instead.
+if [[ "${EUID:-$(id -u)}" -eq 0 && -z "${GETH_DATADIR:-}" ]]; then
+    GETH_DATADIR="/home/${LOGIN_UNAME}/.ethereum"
+    echo "NOTE: running as root — using GETH_DATADIR=$GETH_DATADIR (from LOGIN_UNAME=$LOGIN_UNAME)"
+    echo "      Override with: GETH_DATADIR=/custom/path $0"
+fi
 GETH_DATADIR="${GETH_DATADIR:-$HOME/.ethereum}"
 SERVICE_FILE="/etc/systemd/system/eth1.service"
 

--- a/clean_geth_history.sh
+++ b/clean_geth_history.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-source ./exports.sh
+# shellcheck source=exports.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/exports.sh"
 
 # ---------------------------------------------------------------------------
 # clean_geth_history.sh - reclaim disk by pruning geth's ancient freezer

--- a/install/execution/geth.sh
+++ b/install/execution/geth.sh
@@ -52,8 +52,12 @@ export GETH_CMD="/usr/bin/geth --cache=$GETH_CACHE --syncmode snap \
 --ws --ws.addr $LH --ws.origins \"*\" --ws.api=\"web3, eth, net, engine\" \
 --authrpc.addr $LH --authrpc.port $ENGINE_PORT --authrpc.jwtsecret=$HOME/secrets/jwt.hex \
 --miner.etherbase=$FEE_RECIPIENT --miner.extradata=$GRAFITTI \
+--history.chain postmerge \
 --maxpeers 50 --txpool.globalslots 10000 --txpool.globalqueue 5000 \
 --metrics --metrics.addr $LH --metrics.port $METRICS_PORT"
+# --history.chain postmerge: don't keep pre-merge block bodies/receipts in the
+# ancient freezer (saves ~500-800G on a staking node). To reclaim space on an
+# already-synced node, run clean_geth_history.sh. See HANDOFF_diskcleanup.md.
 
 
 ensure_directory "$HOME/secrets"


### PR DESCRIPTION
## What
- **`clean_geth_history.sh`** — one-shot: stops geth, runs `geth prune-history --history.chain postmerge`, patches `eth1.service` to keep it pruned, restarts geth, reports reclaimed disk.
- **`install/execution/geth.sh`** — adds `--history.chain postmerge` so fresh installs never build the pre-merge freezer.
- **`HANDOFF_diskcleanup.md`** — why `prune-state` is refused under PBSS and where the disk actually goes.

## Why
A staking node's ancient freezer is dominated (~1.2T) by pre-merge bodies/receipts it never needs. geth runs PBSS, so `geth snapshot prune-state` is refused (`Offline pruning is not required for path scheme`). `prune-history --history.chain postmerge` is the correct tool.

## Tested
Run live on the mainnet node: reclaimed **~356G** (root 99% → 78%, freezer 1.2T → 810G). geth restarted with the flag, resynced to head cleanly (`eth.syncing == false`), validator resumed attesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)