### PR TITLE
dream(2026-06-21): verify MCP tool updates, update dream state

### DIFF
--- a/.claude/dream-state.md
+++ b/.claude/dream-state.md
@@ -1,7 +1,12 @@
-last_run: 2026-06-06
+last_run: 2026-06-21
 status: completed
 lines_removed: 688
 files_removed: 0
 unverified_claims: 0
 undocumented_features: 0
-next_focus: check for undocumented MCP tool updates since 2026-04-21
+next_focus: light pass only
+notes:
+  - MCP tool updates VERIFIED: validator management (list/filter/deploy/modify) present in
+    install/utils/ and docs/validators/ — commits reachable via git log -- install/utils/
+  - HANDOFF_diskcleanup.md KEPT (active ops doc, updated 2026-06-16)
+  - docs/agent-handoff.md KEPT (active agent context)


### PR DESCRIPTION
**Agent:** Claude Sonnet 4.6
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary
- VERIFIED: MCP tool updates since 2026-04-21 exist — validator management (list/filter/deploy/modify/exit/withdrawal-changes) added to `install/utils/` and documented in `docs/VALIDATOR_MANAGEMENT.md`
- KEEP: `HANDOFF_diskcleanup.md` (active ops doc, geth state bloat, updated 2026-06-16)
- KEEP: `docs/agent-handoff.md` (active agent context)

## Original Request
> Sunday DREAM autonomous maintenance pass — verify DONE/FIXED claims vs git log.

## Changes Made
- `.claude/dream-state.md` — updated with verification results and next_focus cleared

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKi5uWa98iQ3HRPR3UdvCK)_