### PR TITLE
fix: installer/config correctness across EL/CL clients (supersedes #188)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
           echo "::group::Install planner unit tests"
           docker run --rm -e USE_MOCKS=true eth-node-test bash /workspace/install/test/test_install_planner.sh
           echo "::endgroup::"
+          echo "::group::EL installer security assertions"
+          docker run --rm -e USE_MOCKS=true eth-node-test bash /workspace/install/test/test_installer_security_assertions.sh
+          echo "::endgroup::"
           echo "::group::MCP unit tests"
           docker run --rm -e USE_MOCKS=true eth-node-test bash /workspace/test/ci_test_mcp_server.sh
           echo "::endgroup::"

--- a/configs/besu/besu_base.toml
+++ b/configs/besu/besu_base.toml
@@ -24,7 +24,7 @@ rpc-http-api=["ADMIN","ETH","NET","WEB3"]
 # WebSocket settings
 rpc-ws-enabled=true
 rpc-ws-host="$LH"
-rpc-ws-api=["WEB3","ETH","NET","ENGINE"]
+rpc-ws-api=["WEB3","ETH","NET"]
 
 # Engine API settings (for consensus client communication)
 engine-rpc-enabled=true

--- a/configs/besu/besu_base.toml
+++ b/configs/besu/besu_base.toml
@@ -2,9 +2,13 @@
 # Current as of Besu 24.x — BONSAI + SNAP are default (24.3+)
 
 # Network settings
+# NOTE: p2p-host (the advertised P2P host) is intentionally NOT set here. besu.sh
+# injects the detected external IP at install time; pinning it to loopback in the base
+# both reintroduces the loopback-peering bug and produces a DUPLICATE p2p-host key
+# (besu's strict TOML parser rejects duplicates -> exit 2 crash-loop). On detection
+# failure besu falls back to its own default.
 network="mainnet"
 p2p-port=30303
-p2p-host="127.0.0.1"
 discovery-enabled=true
 max-peers=50
 

--- a/configs/besu/besu_base.toml
+++ b/configs/besu/besu_base.toml
@@ -33,6 +33,12 @@ engine-host-allowlist=["localhost","$LH"]
 # Sync settings
 sync-mode="SNAP"
 
+# Post-merge history pruning (geth --history.chain postmerge analogue).
+# On besu 26.6.x the flag is marked deprecated but is the only online history-prune
+# lever available; it prunes pre-merge block bodies+receipts to keep footprint
+# comparable to geth/nethermind. A non-deprecated replacement is expected in 27.x.
+history-expiry-prune=true
+
 # Performance optimizations
 # tx-pool-max-size, tx-pool-hash-limit, tx-pool-retention-hours removed:
 # incompatible with besu 25.x layered tx pool implementation.

--- a/configs/besu/besu_base.toml
+++ b/configs/besu/besu_base.toml
@@ -19,7 +19,7 @@ data-storage-format="BONSAI"
 rpc-http-enabled=true
 rpc-http-host="$LH"
 rpc-http-cors-origins=["*"]
-rpc-http-api=["ADMIN","ETH","NET","WEB3","ENGINE"]
+rpc-http-api=["ADMIN","ETH","NET","WEB3"]
 
 # WebSocket settings
 rpc-ws-enabled=true

--- a/configs/besu/besu_base.toml
+++ b/configs/besu/besu_base.toml
@@ -19,7 +19,7 @@ data-storage-format="BONSAI"
 rpc-http-enabled=true
 rpc-http-host="$LH"
 rpc-http-cors-origins=["*"]
-rpc-http-api=["ADMIN","ETH","NET","WEB3"]
+rpc-http-api=["ETH","NET","WEB3"]
 
 # WebSocket settings
 rpc-ws-enabled=true

--- a/configs/lodestar/lodestar_beacon_base.json
+++ b/configs/lodestar/lodestar_beacon_base.json
@@ -12,6 +12,9 @@
   "builder": {
     "enabled": false
   },
+  "chain": {
+    "pruneHistory": true
+  },
   "logLevel": "info",
   "targetPeers": 50
 }

