### PR TITLE
dream(docs): relocate HANDOFF_diskcleanup.md to docs/GETH_DISK_PRUNE.md

### DIFF
--- a/.claude/dream-state.md
+++ b/.claude/dream-state.md
@@ -1,7 +1,12 @@
-last_run: 2026-06-06
+last_run: 2026-07-12
 status: completed
-lines_removed: 688
+lines_removed: 0
 files_removed: 0
+files_moved: 1
+actions:
+  - moved HANDOFF_diskcleanup.md to docs/GETH_DISK_PRUNE.md (session-artifact name cleaned from root)
+  - updated reference in clean_geth_history.sh
+  - updated reference in install/execution/geth.sh
 unverified_claims: 0
 undocumented_features: 0
-next_focus: check for undocumented MCP tool updates since 2026-04-21
+next_focus: light pass only

--- a/clean_geth_history.sh
+++ b/clean_geth_history.sh
@@ -5,7 +5,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/exports.sh"
 # ---------------------------------------------------------------------------
 # clean_geth_history.sh - reclaim disk by pruning geth's ancient freezer
 # ---------------------------------------------------------------------------
-# WHY THIS EXISTS (see HANDOFF_diskcleanup.md for the full story):
+# WHY THIS EXISTS (see docs/GETH_DISK_PRUNE.md for the full story):
 #
 #   `geth snapshot prune-state` DOES NOT WORK on this node and never will.
 #   Our geth runs the path-based state scheme (PBSS), and geth refuses

--- a/docs/GETH_DISK_PRUNE.md
+++ b/docs/GETH_DISK_PRUNE.md
@@ -1,4 +1,4 @@
-# Disk cleanup handoff — geth state bloat / freezer pruning
+# Geth disk prune — reclaiming freezer space
 
 _Last updated: 2026-06-16_
 
@@ -9,7 +9,7 @@ _Last updated: 2026-06-16_
 - `geth snapshot prune-state` **does not work and never will** on this node —
   it's the wrong tool for our setup.
 - The fix is **`geth prune-history --history.chain postmerge`**, wrapped in
-  [`clean_geth_history.sh`](./clean_geth_history.sh).
+  [`clean_geth_history.sh`](../clean_geth_history.sh).
 - There is **only one geth database**. A whole-disk scan found exactly one
   `chaindata` + one `ancient`. No second/duplicate db.
 

--- a/install/execution/geth.sh
+++ b/install/execution/geth.sh
@@ -58,7 +58,7 @@ export GETH_CMD="/usr/bin/geth --cache=$GETH_CACHE --syncmode snap \
 # built-in miner; fee recipient is set by the consensus client (MEV / vanilla).
 # --history.chain postmerge: don't keep pre-merge block bodies/receipts in the
 # ancient freezer (saves ~500-800G on a staking node). To reclaim space on an
-# already-synced node, run clean_geth_history.sh. See HANDOFF_diskcleanup.md.
+# already-synced node, run clean_geth_history.sh. See docs/GETH_DISK_PRUNE.md.
 # --http.api / --ws.api: no spaces after commas (systemd ExecStart splits on spaces).
 
 


### PR DESCRIPTION
**Agent:** Claude Sonnet 4.6
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary
- Move session-artifact-named `HANDOFF_diskcleanup.md` from repo root to `docs/GETH_DISK_PRUNE.md`
- Update title to drop "handoff" framing; content preserved verbatim
- Fix relative markdown link (`./clean_geth_history.sh` → `../clean_geth_history.sh`)
- Update cross-references in `clean_geth_history.sh` and `install/execution/geth.sh`

## Original Request
> Sunday Dream pass (2026-07-12): relocate session-artifact-named files from repo root to proper docs/ location

## Changes Made
- `HANDOFF_diskcleanup.md` → `docs/GETH_DISK_PRUNE.md` (rename + title update)
- `clean_geth_history.sh:8` — updated doc reference
- `install/execution/geth.sh:61` — updated doc reference
- `.claude/dream-state.md` — updated to record this pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01H51yhb39P6tT7jzTaCVNLB)_