### PR TITLE
fix(validators): feed withdrawal mnemonic on stdin, not argv

### DIFF
--- a/install/test/test_validator_withdrawal_changes.sh
+++ b/install/test/test_validator_withdrawal_changes.sh
@@ -49,6 +49,13 @@ setup_fake_env() {
 set -Eeuo pipefail
 : "${MOCK_DEPOSIT_LOG:?missing MOCK_DEPOSIT_LOG}"
 echo "[MOCK] deposit.sh $*" >> "$MOCK_DEPOSIT_LOG"
+# The real deposit CLI prompts for the mnemonic on stdin when --mnemonic is
+# omitted; capture it so the test can confirm it arrived off-argv.
+if [[ -n "${MOCK_MNEMONIC_LOG:-}" ]]; then
+    _stdin_mnemonic=""
+    IFS= read -r _stdin_mnemonic || true
+    printf '%s\n' "$_stdin_mnemonic" >> "$MOCK_MNEMONIC_LOG"
+fi
 out_dir=""
 indices=""
 for arg in "$@"; do
@@ -199,13 +206,14 @@ JSONEOF
 
 # shellcheck disable=SC2317
 test_generate_and_submit_0x00_changes() {
-    local temp_root output deposit_log curl_log out_dir
+    local temp_root output deposit_log curl_log out_dir mnemonic_log
     temp_root="$(setup_fake_env)"
     deposit_log="$temp_root/deposit.log"
     curl_log="$temp_root/curl.log"
+    mnemonic_log="$temp_root/mnemonic.stdin.log"
     out_dir="$temp_root/generated"
 
-    output="$(MOCK_DEPOSIT_LOG="$deposit_log" MOCK_CURL_LOG="$curl_log" PATH="$temp_root/bin:$PATH" "$PROJECT_ROOT/install/utils/validator_withdrawal_changes.sh" \
+    output="$(MOCK_DEPOSIT_LOG="$deposit_log" MOCK_CURL_LOG="$curl_log" MOCK_MNEMONIC_LOG="$mnemonic_log" PATH="$temp_root/bin:$PATH" "$PROJECT_ROOT/install/utils/validator_withdrawal_changes.sh" \
         --validators-json "$temp_root/validators.json" \
         --credential-type 0x00 \
         --generate \
@@ -224,6 +232,11 @@ test_generate_and_submit_0x00_changes() {
     assert_contains "--execution_address=0x1111111111111111111111111111111111111111" "$deposit_log"
     test -f "$out_dir/bls_to_execution_change-1700000000.json"
     assert_contains "/eth/v1/beacon/pool/bls_to_execution_changes" "$curl_log"
+
+    # Security: the master mnemonic must NOT appear on argv (it would be visible
+    # in /proc/<pid>/cmdline and `ps`). It must instead be delivered on stdin.
+    if grep -q -- '--mnemonic=' "$deposit_log"; then return 1; fi
+    assert_contains "abandon abandon abandon" "$mnemonic_log"
 
     printf '%s\n' "$output" | grep -q "Submitting bls_to_execution_change-1700000000.json"
 

--- a/install/utils/validator_withdrawal_changes.sh
+++ b/install/utils/validator_withdrawal_changes.sh
@@ -353,7 +353,6 @@ generate_changes() {
         generate-bls-to-execution-change
         --bls_to_execution_changes_folder="$target_dir"
         --chain="$CHAIN"
-        --mnemonic="$mnemonic"
         --validator_indices="$SELECTED_INDICES"
         --bls_withdrawal_credentials_list="$SELECTED_WITHDRAWAL_CREDENTIALS"
         --execution_address="$WITHDRAWAL_ADDRESS"
@@ -363,7 +362,12 @@ generate_changes() {
     fi
 
     log_info "Generating BLS-to-execution changes with $launcher"
-    "$launcher" "${args[@]}"
+    # Feed the mnemonic on stdin instead of via --mnemonic= on argv, so the
+    # master secret never appears in /proc/<pid>/cmdline or `ps` while the
+    # deposit CLI runs. The CLI prompts for the mnemonic when the flag is
+    # omitted and reads it from stdin. (A mnemonic passphrase, if used, still
+    # transits --mnemonic_password on argv — the CLI does not prompt for it.)
+    printf '%s\n' "$mnemonic" | "$launcher" "${args[@]}"
     write_generation_manifest "$target_dir" || return 1
 }
 
@@ -377,10 +381,10 @@ preview_generation() {
             generate-bls-to-execution-change \
             --bls_to_execution_changes_folder="$target_dir_hint" \
             --chain="$CHAIN" \
-            --mnemonic="<hidden>" \
             --validator_indices="$SELECTED_INDICES" \
             --bls_withdrawal_credentials_list="$SELECTED_WITHDRAWAL_CREDENTIALS" \
             --execution_address="$WITHDRAWAL_ADDRESS"
+        log_info "  (the mnemonic is fed to the deposit CLI on stdin, not via --mnemonic on the command line)"
     else
         log_warn "Deposit CLI not found; install deposit.sh or deposit before generating for real."
     fi


### PR DESCRIPTION
## Summary

`validator_withdrawal_changes.sh` passed the withdrawal **master mnemonic** to the deposit CLI as `--mnemonic=<secret>` on **argv** — visible in `/proc/<pid>/cmdline` and `ps` to any local user for the life of the call. The mnemonic derives every validator key, so it's the most sensitive secret in the flow. (The consolidation path already keeps its private key off argv via a temp keystore; this closes the same gap here.)

**Fix:** omit `--mnemonic` and pipe the mnemonic to the CLI on **stdin** (the CLI prompts for it when the flag is absent). The secret never reaches argv. **Fails safe** — if the CLI errored instead of prompting, generation fails visibly; it can never submit a wrong address.

## Verification

- Mock deposit CLI now reads the mnemonic from stdin; the generate test asserts **(a)** `--mnemonic=` is absent from argv and **(b)** the mnemonic arrived on stdin. Confirmed the assertion **bites** (the old argv code fails it). Full withdrawal suite: 5/5.

## ⚠️ Caveat — validate before merge

The CLI's "omit-flag → prompt-on-stdin" behavior is confirmed from the **staking-deposit-cli docs** ("if there are missing arguments … it will ask you for them") but is exercised here only against the **mock**, not a real CLI. **Please validate against a real `generate-bls-to-execution-change` run before merging.** A mnemonic passphrase (if used) still transits `--mnemonic_password` on argv — the CLI doesn't prompt for it (smaller, optional exposure; noted in-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYEPfpBn9QyJULWyPBQfhP