--- a/configs/nethermind/nethermind_base.cfg
+++ b/configs/nethermind/nethermind_base.cfg
@@ -8,8 +8,7 @@
   },
   "Network": {
     "DiscoveryPort": 30303,
-    "P2PPort": 30303,
-    "LocalIp": "127.0.0.1"
+    "P2PPort": 30303
   },
   "JsonRpc": {
     "Enabled": true,

--- a/configs/nethermind/nethermind_base.cfg
+++ b/configs/nethermind/nethermind_base.cfg
@@ -23,13 +23,13 @@
     "Enabled": false
   },
   "Sync": {
-    "FastSync": true,
-    "PivotNumber": 0,
-    "PivotHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "PivotTotalDifficulty": "0",
+    "SnapSync": true,
+    "PivotTotalDifficulty": "58750000000000000000000",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": false,
-    "FastSyncCatchUpHeightDelta": 10000000000
+    "AncientBodiesBarrier": 15537394,
+    "AncientReceiptsBarrier": 15537394,
+    "SnapSyncCatchUpHeightDelta": 10000000000
   },
   "Bloom": {
     "IndexLevelBucketSizes": [4, 8, 8]

--- a/configs/nethermind/nethermind_base.cfg
+++ b/configs/nethermind/nethermind_base.cfg
@@ -14,7 +14,7 @@
     "Enabled": true,
     "Timeout": 20000,
     "Host": "$LH",
-    "EnabledModules": ["Admin", "Eth", "Net", "Web3", "Engine"]
+    "EnabledModules": ["Eth", "Net", "Web3"]
   },
   "EthStats": {
     "Enabled": false
@@ -23,13 +23,14 @@
     "Enabled": false
   },
   "Sync": {
+    "FastSync": true,
     "SnapSync": true,
-    "PivotTotalDifficulty": "58750000000000000000000",
+    "PivotTotalDifficulty": "58750003716598352816469",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": false,
     "AncientBodiesBarrier": 15537394,
     "AncientReceiptsBarrier": 15537394,
-    "SnapSyncCatchUpHeightDelta": 10000000000
+    "FastSyncCatchUpHeightDelta": 10000000000
   },
   "Bloom": {
     "IndexLevelBucketSizes": [4, 8, 8]

--- a/configs/nimbus/nimbus_base.toml
+++ b/configs/nimbus/nimbus_base.toml
@@ -32,3 +32,6 @@ payload-builder-url = "http://$MEV_HOST:$MEV_PORT"
 
 # Safety
 doppelganger-detection = true
+
+# History retention (prune is the default; set explicitly for clarity and gate checks).
+history = "prune"

--- a/configs/nimbus/nimbus_eth1_base.toml
+++ b/configs/nimbus/nimbus_eth1_base.toml
@@ -7,6 +7,14 @@ network = ["mainnet"]
 tcp-port = 30303
 udp-port = 30303
 
+# Post-merge history pruning: drop expired pre-merge block bodies + receipts
+# (geth `--history.chain postmerge` analogue; safe for a staking node, saves disk).
+# Efficacy note: some nimbus-eth1 versions only prune expired bodies/receipts online
+# and require an era1 archive import for complete pre-merge removal. This flag was
+# set and verified on bake-off run client-bakeoff-stageB-2026-06-23.
+# Do NOT add --history-expiry / history-expiry — that pulls a Portal Network dependency.
+prune = true
+
 # JSON-RPC settings (rpc-port/rpc-address in custom config)
 # rpc-enabled deprecated — presence of rpc-port enables RPC
 

--- a/configs/prysm/prysm_beacon_conf.yaml
+++ b/configs/prysm/prysm_beacon_conf.yaml
@@ -38,3 +38,8 @@ min-builder-bid: 2000000
 disable-broadcast-slashings: true
 enable-discovery-reboot: true
 ignore-unviable-attestations: true
+
+# DB pruning: prune beacon DB beyond MIN_EPOCHS_FOR_BLOCK_REQUESTS duration.
+# Without this the DB grows linearly on long-running nodes.
+# Verified flag against: prysm.sh beacon-chain --help on installed binary.
+beacon-db-pruning: true

--- a/configs/teku/teku_beacon_base.yaml
+++ b/configs/teku/teku_beacon_base.yaml
@@ -1,5 +1,5 @@
 # Teku Beacon Node Base Configuration
-# Current as of Teku 25.x — data-storage-mode: prune
+# Current as of Teku 25.x — data-storage-mode: minimal (prunes historic blocks too)
 
 # Network
 network: "mainnet"
@@ -8,8 +8,9 @@ p2p-port: 9000
 p2p-discovery-enabled: true
 p2p-peer-lower-bound: 64
 
-# Data storage
-data-storage-mode: "prune"
+# Data storage: minimal prunes finalized blocks beyond MIN_EPOCHS_FOR_BLOCK_REQUESTS
+# (valid values: ARCHIVE, PRUNE, MINIMAL — case-insensitive on teku 25.x).
+data-storage-mode: "minimal"
 
 # Execution layer connection
 ee-endpoint: "http://$LH:$ENGINE_PORT"

--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -98,11 +98,31 @@ rm -rf ./tmp/
 - **Base Config**: `configs/nethermind/nethermind_base.cfg`
 - **Custom Variables**: Memory, ports, fee recipient, graffiti
 - **Merge Strategy**: Generated JSON + base defaults (not yet standardized on schema-aware merge tooling)
+- **History mode**: **Pruned full node** (not archive). `AncientBodiesBarrier: 15537394` and
+  `AncientReceiptsBarrier: 15537394` drop pre-merge block bodies and receipts. Recent state
+  is fully present; historical state queries before the merge block (e.g. `eth_getBalance` at
+  an ancient block number, `debug_traceTransaction` on a pre-merge tx) will return `null` or
+  an error. If your use-case requires archive state, run Nethermind without the Ancient barriers
+  and without `SnapSync` (use a full `FastSync` or `Archive` config).
 
-#### Besu (TOML)  
+#### Besu (TOML)
 - **Base Config**: `configs/besu/besu_base.toml`
 - **Custom Variables**: Memory, ports, data path, mining settings
 - **Merge Strategy**: TOML concatenation
+- **History mode**: **Pruned full node** (not archive). `history-expiry-prune=true` removes
+  pre-merge block bodies and receipts (Besu 26.x lever; a non-deprecated replacement is expected
+  in 27.x). Historical state queries for ancient blocks will return `null`. For archive state,
+  omit `history-expiry-prune` and use `data-storage-format="FOREST"` (deprecated but still
+  available; BONSAI does not support archive queries in all versions).
+
+#### Reth (Rust)
+- **No base config file** — flags are passed on the `reth node` command line by `reth.sh`.
+- **History mode**: **Pruned full node** (not archive). `--full` enables pruned-full mode (reth
+  default is archive). `--prune.bodies.pre-merge` and `--prune.receipts.pre-merge` additionally
+  drop pre-merge block bodies and receipts for post-merge parity with geth
+  `--history.chain postmerge`. Ancient pre-merge state queries will return `null`. For archive
+  state, remove all `--full` and `--prune.*` flags; note this requires significantly more disk
+  (~2.8 TiB vs ~1 TiB for pruned-full as of mid-2026).
 
 ### Consensus Clients
 

--- a/install/consensus/grandine.sh
+++ b/install/consensus/grandine.sh
@@ -14,6 +14,8 @@ source "$PROJECT_ROOT/lib/common_functions.sh"
 # Get script directories
 get_script_directories
 
+CLIENT_GRAFFITI="$(printf '%s' "Grandine ${GRAFITTI}" | head -c 32)"
+
 # Start installation
 log_installation_start "Grandine"
 
@@ -115,7 +117,7 @@ BEACON_EXEC_START="$GRANDINE_DIR/grandine \
   --metrics-port 8008 \
   --checkpoint-sync-url $GRANDINE_CHECKPOINT_URL \
   --suggested-fee-recipient $FEE_RECIPIENT \
-  --graffiti $GRAFITTI \
+  --graffiti \"$CLIENT_GRAFFITI\" \
   --prune-storage \
   --target-peers $MAX_PEERS \
   --listen-address 0.0.0.0 \

--- a/install/consensus/grandine.sh
+++ b/install/consensus/grandine.sh
@@ -116,6 +116,7 @@ BEACON_EXEC_START="$GRANDINE_DIR/grandine \
   --checkpoint-sync-url $GRANDINE_CHECKPOINT_URL \
   --suggested-fee-recipient $FEE_RECIPIENT \
   --graffiti $GRAFITTI \
+  --prune-storage \
   --target-peers $MAX_PEERS \
   --listen-address 0.0.0.0 \
   --libp2p-port 9000 \

--- a/install/consensus/lodestar.sh
+++ b/install/consensus/lodestar.sh
@@ -14,6 +14,8 @@ source "$PROJECT_ROOT/lib/common_functions.sh"
 # Get script directories
 get_script_directories
 
+CLIENT_GRAFFITI="$(printf '%s' "Lodestar ${GRAFITTI}" | head -c 32)"
+
 # Start installation
 log_installation_start "Lodestar"
 
@@ -94,7 +96,7 @@ cat > ./tmp/lodestar_validator_custom.json << EOF
   "dataDir": "$LODESTAR_DATA_DIR/validator",
   "beaconNodes": ["http://$CONSENSUS_HOST:${LODESTAR_REST_PORT}"],
   "suggestedFeeRecipient": "$FEE_RECIPIENT",
-  "graffiti": "$GRAFITTI",
+  "graffiti": "$CLIENT_GRAFFITI",
   "metrics": {
     "port": 8009
   },

--- a/install/consensus/nimbus.sh
+++ b/install/consensus/nimbus.sh
@@ -14,6 +14,8 @@ source "$PROJECT_ROOT/lib/common_functions.sh"
 # Get script directories
 get_script_directories
 
+CLIENT_GRAFFITI="$(printf '%s' "Nimbus ${GRAFITTI}" | head -c 32)"
+
 log_installation_start "Nimbus"
 
 
@@ -102,7 +104,7 @@ log-file = "$NIMBUS_DATA_DIR/beacon_node.log"
 
 # Performance
 suggested-fee-recipient = "$FEE_RECIPIENT"
-graffiti = "$GRAFITTI"
+graffiti = "$CLIENT_GRAFFITI"
 EOF
 
 # Merge base configuration with custom settings
@@ -118,7 +120,7 @@ beacon-node = "http://127.0.0.1:5052"
 validators-dir = "$VALIDATOR_DATA_DIR"
 secrets-dir = "$VALIDATOR_DATA_DIR/secrets"
 suggested-fee-recipient = "$FEE_RECIPIENT"
-graffiti = "$GRAFITTI"
+graffiti = "$CLIENT_GRAFFITI"
 metrics = true
 metrics-port = 8009
 metrics-address = "$CONSENSUS_HOST"

--- a/install/consensus/prysm.sh
+++ b/install/consensus/prysm.sh
@@ -64,7 +64,7 @@ create_temp_config_dir
 # Note: graffiti is a validator-only flag, not beacon
 cat > ./tmp/prysm_beacon_custom.yaml << EOF
 suggested-fee-recipient: $FEE_RECIPIENT
-p2p-host-ip: $(curl -s v4.ident.me)
+p2p-host-ip: $(detect_external_ip)
 p2p-max-peers: $MAX_PEERS
 checkpoint-sync-url: $PRYSM_CPURL
 genesis-beacon-api-url: $PRYSM_CPURL

--- a/install/consensus/prysm.sh
+++ b/install/consensus/prysm.sh
@@ -90,11 +90,15 @@ BEACON_EXEC_START="$PRYSM_DIR/prysm.sh beacon-chain --config-file=$PRYSM_DIR/pry
 
 create_systemd_service "cl" "Prysm Ethereum Consensus Client (Beacon Node)" "$BEACON_EXEC_START" "$(whoami)" "on-failure" "600" "5" "300" "network-online.target eth1.service" "network-online.target eth1.service"
 
-# Pin USE_PRYSM_VERSION to the locally cached binary so prysm.sh skips the live
-# version check against prysmaticlabs.com (fails with 403 on rate-limited hosts).
-PRYSM_PINNED=""
-if [[ -d "$PRYSM_DIR/dist" ]]; then
+# Resolve the prysm version to pin. Prefer the latest published release from the
+# GitHub API (avoids the prysmaticlabs.com live version check, which 403s on
+# rate-limited hosts); fall back to the newest locally cached binary only if the
+# API is unreachable. Pinning to newest-cached alone silently goes stale — a
+# stale v7.1.5 pin once stalled a besu sync ~30h until manually bumped to v7.1.6.
+PRYSM_PINNED="$(get_latest_release "prysmaticlabs/prysm" 2>/dev/null || true)"
+if [[ -z "${PRYSM_PINNED:-}" && -d "$PRYSM_DIR/dist" ]]; then
   PRYSM_PINNED="$(find "$PRYSM_DIR/dist/" -maxdepth 1 -name 'beacon-chain-v*-linux-amd64' ! -name '*.sha256' ! -name '*.sig' 2>/dev/null | sed 's|.*/beacon-chain-||; s|-linux-amd64||' | sort -V | tail -1 || true)"
+  [[ -n "${PRYSM_PINNED:-}" ]] && log_warn "prysm GitHub release lookup failed; falling back to newest cached binary $PRYSM_PINNED"
 fi
 if [[ -n "${PRYSM_PINNED:-}" ]]; then
   sudo sed -i "/^\[Service\]/a Environment=\"USE_PRYSM_VERSION=${PRYSM_PINNED}\"" /etc/systemd/system/cl.service

--- a/install/consensus/prysm.sh
+++ b/install/consensus/prysm.sh
@@ -96,6 +96,13 @@ create_systemd_service "cl" "Prysm Ethereum Consensus Client (Beacon Node)" "$BE
 # API is unreachable. Pinning to newest-cached alone silently goes stale — a
 # stale v7.1.5 pin once stalled a besu sync ~30h until manually bumped to v7.1.6.
 PRYSM_PINNED="$(get_latest_release "prysmaticlabs/prysm" 2>/dev/null || true)"
+# get_latest_release() prints diagnostics to stdout when the GitHub API is
+# rate-limited/unparseable (fresh CI containers); those would otherwise be
+# captured above as a bogus "version". Only accept a real vX.Y tag — anything
+# else falls through to the cached-binary fallback / no-pin.
+if [[ ! "${PRYSM_PINNED:-}" =~ ^v[0-9]+\.[0-9]+ ]]; then
+  PRYSM_PINNED=""
+fi
 if [[ -z "${PRYSM_PINNED:-}" && -d "$PRYSM_DIR/dist" ]]; then
   PRYSM_PINNED="$(find "$PRYSM_DIR/dist/" -maxdepth 1 -name 'beacon-chain-v*-linux-amd64' ! -name '*.sha256' ! -name '*.sig' 2>/dev/null | sed 's|.*/beacon-chain-||; s|-linux-amd64||' | sort -V | tail -1 || true)"
   [[ -n "${PRYSM_PINNED:-}" ]] && log_warn "prysm GitHub release lookup failed; falling back to newest cached binary $PRYSM_PINNED"

--- a/install/consensus/prysm.sh
+++ b/install/consensus/prysm.sh
@@ -14,6 +14,8 @@ source "$PROJECT_ROOT/lib/common_functions.sh"
 # Get script directories
 get_script_directories
 
+CLIENT_GRAFFITI="$(printf '%s' "Prysm ${GRAFITTI}" | head -c 32)"
+
 log_installation_start "Prysm"
 
 
@@ -71,7 +73,7 @@ EOF
 
 # Create custom validator configuration variables
 cat > ./tmp/prysm_validator_custom.yaml << EOF
-graffiti: $GRAFITTI
+graffiti: $CLIENT_GRAFFITI
 suggested-fee-recipient: $FEE_RECIPIENT
 wallet-password-file: $HOME/secrets/pass.txt
 EOF

--- a/install/consensus/teku.sh
+++ b/install/consensus/teku.sh
@@ -14,6 +14,8 @@ source "$PROJECT_ROOT/lib/common_functions.sh"
 # Get script directories
 get_script_directories
 
+CLIENT_GRAFFITI="$(printf '%s' "Teku ${GRAFITTI}" | head -c 32)"
+
 log_installation_start "Teku"
 
 
@@ -106,7 +108,7 @@ checkpoint-sync-url: "$TEKU_CHECKPOINT_URL"
 metrics-port: 8008
 
 # Validator settings
-validators-graffiti: "$GRAFITTI"
+validators-graffiti: "$CLIENT_GRAFFITI"
 validators-proposer-default-fee-recipient: "$FEE_RECIPIENT"
 EOF
 
@@ -119,7 +121,7 @@ beacon-node-api-endpoint: "http://$CONSENSUS_HOST:${TEKU_REST_PORT}"
 
 # Validator settings
 validator-keys: "$VALIDATOR_DATA_DIR/keys:$VALIDATOR_DATA_DIR/passwords"
-validators-graffiti: "$GRAFITTI"
+validators-graffiti: "$CLIENT_GRAFFITI"
 validators-proposer-default-fee-recipient: "$FEE_RECIPIENT"
 
 # Data storage

--- a/install/execution/besu.sh
+++ b/install/execution/besu.sh
@@ -80,6 +80,12 @@ ensure_directory "$BESU_DATA_DIR"
 # Create temporary directory for custom configuration
 create_temp_config_dir
 
+# Detect external IP for P2P advertisement (base template defaults to 127.0.0.1).
+BESU_EXTERNAL_IP="$(detect_external_ip)"
+if [[ -z "$BESU_EXTERNAL_IP" ]]; then
+    log_warn "Could not detect external IP — besu will advertise loopback for P2P (degraded peering)"
+fi
+
 # Create custom configuration variables file
 cat > ./tmp/besu_custom.toml << EOF
 # Besu Custom Configuration Variables
@@ -87,7 +93,7 @@ cat > ./tmp/besu_custom.toml << EOF
 # Data storage
 data-path="$BESU_DATA_DIR"
 
-# JSON-RPC settings  
+# JSON-RPC settings
 rpc-http-port=${BESU_HTTP_PORT}
 
 # WebSocket settings
@@ -97,6 +103,13 @@ rpc-ws-port=${BESU_WS_PORT}
 engine-rpc-port=${BESU_ENGINE_PORT}
 engine-jwt-secret="$HOME/secrets/jwt.hex"
 EOF
+
+# Inject p2p-host only when detection succeeded (non-empty); avoids writing
+# an empty or 0.0.0.0 advertised host, which would be no better than the default.
+if [[ -n "$BESU_EXTERNAL_IP" ]]; then
+    echo "p2p-host=\"$BESU_EXTERNAL_IP\"" >> ./tmp/besu_custom.toml
+    log_info "Besu P2P host set to external IP: $BESU_EXTERNAL_IP"
+fi
 
 # Merge base configuration with custom settings
 merge_client_config "Besu" "main" "$PROJECT_ROOT/configs/besu/besu_base.toml" "./tmp/besu_custom.toml" "$BESU_DIR/besu.toml"

--- a/install/execution/besu.sh
+++ b/install/execution/besu.sh
@@ -81,7 +81,8 @@ ensure_directory "$BESU_DATA_DIR"
 create_temp_config_dir
 
 # Detect external IP for P2P advertisement (base template defaults to 127.0.0.1).
-BESU_EXTERNAL_IP="$(detect_external_ip)"
+# `|| true` guards set -e: detection failure must degrade gracefully, not abort install.
+BESU_EXTERNAL_IP="$(detect_external_ip || true)"
 if [[ -z "$BESU_EXTERNAL_IP" ]]; then
     log_warn "Could not detect external IP — besu will advertise loopback for P2P (degraded peering)"
 fi

--- a/install/execution/geth.sh
+++ b/install/execution/geth.sh
@@ -45,7 +45,7 @@ if ! command -v geth &>/dev/null; then
     log_error "Geth binary not found after installation"
     exit 1
 fi
-log_info "Geth installed: $(geth version | head -1)"
+log_info "Geth installed: $(geth version </dev/null 2>&1 | head -1)"
 
 export GETH_CMD="/usr/bin/geth --cache=$GETH_CACHE --syncmode snap \
 --http --http.addr $LH --http.corsdomain \"*\" --http.vhosts=* --http.api=\"admin,eth,net,web3,engine\" \

--- a/install/execution/geth.sh
+++ b/install/execution/geth.sh
@@ -48,8 +48,8 @@ fi
 log_info "Geth installed: $(geth version </dev/null 2>&1 | head -1)"
 
 export GETH_CMD="/usr/bin/geth --cache=$GETH_CACHE --syncmode snap \
---http --http.addr $LH --http.corsdomain \"*\" --http.vhosts=* --http.api=\"admin,eth,net,web3,engine\" \
---ws --ws.addr $LH --ws.origins \"*\" --ws.api=\"web3,eth,net,engine\" \
+--http --http.addr $LH --http.corsdomain \"*\" --http.vhosts=* --http.api=\"eth,net,web3\" \
+--ws --ws.addr $LH --ws.origins \"*\" --ws.api=\"web3,eth,net\" \
 --authrpc.addr $LH --authrpc.port $ENGINE_PORT --authrpc.jwtsecret=$HOME/secrets/jwt.hex \
 --history.chain postmerge \
 --maxpeers 50 --txpool.globalslots 10000 --txpool.globalqueue 5000 \

--- a/install/execution/nethermind.sh
+++ b/install/execution/nethermind.sh
@@ -72,17 +72,31 @@ fi
 
 # Fetch the latest finalized block to use as a real snap pivot (post-merge, so TTD is fixed).
 # A zero pivot makes SnapSync degenerate to a full fast-sync from genesis.
-_nmd_pivot_json="$(curl -s --max-time 15 -H 'Content-Type: application/json' \
-  --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}' \
-  https://ethereum.publicnode.com 2>/dev/null || \
-  curl -s --max-time 15 -H 'Content-Type: application/json' \
-  --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}' \
-  https://rpc.flashbots.net 2>/dev/null || true)"
-NETHERMIND_PIVOT_NUMBER="$(printf '%s' "$_nmd_pivot_json" | python3 -c \
-  'import json,sys; b=json.load(sys.stdin)["result"]; print(int(b["number"],16))' 2>/dev/null || echo 0)"
-NETHERMIND_PIVOT_HASH="$(printf '%s' "$_nmd_pivot_json" | python3 -c \
-  'import json,sys; b=json.load(sys.stdin)["result"]; print(b["hash"])' 2>/dev/null || \
-  echo '0x0000000000000000000000000000000000000000000000000000000000000000')"
+# Each endpoint is validated independently: a 200-OK JSON-RPC error body (missing .result,
+# or .result.number missing/empty) is treated as a failure and the next endpoint is tried.
+# Transport failure (curl non-zero) also falls through to the next endpoint.
+# If ALL endpoints fail, NETHERMIND_PIVOT_NUMBER stays 0 and NETHERMIND_PIVOT_HASH stays empty.
+NETHERMIND_PIVOT_NUMBER=0
+NETHERMIND_PIVOT_HASH=""
+_nmd_pivot_rpc_data='{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}'
+for _nmd_url in "https://ethereum.publicnode.com" "https://rpc.flashbots.net"; do
+    _nmd_json="$(curl -s --max-time 15 -H 'Content-Type: application/json' \
+        --data "$_nmd_pivot_rpc_data" "$_nmd_url" 2>/dev/null || true)"
+    # Validate: .result must exist and .result.number must be a non-empty hex string.
+    # A JSON-RPC error body has no .result key; we use .get() so KeyError becomes empty string.
+    _nmd_parsed="$(printf '%s' "$_nmd_json" | python3 -c \
+        'import json,sys
+r=(json.load(sys.stdin) if sys.stdin else {}).get("result") or {}
+n=r.get("number",""); h=r.get("hash","")
+print(str(int(n,16))+" "+h if n and h else "")
+' 2>/dev/null || true)"
+    if [[ -n "$_nmd_parsed" ]]; then
+        NETHERMIND_PIVOT_NUMBER="${_nmd_parsed%% *}"
+        NETHERMIND_PIVOT_HASH="${_nmd_parsed##* }"
+        break
+    fi
+    log_warn "Nethermind pivot: endpoint ${_nmd_url} returned unusable response, trying next"
+done
 
 # Only write a pivot if we fetched a real, recent finalized block. On failure we OMIT
 # PivotNumber/PivotHash rather than write 0 — a zero pivot degenerates SnapSync into a

--- a/install/execution/nethermind.sh
+++ b/install/execution/nethermind.sh
@@ -72,7 +72,7 @@ cat > "$NETHERMIND_DIR/nethermind_custom.cfg" << EOF
   "Network": {
     "DiscoveryPort": 30303,
     "P2PPort": 30303,
-    "LocalIp": "127.0.0.1"
+    "ExternalIp": "$(curl -s v4.ident.me)"
   },
   "JsonRpc": {
     "Enabled": true,

--- a/install/execution/nethermind.sh
+++ b/install/execution/nethermind.sh
@@ -59,9 +59,15 @@ ensure_directory "$HOME/.local/share/nethermind/nethermind_db"
 create_temp_config_dir
 
 # Detect external IP via shared helper (safe fallback chain; no-op if all fail).
-NETHERMIND_EXTERNAL_IP="$(detect_external_ip)"
-if [[ -z "$NETHERMIND_EXTERNAL_IP" ]]; then
-    log_warn "Could not detect external IP — nethermind will advertise no ExternalIp (degraded peering)"
+# `|| true` guards set -e: the substitution must not abort the install if detection
+# fails — we degrade gracefully instead (besu.sh follows the same guarded pattern).
+NETHERMIND_EXTERNAL_IP="$(detect_external_ip || true)"
+if [[ -n "$NETHERMIND_EXTERNAL_IP" ]]; then
+    NETHERMIND_EXTERNAL_IP_LINE="    \"ExternalIp\": \"${NETHERMIND_EXTERNAL_IP}\","
+    log_info "Nethermind advertising external IP for P2P: ${NETHERMIND_EXTERNAL_IP}"
+else
+    NETHERMIND_EXTERNAL_IP_LINE=""
+    log_warn "Could not detect external IP — omitting ExternalIp; nethermind will rely on its own NAT/discovery detection (may yield degraded peering)"
 fi
 
 # Fetch the latest finalized block to use as a real snap pivot (post-merge, so TTD is fixed).
@@ -77,7 +83,21 @@ NETHERMIND_PIVOT_NUMBER="$(printf '%s' "$_nmd_pivot_json" | python3 -c \
 NETHERMIND_PIVOT_HASH="$(printf '%s' "$_nmd_pivot_json" | python3 -c \
   'import json,sys; b=json.load(sys.stdin)["result"]; print(b["hash"])' 2>/dev/null || \
   echo '0x0000000000000000000000000000000000000000000000000000000000000000')"
-log_info "Nethermind snap pivot: block ${NETHERMIND_PIVOT_NUMBER} (${NETHERMIND_PIVOT_HASH})"
+
+# Only write a pivot if we fetched a real, recent finalized block. On failure we OMIT
+# PivotNumber/PivotHash rather than write 0 — a zero pivot degenerates SnapSync into a
+# genesis fast-sync. With no pivot, SnapSync bootstraps from the consensus client's
+# forkchoice once peers connect (safe fallback: dynamic value, sane default on failure).
+NETHERMIND_PIVOT_BLOCK=""
+if [[ "$NETHERMIND_PIVOT_NUMBER" =~ ^[0-9]+$ ]] && [[ "$NETHERMIND_PIVOT_NUMBER" -gt 0 ]] \
+   && [[ "$NETHERMIND_PIVOT_HASH" =~ ^0x[0-9a-fA-F]{64}$ ]] \
+   && [[ "$NETHERMIND_PIVOT_HASH" != "0x0000000000000000000000000000000000000000000000000000000000000000" ]]; then
+    NETHERMIND_PIVOT_BLOCK="    \"PivotNumber\": ${NETHERMIND_PIVOT_NUMBER},
+    \"PivotHash\": \"${NETHERMIND_PIVOT_HASH}\","
+    log_info "Nethermind snap pivot: block ${NETHERMIND_PIVOT_NUMBER} (${NETHERMIND_PIVOT_HASH})"
+else
+    log_warn "Could not fetch a finalized snap pivot — omitting PivotNumber/PivotHash; SnapSync will bootstrap its pivot from the consensus client forkchoice once peers connect (slower start, NOT a genesis fast-sync)"
+fi
 
 # Create custom configuration with variables
 cat > "$NETHERMIND_DIR/nethermind_custom.cfg" << EOF
@@ -92,8 +112,8 @@ cat > "$NETHERMIND_DIR/nethermind_custom.cfg" << EOF
   },
   "Network": {
     "DiscoveryPort": 30303,
-    "P2PPort": 30303,
-    "ExternalIp": "${NETHERMIND_EXTERNAL_IP}"
+${NETHERMIND_EXTERNAL_IP_LINE}
+    "P2PPort": 30303
   },
   "JsonRpc": {
     "Enabled": true,
@@ -119,8 +139,7 @@ cat > "$NETHERMIND_DIR/nethermind_custom.cfg" << EOF
   },
   "Sync": {
     "SnapSync": true,
-    "PivotNumber": ${NETHERMIND_PIVOT_NUMBER},
-    "PivotHash": "${NETHERMIND_PIVOT_HASH}",
+${NETHERMIND_PIVOT_BLOCK}
     "PivotTotalDifficulty": "58750000000000000000000",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": false,

--- a/install/execution/nethermind.sh
+++ b/install/execution/nethermind.sh
@@ -58,6 +58,12 @@ ensure_directory "$HOME/.local/share/nethermind/nethermind_db"
 # Create temporary directory for custom configuration
 create_temp_config_dir
 
+# Detect external IP via shared helper (safe fallback chain; no-op if all fail).
+NETHERMIND_EXTERNAL_IP="$(detect_external_ip)"
+if [[ -z "$NETHERMIND_EXTERNAL_IP" ]]; then
+    log_warn "Could not detect external IP — nethermind will advertise no ExternalIp (degraded peering)"
+fi
+
 # Fetch the latest finalized block to use as a real snap pivot (post-merge, so TTD is fixed).
 # A zero pivot makes SnapSync degenerate to a full fast-sync from genesis.
 _nmd_pivot_json="$(curl -s --max-time 15 -H 'Content-Type: application/json' \
@@ -87,7 +93,7 @@ cat > "$NETHERMIND_DIR/nethermind_custom.cfg" << EOF
   "Network": {
     "DiscoveryPort": 30303,
     "P2PPort": 30303,
-    "ExternalIp": "$(curl -s v4.ident.me)"
+    "ExternalIp": "${NETHERMIND_EXTERNAL_IP}"
   },
   "JsonRpc": {
     "Enabled": true,

--- a/install/execution/nethermind.sh
+++ b/install/execution/nethermind.sh
@@ -58,6 +58,18 @@ ensure_directory "$HOME/.local/share/nethermind/nethermind_db"
 # Create temporary directory for custom configuration
 create_temp_config_dir
 
+# Fetch the latest finalized block to use as a real snap pivot (post-merge, so TTD is fixed).
+# A zero pivot makes SnapSync degenerate to a full fast-sync from genesis.
+_nmd_pivot_json="$(curl -s --max-time 15 -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}' \
+  https://cloudflare-eth.com 2>/dev/null || true)"
+NETHERMIND_PIVOT_NUMBER="$(printf '%s' "$_nmd_pivot_json" | python3 -c \
+  'import json,sys; b=json.load(sys.stdin)["result"]; print(int(b["number"],16))' 2>/dev/null || echo 0)"
+NETHERMIND_PIVOT_HASH="$(printf '%s' "$_nmd_pivot_json" | python3 -c \
+  'import json,sys; b=json.load(sys.stdin)["result"]; print(b["hash"])' 2>/dev/null || \
+  echo '0x0000000000000000000000000000000000000000000000000000000000000000')"
+log_info "Nethermind snap pivot: block ${NETHERMIND_PIVOT_NUMBER} (${NETHERMIND_PIVOT_HASH})"
+
 # Create custom configuration with variables
 cat > "$NETHERMIND_DIR/nethermind_custom.cfg" << EOF
 {
@@ -98,11 +110,13 @@ cat > "$NETHERMIND_DIR/nethermind_custom.cfg" << EOF
   },
   "Sync": {
     "SnapSync": true,
-    "PivotNumber": 0,
-    "PivotHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "PivotTotalDifficulty": "0",
+    "PivotNumber": ${NETHERMIND_PIVOT_NUMBER},
+    "PivotHash": "${NETHERMIND_PIVOT_HASH}",
+    "PivotTotalDifficulty": "58750000000000000000000",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": false,
+    "AncientBodiesBarrier": 15537394,
+    "AncientReceiptsBarrier": 15537394,
     "SnapSyncCatchUpHeightDelta": 10000000000
   },
   "Bloom": {

--- a/install/execution/nethermind.sh
+++ b/install/execution/nethermind.sh
@@ -138,7 +138,7 @@ ${NETHERMIND_EXTERNAL_IP_LINE}
     "JwtSecretFile": "$HOME/secrets/jwt.hex",
     "EngineHost": "$LH",
     "EnginePort": ${NETHERMIND_ENGINE_PORT},
-    "EnabledModules": ["Admin", "Eth", "Net", "Web3"]
+    "EnabledModules": ["Eth", "Net", "Web3"]
   },
   "EthStats": {
     "Enabled": false
@@ -152,14 +152,15 @@ ${NETHERMIND_EXTERNAL_IP_LINE}
     "ExposePort": 6060
   },
   "Sync": {
+    "FastSync": true,
     "SnapSync": true,
 ${NETHERMIND_PIVOT_BLOCK}
-    "PivotTotalDifficulty": "58750000000000000000000",
+    "PivotTotalDifficulty": "58750003716598352816469",
     "FastBlocks": true,
     "UseGethLimitsInFastBlocks": false,
     "AncientBodiesBarrier": 15537394,
     "AncientReceiptsBarrier": 15537394,
-    "SnapSyncCatchUpHeightDelta": 10000000000
+    "FastSyncCatchUpHeightDelta": 10000000000
   },
   "Bloom": {
     "IndexLevelBucketSizes": [4, 8, 8]

--- a/install/execution/nethermind.sh
+++ b/install/execution/nethermind.sh
@@ -62,7 +62,10 @@ create_temp_config_dir
 # A zero pivot makes SnapSync degenerate to a full fast-sync from genesis.
 _nmd_pivot_json="$(curl -s --max-time 15 -H 'Content-Type: application/json' \
   --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}' \
-  https://cloudflare-eth.com 2>/dev/null || true)"
+  https://ethereum.publicnode.com 2>/dev/null || \
+  curl -s --max-time 15 -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized",false],"id":1}' \
+  https://rpc.flashbots.net 2>/dev/null || true)"
 NETHERMIND_PIVOT_NUMBER="$(printf '%s' "$_nmd_pivot_json" | python3 -c \
   'import json,sys; b=json.load(sys.stdin)["result"]; print(int(b["number"],16))' 2>/dev/null || echo 0)"
 NETHERMIND_PIVOT_HASH="$(printf '%s' "$_nmd_pivot_json" | python3 -c \

--- a/install/execution/reth.sh
+++ b/install/execution/reth.sh
@@ -67,9 +67,12 @@ chmod +x "$RETH_DIR/reth"
 ensure_jwt_secret "$HOME/secrets/jwt.hex"
 
 # Create systemd service
-# --full runs a pruned full node (~1.2 TiB), not reth's default archive (~2.8 TiB):
-# keeps full block/receipt history but prunes historical state changesets+indices.
-EXEC_START="$RETH_DIR/reth node --full --http --http.addr $LH --http.port 8545 --http.api eth,net,web3 --authrpc.addr $LH --authrpc.port $ENGINE_PORT --authrpc.jwtsecret $HOME/secrets/jwt.hex --datadir $HOME/.local/share/reth"
+# --full: reth is full-sync-only (no snap); --full prunes historical state changesets
+# and index data, leaving only recent-window state (not full block/receipt history).
+# --prune.bodies.pre-merge + --prune.receipts.pre-merge: additionally drop pre-merge
+# block bodies and receipts for post-merge parity with geth --history.chain postmerge.
+# Verified flags against reth node --help on installed binary.
+EXEC_START="$RETH_DIR/reth node --full --prune.bodies.pre-merge --prune.receipts.pre-merge --http --http.addr $LH --http.port 8545 --http.api eth,net,web3 --authrpc.addr $LH --authrpc.port $ENGINE_PORT --authrpc.jwtsecret $HOME/secrets/jwt.hex --datadir $HOME/.local/share/reth"
 
 create_systemd_service "eth1" "Reth Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "6000" "10" "3000"
 

--- a/install/test/test_installer_security_assertions.sh
+++ b/install/test/test_installer_security_assertions.sh
@@ -6,7 +6,7 @@
 #   A) HTTP RPC exposes only intended modules (no Engine/auth namespace on 8545)
 #   B) Auth/Engine RPC is local + JWT-protected, uses $HOME/secrets/jwt.hex
 #   C) Pruned-history clients (reth/besu/nethermind) carry the expected flags/keys;
-#      an archive-only state query would fail — documented expectation asserted via config
+#      config-level assertion that prune flags are present (not a runtime query check)
 #   D) External-IP helper: detection failure does NOT abort install; leaves a warning + safe default
 #
 # Run: bash install/test/test_installer_security_assertions.sh
@@ -38,18 +38,29 @@ test_nethermind_http_no_engine() {
     return 1
 }
 
-# A2: Besu base config — rpc-http-api must not contain ENGINE
-test_besu_http_no_engine() {
+# A2: Besu base config — neither rpc-http-api nor rpc-ws-api must contain ENGINE
+test_besu_no_engine_on_user_rpc() {
     local file="$PROJECT_ROOT/configs/besu/besu_base.toml"
+    local ok=0
     if grep -q "^rpc-http-api=" "$file"; then
         if grep "^rpc-http-api=" "$file" | grep -qi '"ENGINE"'; then
             log_error "besu_base.toml rpc-http-api exposes ENGINE on HTTP RPC"
-            return 1
+            ok=1
         fi
-        return 0
+    else
+        log_error "besu_base.toml: rpc-http-api line not found"
+        ok=1
     fi
-    log_error "besu_base.toml: rpc-http-api line not found"
-    return 1
+    if grep -q "^rpc-ws-api=" "$file"; then
+        if grep "^rpc-ws-api=" "$file" | grep -qi '"ENGINE"'; then
+            log_error "besu_base.toml rpc-ws-api exposes ENGINE on WS RPC"
+            ok=1
+        fi
+    else
+        log_error "besu_base.toml: rpc-ws-api line not found"
+        ok=1
+    fi
+    return $ok
 }
 
 # A3: Reth — http.api must not contain engine/auth
@@ -128,10 +139,10 @@ test_reth_engine_local_jwt() {
 }
 
 # ---------------------------------------------------------------------------
-# C. Pruned-history clients carry the expected prune flags (negative archive assertion)
-#    These clients do NOT store full pre-merge history; an eth_getBlockByNumber on an
-#    ancient pre-merge block would return null (not an error, but no state/receipts).
-#    We assert the prune flags are present so the expectation is explicit and locked down.
+# C. Pruned-history clients carry the expected prune flags
+#    Config-level assertion: prune flags are present in installer config/scripts.
+#    This locks down the expectation that these clients run pruned, not archive.
+#    Runtime behaviour (e.g. null receipts for ancient blocks) is not tested here.
 # ---------------------------------------------------------------------------
 
 # C1: Reth runs with --full and pre-merge body/receipt prune flags
@@ -227,10 +238,10 @@ else
     record_test "nethermind HTTP RPC: no Engine namespace on user port" "FAIL"
 fi
 
-if test_besu_http_no_engine; then
-    record_test "besu HTTP RPC: no ENGINE in rpc-http-api" "PASS"
+if test_besu_no_engine_on_user_rpc; then
+    record_test "besu user RPC: no ENGINE in rpc-http-api or rpc-ws-api" "PASS"
 else
-    record_test "besu HTTP RPC: no ENGINE in rpc-http-api" "FAIL"
+    record_test "besu user RPC: no ENGINE in rpc-http-api or rpc-ws-api" "FAIL"
 fi
 
 if test_reth_http_no_engine; then

--- a/install/test/test_installer_security_assertions.sh
+++ b/install/test/test_installer_security_assertions.sh
@@ -23,39 +23,62 @@ log_header "EL Installer Security Assertions"
 # A. HTTP RPC must NOT expose Engine/auth namespace on user-facing port
 # ---------------------------------------------------------------------------
 
-# A1: Nethermind — EnabledModules must not contain Engine
+# A1: Nethermind — EnabledModules must not contain Engine, Admin, or Debug
+#     Checked in BOTH the installer script AND the base config template.
 test_nethermind_http_no_engine() {
-    local file="$PROJECT_ROOT/install/execution/nethermind.sh"
-    # Extract the EnabledModules line and check it doesn't contain "Engine"
-    if grep -q '"EnabledModules"' "$file"; then
-        if grep '"EnabledModules"' "$file" | grep -qi '"engine"'; then
-            log_error "nethermind.sh EnabledModules exposes Engine on HTTP RPC"
-            return 1
+    local sh="$PROJECT_ROOT/install/execution/nethermind.sh"
+    local cfg="$PROJECT_ROOT/configs/nethermind/nethermind_base.cfg"
+    local ok=0
+    for file in "$sh" "$cfg"; do
+        local label
+        label="$(basename "$file")"
+        if grep -q '"EnabledModules"' "$file"; then
+            if grep '"EnabledModules"' "$file" | grep -qi '"engine"'; then
+                log_error "$label EnabledModules exposes Engine on HTTP RPC"
+                ok=1
+            fi
+            if grep '"EnabledModules"' "$file" | grep -qi '"admin"'; then
+                log_error "$label EnabledModules exposes Admin on HTTP RPC"
+                ok=1
+            fi
+            if grep '"EnabledModules"' "$file" | grep -qi '"debug"'; then
+                log_error "$label EnabledModules exposes Debug on HTTP RPC"
+                ok=1
+            fi
+        else
+            log_error "$label: EnabledModules not found"
+            ok=1
         fi
-        return 0
-    fi
-    log_error "nethermind.sh: EnabledModules not found"
-    return 1
+    done
+    return $ok
 }
 
-# A2: Besu base config — neither rpc-http-api nor rpc-ws-api must contain ENGINE
+# A2: Besu base config — rpc-http-api and rpc-ws-api must not contain ENGINE, ADMIN, or DEBUG
 test_besu_no_engine_on_user_rpc() {
     local file="$PROJECT_ROOT/configs/besu/besu_base.toml"
     local ok=0
     if grep -q "^rpc-http-api=" "$file"; then
-        if grep "^rpc-http-api=" "$file" | grep -qi '"ENGINE"'; then
-            log_error "besu_base.toml rpc-http-api exposes ENGINE on HTTP RPC"
-            ok=1
-        fi
+        local http_line
+        http_line="$(grep "^rpc-http-api=" "$file")"
+        for module in ENGINE ADMIN DEBUG; do
+            if echo "$http_line" | grep -qi "\"${module}\""; then
+                log_error "besu_base.toml rpc-http-api exposes ${module} on HTTP RPC"
+                ok=1
+            fi
+        done
     else
         log_error "besu_base.toml: rpc-http-api line not found"
         ok=1
     fi
     if grep -q "^rpc-ws-api=" "$file"; then
-        if grep "^rpc-ws-api=" "$file" | grep -qi '"ENGINE"'; then
-            log_error "besu_base.toml rpc-ws-api exposes ENGINE on WS RPC"
-            ok=1
-        fi
+        local ws_line
+        ws_line="$(grep "^rpc-ws-api=" "$file")"
+        for module in ENGINE ADMIN DEBUG; do
+            if echo "$ws_line" | grep -qi "\"${module}\""; then
+                log_error "besu_base.toml rpc-ws-api exposes ${module} on WS RPC"
+                ok=1
+            fi
+        done
     else
         log_error "besu_base.toml: rpc-ws-api line not found"
         ok=1
@@ -171,6 +194,48 @@ test_nethermind_pruned_flags_present() {
     local ok=0
     grep -q "AncientBodiesBarrier" "$file" || { log_error "nethermind.sh: AncientBodiesBarrier missing"; ok=1; }
     grep -q "AncientReceiptsBarrier" "$file" || { log_error "nethermind.sh: AncientReceiptsBarrier missing"; ok=1; }
+    return $ok
+}
+
+# C4: Nethermind PivotTotalDifficulty must equal the pivot block's frozen TD, not the TTD threshold.
+#     Also asserts FastSyncCatchUpHeightDelta is present (valid key) and SnapSyncCatchUpHeightDelta
+#     is absent (renamed/invalid key). Both checks run in BOTH the installer script AND the base cfg.
+NETHERMIND_CORRECT_PIVOT_TD="58750003716598352816469"
+NETHERMIND_WRONG_PIVOT_TD="58750000000000000000000"
+
+test_nethermind_pivot_and_catchup_keys() {
+    local sh="$PROJECT_ROOT/install/execution/nethermind.sh"
+    local cfg="$PROJECT_ROOT/configs/nethermind/nethermind_base.cfg"
+    local ok=0
+    for file in "$sh" "$cfg"; do
+        local label
+        label="$(basename "$file")"
+        # PivotTotalDifficulty must equal the frozen pivot block TD
+        if grep -q "PivotTotalDifficulty" "$file"; then
+            if ! grep "PivotTotalDifficulty" "$file" | grep -q "${NETHERMIND_CORRECT_PIVOT_TD}"; then
+                log_error "$label: PivotTotalDifficulty is not the correct frozen pivot TD (${NETHERMIND_CORRECT_PIVOT_TD})"
+                ok=1
+            fi
+            # Must NOT be the TTD threshold (wrong value — degrades to full genesis sync)
+            if grep "PivotTotalDifficulty" "$file" | grep -q "${NETHERMIND_WRONG_PIVOT_TD}\""; then
+                log_error "$label: PivotTotalDifficulty is the TTD threshold, not the pivot block TD"
+                ok=1
+            fi
+        else
+            log_error "$label: PivotTotalDifficulty key not found"
+            ok=1
+        fi
+        # FastSyncCatchUpHeightDelta (valid key) must be present
+        if ! grep -q "FastSyncCatchUpHeightDelta" "$file"; then
+            log_error "$label: FastSyncCatchUpHeightDelta missing (valid key, required for post-merge fast-sync)"
+            ok=1
+        fi
+        # SnapSyncCatchUpHeightDelta (renamed/non-existent key) must be absent
+        if grep -q "SnapSyncCatchUpHeightDelta" "$file"; then
+            log_error "$label: SnapSyncCatchUpHeightDelta present (invalid key — should be FastSyncCatchUpHeightDelta)"
+            ok=1
+        fi
+    done
     return $ok
 }
 
@@ -308,6 +373,12 @@ if test_nethermind_external_ip_warns; then
     record_test "nethermind: log_warn on external IP detection failure" "PASS"
 else
     record_test "nethermind: log_warn on external IP detection failure" "FAIL"
+fi
+
+if test_nethermind_pivot_and_catchup_keys; then
+    record_test "nethermind: correct PivotTotalDifficulty + FastSyncCatchUpHeightDelta (both files)" "PASS"
+else
+    record_test "nethermind: correct PivotTotalDifficulty + FastSyncCatchUpHeightDelta (both files)" "FAIL"
 fi
 
 print_test_summary

--- a/install/test/test_installer_security_assertions.sh
+++ b/install/test/test_installer_security_assertions.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# Security-surface assertions for EL installer correctness.
+# These are static-analysis (source-code) tests — no running node required.
+#
+# Assertions validated here:
+#   A) HTTP RPC exposes only intended modules (no Engine/auth namespace on 8545)
+#   B) Auth/Engine RPC is local + JWT-protected, uses $HOME/secrets/jwt.hex
+#   C) Pruned-history clients (reth/besu/nethermind) carry the expected flags/keys;
+#      an archive-only state query would fail — documented expectation asserted via config
+#   D) External-IP helper: detection failure does NOT abort install; leaves a warning + safe default
+#
+# Run: bash install/test/test_installer_security_assertions.sh
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/../../test/lib/test_utils.sh"
+
+log_header "EL Installer Security Assertions"
+
+# ---------------------------------------------------------------------------
+# A. HTTP RPC must NOT expose Engine/auth namespace on user-facing port
+# ---------------------------------------------------------------------------
+
+# A1: Nethermind — EnabledModules must not contain Engine
+test_nethermind_http_no_engine() {
+    local file="$PROJECT_ROOT/install/execution/nethermind.sh"
+    # Extract the EnabledModules line and check it doesn't contain "Engine"
+    if grep -q '"EnabledModules"' "$file"; then
+        if grep '"EnabledModules"' "$file" | grep -qi '"engine"'; then
+            log_error "nethermind.sh EnabledModules exposes Engine on HTTP RPC"
+            return 1
+        fi
+        return 0
+    fi
+    log_error "nethermind.sh: EnabledModules not found"
+    return 1
+}
+
+# A2: Besu base config — rpc-http-api must not contain ENGINE
+test_besu_http_no_engine() {
+    local file="$PROJECT_ROOT/configs/besu/besu_base.toml"
+    if grep -q "^rpc-http-api=" "$file"; then
+        if grep "^rpc-http-api=" "$file" | grep -qi '"ENGINE"'; then
+            log_error "besu_base.toml rpc-http-api exposes ENGINE on HTTP RPC"
+            return 1
+        fi
+        return 0
+    fi
+    log_error "besu_base.toml: rpc-http-api line not found"
+    return 1
+}
+
+# A3: Reth — http.api must not contain engine/auth
+test_reth_http_no_engine() {
+    local file="$PROJECT_ROOT/install/execution/reth.sh"
+    # Use python3 to avoid grep wrapper/regex issues with literal '--http.api' string
+    local api_val
+    api_val="$(python3 -c "
+import re, sys
+txt = open('$file').read()
+m = re.search(r'--http\.api\s+(\S+)', txt)
+print(m.group(1).lower() if m else '')
+" 2>/dev/null || true)"
+    if [[ -z "$api_val" ]]; then
+        log_error "reth.sh: --http.api flag not found"
+        return 1
+    fi
+    if [[ "$api_val" == *engine* ]] || [[ "$api_val" == *auth* ]]; then
+        log_error "reth.sh --http.api exposes engine/auth on HTTP port: $api_val"
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# B. Auth/Engine RPC must be local-bound and JWT-protected
+# ---------------------------------------------------------------------------
+
+# B1: Nethermind — EngineHost is local, JwtSecretFile references jwt.hex
+test_nethermind_engine_local_jwt() {
+    local file="$PROJECT_ROOT/install/execution/nethermind.sh"
+    local ok=0
+    # EngineHost bound to LH (127.0.0.1) — check the variable reference
+    grep -q '"EngineHost".*LH' "$file" || { log_error "nethermind.sh: EngineHost not bound to \$LH"; ok=1; }
+    # JwtSecretFile references jwt.hex
+    grep -q '"JwtSecretFile".*jwt\.hex' "$file" || { log_error "nethermind.sh: JwtSecretFile missing/wrong"; ok=1; }
+    return $ok
+}
+
+# B2: Besu — engine-jwt-secret references jwt.hex, engine-host-allowlist is local
+test_besu_engine_local_jwt() {
+    local cfg="$PROJECT_ROOT/configs/besu/besu_base.toml"
+    local sh="$PROJECT_ROOT/install/execution/besu.sh"
+    local ok=0
+    # engine-host-allowlist must exist and must NOT allow "*" or "0.0.0.0"
+    local allowlist_line
+    allowlist_line="$(python3 -c "
+for line in open('$cfg'):
+    if 'engine-host-allowlist' in line:
+        print(line.strip())
+        break
+" 2>/dev/null || true)"
+    if [[ -z "$allowlist_line" ]]; then
+        log_error "besu_base.toml: engine-host-allowlist not found"
+        ok=1
+    elif [[ "$allowlist_line" == *'"*"'* ]] || [[ "$allowlist_line" == *'"0.0.0.0"'* ]]; then
+        log_error "besu_base.toml engine-host-allowlist is not restricted to local: $allowlist_line"
+        ok=1
+    fi
+    # engine-jwt-secret references jwt.hex in the install script
+    python3 -c "
+import sys
+txt = open('$sh').read()
+sys.exit(0 if 'engine-jwt-secret' in txt and 'jwt.hex' in txt else 1)
+" 2>/dev/null || { log_error "besu.sh: engine-jwt-secret not set to jwt.hex"; ok=1; }
+    return $ok
+}
+
+# B3: Reth — authrpc bound to local LH, jwtsecret references jwt.hex
+test_reth_engine_local_jwt() {
+    local file="$PROJECT_ROOT/install/execution/reth.sh"
+    local ok=0
+    grep -q -- "--authrpc.addr.*LH" "$file" || { log_error "reth.sh: --authrpc.addr not bound to \$LH"; ok=1; }
+    grep -q -- "--authrpc.jwtsecret.*jwt\.hex" "$file" || { log_error "reth.sh: --authrpc.jwtsecret missing"; ok=1; }
+    return $ok
+}
+
+# ---------------------------------------------------------------------------
+# C. Pruned-history clients carry the expected prune flags (negative archive assertion)
+#    These clients do NOT store full pre-merge history; an eth_getBlockByNumber on an
+#    ancient pre-merge block would return null (not an error, but no state/receipts).
+#    We assert the prune flags are present so the expectation is explicit and locked down.
+# ---------------------------------------------------------------------------
+
+# C1: Reth runs with --full and pre-merge body/receipt prune flags
+test_reth_pruned_flags_present() {
+    local file="$PROJECT_ROOT/install/execution/reth.sh"
+    local ok=0
+    grep -q -- "--full" "$file" || { log_error "reth.sh: --full flag missing (reth would run archive)"; ok=1; }
+    grep -q -- "--prune.bodies.pre-merge" "$file" || { log_error "reth.sh: --prune.bodies.pre-merge missing"; ok=1; }
+    grep -q -- "--prune.receipts.pre-merge" "$file" || { log_error "reth.sh: --prune.receipts.pre-merge missing"; ok=1; }
+    return $ok
+}
+
+# C2: Besu runs with history-expiry-prune=true in base config
+test_besu_pruned_flags_present() {
+    local file="$PROJECT_ROOT/configs/besu/besu_base.toml"
+    if grep -q "^history-expiry-prune=true" "$file"; then
+        return 0
+    fi
+    log_error "besu_base.toml: history-expiry-prune=true missing"
+    return 1
+}
+
+# C3: Nethermind carries AncientBodiesBarrier/AncientReceiptsBarrier (post-merge barriers)
+test_nethermind_pruned_flags_present() {
+    local file="$PROJECT_ROOT/install/execution/nethermind.sh"
+    local ok=0
+    grep -q "AncientBodiesBarrier" "$file" || { log_error "nethermind.sh: AncientBodiesBarrier missing"; ok=1; }
+    grep -q "AncientReceiptsBarrier" "$file" || { log_error "nethermind.sh: AncientReceiptsBarrier missing"; ok=1; }
+    return $ok
+}
+
+# ---------------------------------------------------------------------------
+# D. External-IP helper: failure must NOT abort install; must leave a warning
+# ---------------------------------------------------------------------------
+
+# D1: detect_external_ip in common_functions.sh: exits cleanly with empty output on all-fail
+# (no 'exit 1' or 'return 1' without an echo, so callers can test -z safely)
+test_detect_external_ip_safe_failure() {
+    local file="$PROJECT_ROOT/lib/common_functions.sh"
+    # Function exists
+    if ! grep -q "^detect_external_ip()" "$file"; then
+        log_error "detect_external_ip() not found in common_functions.sh"
+        return 1
+    fi
+    # The function must NOT call 'exit' (that would kill the entire install)
+    local fn_body
+    fn_body="$(awk '/^detect_external_ip\(\)/,/^}/' "$file")"
+    if echo "$fn_body" | grep -qw "exit"; then
+        log_error "detect_external_ip() contains 'exit' — would abort install on failure"
+        return 1
+    fi
+    return 0
+}
+
+# D2: nethermind.sh guards detect_external_ip call with '|| true' (safe under set -e)
+test_nethermind_external_ip_guarded() {
+    local file="$PROJECT_ROOT/install/execution/nethermind.sh"
+    if grep -q "detect_external_ip.*|| true" "$file"; then
+        return 0
+    fi
+    log_error "nethermind.sh: detect_external_ip not guarded with '|| true'"
+    return 1
+}
+
+# D3: besu.sh guards detect_external_ip call and only injects p2p-host when non-empty
+test_besu_external_ip_guarded() {
+    local file="$PROJECT_ROOT/install/execution/besu.sh"
+    local ok=0
+    # Must have || true or -z guard
+    grep -q 'detect_external_ip\b' "$file" || { log_error "besu.sh: detect_external_ip not called"; ok=1; }
+    # IP injection is behind [[ -n ]] guard (safe fallback)
+    grep -q '\[\[ -n.*BESU_EXTERNAL_IP' "$file" || { log_error "besu.sh: p2p-host injection not guarded by [[ -n ]] check"; ok=1; }
+    return $ok
+}
+
+# D4: nethermind.sh emits a log_warn on detection failure (clear warning to operator)
+test_nethermind_external_ip_warns() {
+    local file="$PROJECT_ROOT/install/execution/nethermind.sh"
+    if grep -q "log_warn.*detect\|Could not detect" "$file"; then
+        return 0
+    fi
+    log_error "nethermind.sh: no log_warn for external IP detection failure"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+if test_nethermind_http_no_engine; then
+    record_test "nethermind HTTP RPC: no Engine namespace on user port" "PASS"
+else
+    record_test "nethermind HTTP RPC: no Engine namespace on user port" "FAIL"
+fi
+
+if test_besu_http_no_engine; then
+    record_test "besu HTTP RPC: no ENGINE in rpc-http-api" "PASS"
+else
+    record_test "besu HTTP RPC: no ENGINE in rpc-http-api" "FAIL"
+fi
+
+if test_reth_http_no_engine; then
+    record_test "reth HTTP RPC: no engine/auth in http.api" "PASS"
+else
+    record_test "reth HTTP RPC: no engine/auth in http.api" "FAIL"
+fi
+
+if test_nethermind_engine_local_jwt; then
+    record_test "nethermind Engine RPC: local-bound + jwt.hex" "PASS"
+else
+    record_test "nethermind Engine RPC: local-bound + jwt.hex" "FAIL"
+fi
+
+if test_besu_engine_local_jwt; then
+    record_test "besu Engine RPC: local-bound + jwt.hex" "PASS"
+else
+    record_test "besu Engine RPC: local-bound + jwt.hex" "FAIL"
+fi
+
+if test_reth_engine_local_jwt; then
+    record_test "reth Engine RPC: local-bound + jwt.hex" "PASS"
+else
+    record_test "reth Engine RPC: local-bound + jwt.hex" "FAIL"
+fi
+
+if test_reth_pruned_flags_present; then
+    record_test "reth: pruned-history flags present (not archive)" "PASS"
+else
+    record_test "reth: pruned-history flags present (not archive)" "FAIL"
+fi
+
+if test_besu_pruned_flags_present; then
+    record_test "besu: history-expiry-prune=true present" "PASS"
+else
+    record_test "besu: history-expiry-prune=true present" "FAIL"
+fi
+
+if test_nethermind_pruned_flags_present; then
+    record_test "nethermind: AncientBodies/ReceiptsBarrier present" "PASS"
+else
+    record_test "nethermind: AncientBodies/ReceiptsBarrier present" "FAIL"
+fi
+
+if test_detect_external_ip_safe_failure; then
+    record_test "detect_external_ip: safe empty-output failure (no exit)" "PASS"
+else
+    record_test "detect_external_ip: safe empty-output failure (no exit)" "FAIL"
+fi
+
+if test_nethermind_external_ip_guarded; then
+    record_test "nethermind: detect_external_ip guarded with || true" "PASS"
+else
+    record_test "nethermind: detect_external_ip guarded with || true" "FAIL"
+fi
+
+if test_besu_external_ip_guarded; then
+    record_test "besu: p2p-host injection guarded by non-empty check" "PASS"
+else
+    record_test "besu: p2p-host injection guarded by non-empty check" "FAIL"
+fi
+
+if test_nethermind_external_ip_warns; then
+    record_test "nethermind: log_warn on external IP detection failure" "PASS"
+else
+    record_test "nethermind: log_warn on external IP detection failure" "FAIL"
+fi
+
+print_test_summary

--- a/install/test/test_installer_security_assertions.sh
+++ b/install/test/test_installer_security_assertions.sh
@@ -294,6 +294,71 @@ test_nethermind_external_ip_warns() {
 }
 
 # ---------------------------------------------------------------------------
+# E. Per-client graffiti: each CL installer must use composed CLIENT_GRAFFITI
+# ---------------------------------------------------------------------------
+
+# E1: Each CL script defines CLIENT_GRAFFITI and the graffiti field references $CLIENT_GRAFFITI
+test_client_graffiti_defined() {
+    local ok=0
+
+    local f="$PROJECT_ROOT/install/consensus/grandine.sh"
+    grep -q 'CLIENT_GRAFFITI=' "$f" || { log_error "grandine.sh: CLIENT_GRAFFITI not defined"; ok=1; }
+    # shellcheck disable=SC2016
+    grep -qF -- '--graffiti \"$CLIENT_GRAFFITI\"' "$f" || { log_error "grandine.sh: --graffiti does not use escaped \$CLIENT_GRAFFITI"; ok=1; }
+
+    f="$PROJECT_ROOT/install/consensus/prysm.sh"
+    grep -q 'CLIENT_GRAFFITI=' "$f" || { log_error "prysm.sh: CLIENT_GRAFFITI not defined"; ok=1; }
+    # shellcheck disable=SC2016
+    grep -qF 'graffiti: $CLIENT_GRAFFITI' "$f" || { log_error "prysm.sh: graffiti field does not use \$CLIENT_GRAFFITI"; ok=1; }
+
+    f="$PROJECT_ROOT/install/consensus/nimbus.sh"
+    grep -q 'CLIENT_GRAFFITI=' "$f" || { log_error "nimbus.sh: CLIENT_GRAFFITI not defined"; ok=1; }
+    local nimbus_count
+    # shellcheck disable=SC2016
+    nimbus_count="$(grep -cF 'graffiti = "$CLIENT_GRAFFITI"' "$f" || true)"
+    [[ "$nimbus_count" -ge 2 ]] || { log_error "nimbus.sh: expected >= 2 graffiti lines with \$CLIENT_GRAFFITI, found $nimbus_count"; ok=1; }
+
+    f="$PROJECT_ROOT/install/consensus/teku.sh"
+    grep -q 'CLIENT_GRAFFITI=' "$f" || { log_error "teku.sh: CLIENT_GRAFFITI not defined"; ok=1; }
+    local teku_count
+    # shellcheck disable=SC2016
+    teku_count="$(grep -cF 'validators-graffiti: "$CLIENT_GRAFFITI"' "$f" || true)"
+    [[ "$teku_count" -ge 2 ]] || { log_error "teku.sh: expected >= 2 validators-graffiti lines with \$CLIENT_GRAFFITI, found $teku_count"; ok=1; }
+
+    f="$PROJECT_ROOT/install/consensus/lodestar.sh"
+    grep -q 'CLIENT_GRAFFITI=' "$f" || { log_error "lodestar.sh: CLIENT_GRAFFITI not defined"; ok=1; }
+    # shellcheck disable=SC2016
+    grep -qF '"graffiti": "$CLIENT_GRAFFITI"' "$f" || { log_error "lodestar.sh: graffiti field does not use \$CLIENT_GRAFFITI"; ok=1; }
+
+    return $ok
+}
+
+# E2: Composed CLIENT_GRAFFITI for each client is <= 32 bytes and contains the client name
+test_client_graffiti_length() {
+    local ok=0
+    local grafitti_val
+    grafitti_val="$(grep '^export GRAFITTI=' "$PROJECT_ROOT/exports.sh" | cut -d'"' -f2)"
+    if [[ -z "$grafitti_val" ]]; then
+        log_error "Could not extract GRAFITTI value from exports.sh"
+        return 1
+    fi
+    for name in Grandine Prysm Nimbus Teku Lodestar; do
+        local composed len
+        composed="$(printf '%s' "${name} ${grafitti_val}" | head -c 32)"
+        len="$(printf '%s' "$composed" | wc -c)"
+        if [[ "$len" -gt 32 ]]; then
+            log_error "CLIENT_GRAFFITI for $name is ${len} bytes (>32): '$composed'"
+            ok=1
+        fi
+        if [[ "$composed" != "${name}"* ]]; then
+            log_error "CLIENT_GRAFFITI for $name does not start with client name: '$composed'"
+            ok=1
+        fi
+    done
+    return $ok
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 
@@ -379,6 +444,18 @@ if test_nethermind_pivot_and_catchup_keys; then
     record_test "nethermind: correct PivotTotalDifficulty + FastSyncCatchUpHeightDelta (both files)" "PASS"
 else
     record_test "nethermind: correct PivotTotalDifficulty + FastSyncCatchUpHeightDelta (both files)" "FAIL"
+fi
+
+if test_client_graffiti_defined; then
+    record_test "CL graffiti: CLIENT_GRAFFITI defined; field uses \$CLIENT_GRAFFITI in all 5 scripts" "PASS"
+else
+    record_test "CL graffiti: CLIENT_GRAFFITI defined; field uses \$CLIENT_GRAFFITI in all 5 scripts" "FAIL"
+fi
+
+if test_client_graffiti_length; then
+    record_test "CL graffiti: composed value is <=32 bytes and contains client name" "PASS"
+else
+    record_test "CL graffiti: composed value is <=32 bytes and contains client name" "FAIL"
 fi
 
 print_test_summary

--- a/lib/common_functions.sh
+++ b/lib/common_functions.sh
@@ -61,7 +61,7 @@ is_docker() {
 # result is a well-formed IPv4 before echoing it. Echoes nothing on failure
 # so callers can safely test -z and fall back gracefully.
 detect_external_ip() {
-    local ip
+    local ip _url
     for _url in https://v4.ident.me https://api.ipify.org https://ifconfig.me/ip; do
         ip="$(curl -s -m 10 "$_url" 2>/dev/null | tr -d '[:space:]' || true)"
         if echo "$ip" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then

--- a/lib/common_functions.sh
+++ b/lib/common_functions.sh
@@ -56,6 +56,21 @@ is_docker() {
     [[ -f /.dockerenv ]] || grep -qE 'docker|containerd' /proc/1/cgroup 2>/dev/null
 }
 
+# Detect this host's external/public IPv4 address at install time.
+# Tries three independent endpoints with a 10s timeout each; validates the
+# result is a well-formed IPv4 before echoing it. Echoes nothing on failure
+# so callers can safely test -z and fall back gracefully.
+detect_external_ip() {
+    local ip
+    for _url in https://v4.ident.me https://api.ipify.org https://ifconfig.me/ip; do
+        ip="$(curl -s -m 10 "$_url" 2>/dev/null | tr -d '[:space:]' || true)"
+        if echo "$ip" | grep -qE '^([0-9]{1,3}\.){3}[0-9]{1,3}$'; then
+            echo "$ip"
+            return 0
+        fi
+    done
+}
+
 # Ensure /root/.ssh/authorized_keys exists when in Docker and empty (E2E only; is_docker guard)
 # Dockerfile/ci_test keys may not persist with systemd-as-init; run_1 creates as fallback
 ensure_docker_e2e_keys() {

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -63,6 +63,7 @@ bash install/test/test_doctor_service_drift.sh
 bash install/test/test_ensure_dispatch.sh
 bash install/test/test_plan_json.sh
 bash install/test/test_install_planner.sh
+bash install/test/test_installer_security_assertions.sh
 
 echo "=== Docs consistency ==="
 bash test/ci_test_docs_consistency.sh

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -535,6 +535,16 @@ run_unit_tests() {
         log_test "SKIP" "test_install_planner.sh: file not found"
     fi
 
+    if [[ -f "$PROJECT_ROOT/install/test/test_installer_security_assertions.sh" ]]; then
+        if bash "$PROJECT_ROOT/install/test/test_installer_security_assertions.sh"; then
+            log_test "PASS" "test_installer_security_assertions.sh: all tests passed"
+        else
+            log_test "FAIL" "test_installer_security_assertions.sh: some tests failed"
+        fi
+    else
+        log_test "SKIP" "test_installer_security_assertions.sh: file not found"
+    fi
+
     if [[ -f "$PROJECT_ROOT/test/ci_test_mcp_server.sh" ]]; then
         if bash "$PROJECT_ROOT/test/ci_test_mcp_server.sh"; then
             log_test "PASS" "ci_test_mcp_server.sh: all tests passed"


### PR DESCRIPTION
## Summary

Fresh branch from current master tip (`3657b42`), superseding #188 which was cut from an older base. All 22 commits cherry-picked cleanly; `./scripts/pre-commit.sh` passes 25/25.

- **nethermind:** snap-pivot from publicnode.com at install time (non-zero pivot, never `PivotNumber: 0`); per-endpoint validation with fall-through; omit pivot/ExternalIp on detection failure; external IP for P2P; post-merge history barriers; correct config keys + drop privileged RPC modules
- **besu:** drop loopback `p2p-host` from base template (dedup crash-loop fix); `history-expiry-prune=true`; remove ENGINE from HTTP + WS RPC modules
- **reth:** prune pre-merge bodies+receipts; correct `--full` comment
- **geth:** guard `geth version` call against SIGTTIN install-hang; restrict HTTP/WS RPC to `eth,net,web3`
- **common:** `detect_external_ip()` helper (curl fallback chain + IPv4 validation + empty fallback), used by besu + nethermind + prysm p2p-host-ip
- **consensus:** history pruning across all 5 CLs (grandine `--prune-storage`, teku `data-storage-mode: minimal`, nimbus `history: prune`, lodestar `pruneHistory: true`, prysm `--beacon-db-pruning`); prysm pin to latest GitHub release with version-guard; per-client `CLIENT_GRAFFITI`
- **docs:** pruned-history mode documented; nimbus-eth1 era1-dependency noted
- **tests:** EL installer security assertions suite (13 static assertions, HTTP-RPC surface, ENGINE isolation, external-IP failure path)

## Supersedes

Closes #188 — identical commit set, rebased onto current master for a clean merge. #188 is being closed as superseded.

## Test plan

- [x] `./scripts/pre-commit.sh` 25/25 (shellcheck/shebang/structure/unit tests)
- [x] All 22 commits cherry-picked onto `master` tip with zero conflicts
- [ ] Spot-check nethermind snap-syncs with peers + non-zero pivot (validated live during bake-off: 49 peers, pivot 25,424,235)
- [ ] Spot-check one CL reaches checkpoint sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>