### PR TITLE
test(doctor): make test_doctor_service_drift harness gate

### DIFF
--- a/install/test/test_doctor_service_drift.sh
+++ b/install/test/test_doctor_service_drift.sh
@@ -18,7 +18,13 @@ run_test() {
     echo ""
     echo "=== Test $test_count: $test_name ==="
 
-    if "$test_func"; then
+    local _rc _e_was=0
+    [[ $- == *e* ]] && _e_was=1
+    set +e
+    ( set -euo pipefail; "$test_func" )
+    _rc=$?
+    [[ $_e_was -eq 1 ]] && set -e
+    if [[ $_rc -eq 0 ]]; then
         echo "PASS: $test_name"
         pass_count=$((pass_count + 1))
     else

--- a/install/test/test_doctor_service_drift.sh
+++ b/install/test/test_doctor_service_drift.sh
@@ -138,12 +138,23 @@ EOF
 
 # shellcheck disable=SC2317
 test_doctor_reports_service_unit_drift_in_json() {
-    local temp_root output
+    local temp_root output dj_rc
     temp_root="$(setup_fake_repo)"
 
-    output="$(PATH="$temp_root/bin:$PATH" "$temp_root/install/utils/doctor.sh" --json)"
+    dj_rc=0
+    output="$(PATH="$temp_root/bin:$PATH" "$temp_root/install/utils/doctor.sh" --json 2>"$temp_root/doctor.err")" || dj_rc=$?
 
-    if ! jq -e '.checks[] | select(.name == "Execution client (eth1): Service unit drift detected" and .status == "warn") | .details == "Unit expects ethrex but runtime is geth"' >/dev/null <<< "$output"; then
+    if [[ $dj_rc -ne 0 ]] || ! jq -e '.checks[] | select(.name == "Execution client (eth1): Service unit drift detected" and .status == "warn") | .details == "Unit expects ethrex but runtime is geth"' >/dev/null <<< "$output"; then
+        {
+            echo "=== DIAGNOSTIC: doctor drift test failed (temporary instrumentation) ==="
+            echo "doctor --json exit=$dj_rc  jq=$(command -v jq || echo NO)  bash=$BASH_VERSION  user=$(whoami)"
+            echo "ps=$(command -v ps || echo NO)  systemctl=$(command -v systemctl || echo NO)"
+            echo "--- doctor stderr ---"; head -20 "$temp_root/doctor.err" 2>/dev/null
+            echo "--- stdout valid JSON? ---"; printf '%s' "$output" | jq -e . >/dev/null 2>&1 && echo yes || echo NO
+            echo "--- drift/client checks ---"; printf '%s' "$output" | jq -rc '.checks[]? | select(.name|test("client|drift";"i")) | {name,status,details}' 2>&1 | head
+            echo "--- raw stdout (first 2000 chars) ---"; printf '%s' "$output" | head -c 2000; echo
+            echo "=== END DIAGNOSTIC ==="
+        } >&2
         rm -rf "$temp_root"
         return 1
     fi

--- a/install/test/test_doctor_service_drift.sh
+++ b/install/test/test_doctor_service_drift.sh
@@ -138,23 +138,16 @@ EOF
 
 # shellcheck disable=SC2317
 test_doctor_reports_service_unit_drift_in_json() {
-    local temp_root output dj_rc
+    local temp_root output
     temp_root="$(setup_fake_repo)"
 
-    dj_rc=0
-    output="$(PATH="$temp_root/bin:$PATH" "$temp_root/install/utils/doctor.sh" --json 2>"$temp_root/doctor.err")" || dj_rc=$?
+    # doctor.sh --json exits non-zero whenever the overall status is "fail" —
+    # e.g. a small CI runner fails the disk-space minimum. This test only cares
+    # about the service-unit-drift check, so capture the JSON regardless of exit
+    # code rather than letting a failing environment check abort the assertion.
+    output="$(PATH="$temp_root/bin:$PATH" "$temp_root/install/utils/doctor.sh" --json)" || true
 
-    if [[ $dj_rc -ne 0 ]] || ! jq -e '.checks[] | select(.name == "Execution client (eth1): Service unit drift detected" and .status == "warn") | .details == "Unit expects ethrex but runtime is geth"' >/dev/null <<< "$output"; then
-        {
-            echo "=== DIAGNOSTIC: doctor drift test failed (temporary instrumentation) ==="
-            echo "doctor --json exit=$dj_rc  jq=$(command -v jq || echo NO)  bash=$BASH_VERSION  user=$(whoami)"
-            echo "ps=$(command -v ps || echo NO)  systemctl=$(command -v systemctl || echo NO)"
-            echo "--- doctor stderr ---"; head -20 "$temp_root/doctor.err" 2>/dev/null
-            echo "--- stdout valid JSON? ---"; printf '%s' "$output" | jq -e . >/dev/null 2>&1 && echo yes || echo NO
-            echo "--- drift/client checks ---"; printf '%s' "$output" | jq -rc '.checks[]? | select(.name|test("client|drift";"i")) | {name,status,details}' 2>&1 | head
-            echo "--- raw stdout (first 2000 chars) ---"; printf '%s' "$output" | head -c 2000; echo
-            echo "=== END DIAGNOSTIC ==="
-        } >&2
+    if ! jq -e '.checks[] | select(.name == "Execution client (eth1): Service unit drift detected" and .status == "warn") | .details == "Unit expects ethrex but runtime is geth"' >/dev/null <<< "$output"; then
         rm -rf "$temp_root"
         return 1
     fi


### PR DESCRIPTION
Completes the run_test harness fix (#193, #196) for the last suite. Excluded from #196 because it failed in CI once gating for real, but I could **not reproduce** locally as user+root, in ubuntu containers, or in an exact rebuild of the `eth-node-test` CI image running the exact CI command — pointing to a flake/transient CI condition. Pushing to let CI confirm; will merge if green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYEPfpBn9QyJULWyPBQfhP