### PR TITLE
docs: refresh STATUS.md to current capabilities

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -14,7 +14,7 @@ Last updated: 2026-07-18
 - Diagnostics & operations (`scripts/eth2qs.sh`): `doctor` health checks, `monitor`/`stats` (JSON-capable), `repair`, `update-check`, `clean-data`, `cleanup-host`, `update-all`
 - Agent integration: MCP server (`mcp_server/`) exposing `phase1`/`phase2`/`client-options`/monitoring/repair as first-class tools
 - Experimental: Monad devnet install path (`monad-install`)
-- Client bake-off complete: all 7 execution + 6 consensus clients benchmarked for synced disk footprint and sync time (Stage A triage + Stage B full sync + CL matrix) — see [CLIENT_BAKEOFF_RESULTS.md](CLIENT_BAKEOFF_RESULTS.md)
+- Client bake-off complete: all 7 execution clients plus 5 non-Prysm consensus clients benchmarked for synced disk footprint and sync time (Stage A triage + Stage B full sync + CL matrix; Prysm was the fixed execution-sweep anchor) — see [CLIENT_BAKEOFF_RESULTS.md](CLIENT_BAKEOFF_RESULTS.md)
 - Canonical service units:
   - `eth1.service`
   - `cl.service`

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Project Status
 
-Last updated: 2026-03-13
+Last updated: 2026-07-18
 
 ## Current Capabilities
 
@@ -10,6 +10,11 @@ Last updated: 2026-03-13
 - Execution clients (7): geth, erigon, reth, nethermind, besu, nimbus_eth1, ethrex
 - Consensus clients (6): prysm, lighthouse, teku, nimbus, lodestar, grandine
 - MEV options: MEV-Boost, Commit-Boost, optional ETHGas (with Commit-Boost)
+- Validator lifecycle helpers (`scripts/eth2qs.sh`): `validators` inventory, `validator-exit`, `validator-create-0x01`/`validator-create-0x02`, `validator-deploy`, `validator-manage`, and `validator-withdrawal-changes` (BLS-to-execution, with a `--dry-run` rehearsal path) — see [VALIDATOR_MANAGEMENT.md](VALIDATOR_MANAGEMENT.md)
+- Diagnostics & operations (`scripts/eth2qs.sh`): `doctor` health checks, `monitor`/`stats` (JSON-capable), `repair`, `update-check`, `clean-data`, `cleanup-host`, `update-all`
+- Agent integration: MCP server (`mcp_server/`) exposing `phase1`/`phase2`/`client-options`/monitoring/repair as first-class tools
+- Experimental: Monad devnet install path (`monad-install`)
+- Client bake-off complete: all 7 execution + 6 consensus clients benchmarked for synced disk footprint and sync time (Stage A triage + Stage B full sync + CL matrix) — see [CLIENT_BAKEOFF_RESULTS.md](CLIENT_BAKEOFF_RESULTS.md)
 - Canonical service units:
   - `eth1.service`
   - `cl.service`
@@ -52,3 +57,5 @@ Last updated: 2026-03-13
 - Frontend guide: `docs/FRONTEND.md`
 - Closed PR follow-up tracker: `docs/PR_FOLLOWUPS.md`
 - Session continuity: `docs/agent-handoff.md`
+- Validator management: `docs/VALIDATOR_MANAGEMENT.md`
+- Client bake-off (results + methodology): `docs/CLIENT_BAKEOFF_BLOG.md`, `docs/CLIENT_BAKEOFF_RESULTS.md`


### PR DESCRIPTION
## What

`docs/STATUS.md` was last-updated **2026-03-13** and had drifted well behind the shipped surface. This refreshes it against ground truth (verified against `scripts/eth2qs.sh`'s command list and the docs on disk):

- **Date** → 2026-07-18.
- **Current Capabilities** gains: validator lifecycle helpers (`validators`, `validator-exit`, `validator-create-0x01/0x02`, `validator-deploy`, `validator-manage`, `validator-withdrawal-changes` with `--dry-run`); diagnostics & ops (`doctor`, `monitor`/`stats`, `repair`, `update-check`, `clean-data`, `cleanup-host`, `update-all`); the MCP server (`mcp_server/`); the experimental Monad install path; and the completed client bake-off.
- **Canonical Docs** gains the validator-management and bake-off results docs.

## Verification

Docs-only. Every added flag/command exists in `scripts/eth2qs.sh`; every referenced doc exists on disk. `test/ci_test_docs_consistency.sh` passes (links resolve, no retired-reference regressions).

**Agent:** Claude Opus 4.8
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeQumEfSTcvMDnzJvda2wj