### PR TITLE
docs: record the live site and that master auto-publishes to it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,13 @@ This file provides essential context for AI assistants working in this repositor
 
 The project also includes a **Next.js marketing website** (`frontend/`) and comprehensive **CI pipelines** via GitHub Actions.
 
+**The website is live at [eth2quickstart.com](https://eth2quickstart.com)** (no hyphen), and
+**merging to `master` publishes to it automatically** — within minutes, for edits as well as new
+routes. The deploy pipeline is configured outside this repo (no workflow or deploy config here);
+it serves the Next.js standalone build behind CloudFront. Treat any `frontend/` change reaching
+`master` as publishing to a public website: verify it with a production build and a local preview
+first. See `frontend/README.md` (Deployment) and `docs/BLOG_GUIDE.md`.
+
 ---
 
 ## Critical Rules — Read First

--- a/docs/BLOG_GUIDE.md
+++ b/docs/BLOG_GUIDE.md
@@ -12,6 +12,12 @@ The blog lives in the Next.js frontend (`frontend/app/blog/`). Articles are **ha
 | `/blog/bakeoff-harness` | the function-level harness reference |
 | `/blog/bakeoff-results` | the raw results |
 
+All of it is live at **[eth2quickstart.com](https://eth2quickstart.com)** — e.g.
+[`/blog`](https://eth2quickstart.com/blog). **Merging to `master` publishes automatically**
+(within minutes, edits included), so a merged article change is public immediately. Preview
+locally with `bun run build && bun run start` in `frontend/` first — see
+[frontend/README.md](../frontend/README.md#deployment).
+
 ---
 
 ## Sharing an article — deep links to any subheading

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,6 +1,12 @@
 # Frontend Guide
 
-This repo includes a marketing frontend in `frontend/`.
+This repo includes a marketing frontend in `frontend/`. It is live at
+**[eth2quickstart.com](https://eth2quickstart.com)** (no hyphen), and **merging to `master`
+publishes it automatically** — within minutes, edits included. The deploy pipeline lives
+outside this repo (no workflow or deploy config here) and serves the Next.js standalone build
+behind CloudFront, so a merged `frontend/` change is public immediately: build and preview it
+locally first. Details in [`frontend/README.md`](../frontend/README.md#deployment); the blog and
+slide deck are covered in [`BLOG_GUIDE.md`](BLOG_GUIDE.md).
 
 ## Canonical Sources
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,4 +36,24 @@ frontend/
 
 ## Deployment
 
-Push to GitHub and connect to Vercel for automatic deployment.
+**Live site: [eth2quickstart.com](https://eth2quickstart.com)** — note the spelling: no hyphen.
+(`eth2-quickstart.com`, with a hyphen, does not resolve; it was a stale reference in the code
+until it was corrected, so don't reintroduce it.)
+
+**Merging to `master` publishes automatically.** There is no deploy step in this
+repo — no workflow, no `vercel.json`/`amplify.yml`. The pipeline is configured
+outside the repository: it builds the Next.js standalone output
+(`output: 'standalone'` in `next.config.js`) and serves it behind CloudFront.
+A merge goes live within minutes, for both new routes and edits to existing
+pages, so treat a merge to `master` as publishing to a public website.
+
+Because CloudFront caches aggressively (`s-maxage`, `stale-while-revalidate`),
+give a change a minute and force-reload if you still see the old version.
+
+To preview a production build locally before merging:
+
+```bash
+bun run build
+bun run start                     # quick preview; Next warns it isn't the standalone server
+node .next/standalone/server.js   # production-faithful (matches what's deployed)
+```


### PR DESCRIPTION
## What

The site is live at **[eth2quickstart.com](https://eth2quickstart.com)** and **merging to `master` publishes to it automatically** — verified when #209 merged: the four new blog routes, the deck, `/sitemap.xml` and `/robots.txt` all went live within minutes, and the pre-existing bake-off article started serving its *updated* content (so edits propagate too, not just new routes).

None of that was written down anywhere, and `frontend/README.md` actively claimed the wrong thing.

## Changes

- **Fix a stale, incorrect claim.** `frontend/README.md` said "connect to Vercel for automatic deployment". The live site is served behind **CloudFront** (`via: ... cloudfront.net`, `x-amz-cf-pop`) from the Next.js **standalone** build (`output: 'standalone'`). There is no deploy workflow or deploy config in this repo — the pipeline is configured externally.
- **Note the live URL + auto-publish behaviour** in `frontend/README.md`, `docs/FRONTEND.md`, `docs/BLOG_GUIDE.md`, and `CLAUDE.md`, so anyone touching `frontend/` knows a merge to `master` is a public release and should be previewed first.
- **Record the domain spelling** (no hyphen). `eth2-quickstart.com` does not resolve — it was a stale reference in the code until it was corrected; this keeps it from being reintroduced.
- Add local production-preview commands, including the standalone server, which is what actually gets deployed.

Docs only — no code or behaviour change. `test/ci_test_docs_consistency.sh` passes locally (it validates the local markdown links added here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGFtDbx3D739eprAKUUk9w