### PR TITLE
perf, a11y, and SEO refinements across the frontend

### DIFF
--- a/frontend/__tests__/app/robots.test.ts
+++ b/frontend/__tests__/app/robots.test.ts
@@ -1,0 +1,20 @@
+import robots from '@/app/robots'
+import { SITE_CONFIG } from '@/lib/constants'
+
+describe('robots', () => {
+  const result = robots()
+
+  it('allows all crawling for every user agent', () => {
+    expect(result.rules).toEqual({ userAgent: '*', allow: '/' })
+  })
+
+  it('points sitemap and host at the same domain as SITE_CONFIG.url', () => {
+    expect(result.sitemap).toBe(`${SITE_CONFIG.url}/sitemap.xml`)
+    expect(result.host).toBe(SITE_CONFIG.url)
+  })
+
+  it('uses the canonical non-hyphenated domain literally (guards a wrong constant)', () => {
+    expect(result.host).toBe('https://eth2quickstart.com')
+    expect(result.sitemap).toBe('https://eth2quickstart.com/sitemap.xml')
+  })
+})

--- a/frontend/__tests__/app/sitemap.test.ts
+++ b/frontend/__tests__/app/sitemap.test.ts
@@ -1,0 +1,36 @@
+import sitemap from '@/app/sitemap'
+import { ARTICLES } from '@/lib/articles'
+
+describe('sitemap', () => {
+  const entries = sitemap()
+
+  it('has every url on the canonical (non-hyphenated) domain', () => {
+    entries.forEach((entry) => {
+      expect(entry.url.startsWith('https://eth2quickstart.com')).toBe(true)
+      expect(entry.url).not.toContain('eth2-quickstart.com')
+    })
+  })
+
+  it('includes a route for every article in the registry', () => {
+    ARTICLES.forEach((article) => {
+      const match = entries.find((entry) =>
+        entry.url.endsWith(`/blog/${article.slug}`)
+      )
+      expect(match).toBeDefined()
+    })
+  })
+
+  it('has exactly one sitemap entry per article slug (no missing, no stale)', () => {
+    const blogEntries = entries.filter((entry) =>
+      /\/blog\/[^/]+$/.test(entry.url)
+    )
+    expect(blogEntries.length).toBe(ARTICLES.length)
+  })
+
+  it('includes the core static routes', () => {
+    const paths = entries.map((entry) => entry.url)
+    expect(paths).toContain('https://eth2quickstart.com')
+    expect(paths).toContain('https://eth2quickstart.com/quickstart')
+    expect(paths).toContain('https://eth2quickstart.com/blog')
+  })
+})

--- a/frontend/__tests__/components/AnchorHeading.test.tsx
+++ b/frontend/__tests__/components/AnchorHeading.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { AnchorHeading } from '@/components/ui/AnchorHeading'
+import { copyToClipboard } from '@/lib/utils'
+
+jest.mock('@/lib/utils', () => ({
+  ...jest.requireActual('@/lib/utils'),
+  copyToClipboard: jest.fn(),
+}))
+
+const mockedCopyToClipboard = copyToClipboard as jest.Mock
+
+describe('AnchorHeading', () => {
+  beforeEach(() => {
+    mockedCopyToClipboard.mockReset()
+    window.history.replaceState(null, '', '/some/page')
+  })
+
+  it('renders the requested heading tag with its children', () => {
+    render(
+      <AnchorHeading id="section-one" as="h3">
+        Section One
+      </AnchorHeading>
+    )
+    const heading = screen.getByRole('heading', { level: 3, name: 'Section One' })
+    expect(heading.tagName).toBe('H3')
+    expect(heading).toHaveAttribute('id', 'section-one')
+  })
+
+  it('defaults to h2 when `as` is omitted', () => {
+    render(<AnchorHeading id="default-heading">Default</AnchorHeading>)
+    expect(screen.getByRole('heading', { level: 2, name: 'Default' })).toBeInTheDocument()
+  })
+
+  it('clicking copy sets the url hash and calls copyToClipboard with the absolute url', async () => {
+    mockedCopyToClipboard.mockResolvedValue(true)
+    render(<AnchorHeading id="my-section">My Section</AnchorHeading>)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /copy link/i }))
+      await Promise.resolve()
+    })
+
+    expect(window.location.hash).toBe('#my-section')
+    expect(mockedCopyToClipboard).toHaveBeenCalledWith(
+      `${window.location.origin}${window.location.pathname}#my-section`
+    )
+  })
+
+  it('shows the copied state only when copyToClipboard resolves true', async () => {
+    mockedCopyToClipboard.mockResolvedValue(true)
+    render(<AnchorHeading id="succeeds">Succeeds</AnchorHeading>)
+
+    fireEvent.click(screen.getByRole('button', { name: /copy link/i }))
+
+    expect(await screen.findByRole('button', { name: /link copied/i })).toBeInTheDocument()
+  })
+
+  it('does NOT show the copied state when copyToClipboard resolves false', async () => {
+    mockedCopyToClipboard.mockResolvedValue(false)
+    render(<AnchorHeading id="fails">Fails</AnchorHeading>)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /copy link/i }))
+      // Let the pending promise settle within act() so React flushes any
+      // (absent) state update before we assert.
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByRole('button', { name: /link copied/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /copy link/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/__tests__/components/ArticleJsonLd.test.tsx
+++ b/frontend/__tests__/components/ArticleJsonLd.test.tsx
@@ -39,13 +39,23 @@ describe('ArticleJsonLd', () => {
     expect(blogPosting.dateModified).toBeTruthy()
   })
 
-  it('strips the site-name suffix from headline', () => {
-    const schema = renderJsonLd(slug)
-    const blogPosting = schema['@graph'].find(
-      (node: any) => node['@type'] === 'BlogPosting'
-    )
-    expect(blogPosting.headline).not.toContain('ETH2 Quick Start')
-  })
+  // Titles use two different dash styles before the site name ("- ETH2 Quick Start"
+  // and "— ETH2 Quick Start"), so exercise every article rather than just one.
+  it.each(ARTICLES.map((article) => [article.slug] as const))(
+    'strips the site-name suffix from the headline for %s',
+    (articleSlug) => {
+      const article = getArticle(articleSlug)
+      const schema = renderJsonLd(articleSlug)
+      const blogPosting = schema['@graph'].find(
+        (node: any) => node['@type'] === 'BlogPosting'
+      )
+      expect(blogPosting.headline).not.toContain('ETH2 Quick Start')
+      // The headline must still be the real title, not an empty or truncated string.
+      expect(blogPosting.headline.length).toBeGreaterThan(10)
+      expect(article.pageTitle).toContain(blogPosting.headline)
+      expect(blogPosting.headline).not.toMatch(/[-—]\s*$/)
+    }
+  )
 
   it('attributes author and publisher to the Organization, not a person', () => {
     const schema = renderJsonLd(slug)

--- a/frontend/__tests__/components/ArticleJsonLd.test.tsx
+++ b/frontend/__tests__/components/ArticleJsonLd.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react'
+import { ArticleJsonLd } from '@/components/ui/ArticleJsonLd'
+import { ARTICLES, getArticle } from '@/lib/articles'
+import { SITE_CONFIG } from '@/lib/constants'
+
+function renderJsonLd(slug: string) {
+  const { container } = render(<ArticleJsonLd slug={slug} />)
+  const script = container.querySelector('script[type="application/ld+json"]')
+  expect(script).not.toBeNull()
+  return JSON.parse(script!.innerHTML)
+}
+
+describe('ArticleJsonLd', () => {
+  const slug = ARTICLES[0].slug
+  const article = getArticle(slug)
+
+  it('emits valid JSON-LD (does not throw parsing)', () => {
+    expect(() => renderJsonLd(slug)).not.toThrow()
+  })
+
+  it('includes a BlogPosting with absolute url/image on the site domain', () => {
+    const schema = renderJsonLd(slug)
+    const blogPosting = schema['@graph'].find(
+      (node: any) => node['@type'] === 'BlogPosting'
+    )
+    expect(blogPosting).toBeDefined()
+    expect(blogPosting.url).toBe(`${SITE_CONFIG.url}/blog/${slug}`)
+    expect(blogPosting.url.startsWith(SITE_CONFIG.url)).toBe(true)
+    expect(blogPosting.image).toBe(`${SITE_CONFIG.url}${article.ogImage}`)
+    expect(blogPosting.image.startsWith(SITE_CONFIG.url)).toBe(true)
+  })
+
+  it('sets datePublished and dateModified', () => {
+    const schema = renderJsonLd(slug)
+    const blogPosting = schema['@graph'].find(
+      (node: any) => node['@type'] === 'BlogPosting'
+    )
+    expect(blogPosting.datePublished).toBeTruthy()
+    expect(blogPosting.dateModified).toBeTruthy()
+  })
+
+  it('strips the site-name suffix from headline', () => {
+    const schema = renderJsonLd(slug)
+    const blogPosting = schema['@graph'].find(
+      (node: any) => node['@type'] === 'BlogPosting'
+    )
+    expect(blogPosting.headline).not.toContain('ETH2 Quick Start')
+  })
+
+  it('attributes author and publisher to the Organization, not a person', () => {
+    const schema = renderJsonLd(slug)
+    const blogPosting = schema['@graph'].find(
+      (node: any) => node['@type'] === 'BlogPosting'
+    )
+    expect(blogPosting.author['@type']).toBe('Organization')
+    expect(blogPosting.publisher['@type']).toBe('Organization')
+  })
+
+  it('has a Home -> Blog -> Article BreadcrumbList', () => {
+    const schema = renderJsonLd(slug)
+    const breadcrumb = schema['@graph'].find(
+      (node: any) => node['@type'] === 'BreadcrumbList'
+    )
+    expect(breadcrumb).toBeDefined()
+    const items = breadcrumb.itemListElement
+    expect(items).toHaveLength(3)
+    expect(items[0]).toMatchObject({ position: 1, name: 'Home', item: SITE_CONFIG.url })
+    expect(items[1]).toMatchObject({
+      position: 2,
+      name: 'Blog',
+      item: `${SITE_CONFIG.url}/blog`,
+    })
+    expect(items[2]).toMatchObject({
+      position: 3,
+      name: article.navTitle,
+      item: `${SITE_CONFIG.url}/blog/${slug}`,
+    })
+  })
+})

--- a/frontend/__tests__/components/ArticleToc.test.tsx
+++ b/frontend/__tests__/components/ArticleToc.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { ArticleToc } from '@/components/ui/ArticleToc'
+
+describe('ArticleToc', () => {
+  const links = [
+    { label: 'Intro', href: '#intro' },
+    { label: 'Methodology', href: '#methodology' },
+    { label: 'Results', href: '#results' },
+  ]
+
+  it('renders a labeled nav', () => {
+    render(<ArticleToc links={links} />)
+    expect(screen.getByRole('navigation', { name: 'Table of contents' })).toBeInTheDocument()
+  })
+
+  it('renders exactly one link per item, pointing at the right hrefs', () => {
+    render(<ArticleToc links={links} />)
+    const renderedLinks = screen.getAllByRole('link')
+    expect(renderedLinks).toHaveLength(links.length)
+
+    links.forEach((link) => {
+      const rendered = screen.getByRole('link', { name: link.label })
+      expect(rendered).toHaveAttribute('href', link.href)
+    })
+  })
+
+  it('renders no links when given an empty list', () => {
+    render(<ArticleToc links={[]} />)
+    expect(screen.queryAllByRole('link')).toHaveLength(0)
+  })
+})

--- a/frontend/__tests__/components/BackToTop.test.tsx
+++ b/frontend/__tests__/components/BackToTop.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { BackToTop } from '@/components/ui/BackToTop'
+
+function setScrollY(value: number) {
+  Object.defineProperty(window, 'scrollY', { value, configurable: true })
+}
+
+function mockMatchMedia(reducedMotion: boolean) {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: reducedMotion,
+    media: query,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  }))
+}
+
+describe('BackToTop', () => {
+  const originalMatchMedia = window.matchMedia
+  const originalScrollY = window.scrollY
+  const originalScrollTo = window.scrollTo
+  const originalIntersectionObserver = (window as any).IntersectionObserver
+
+  beforeEach(() => {
+    setScrollY(0)
+    window.scrollTo = jest.fn()
+  })
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia
+    setScrollY(originalScrollY ?? 0)
+    window.scrollTo = originalScrollTo
+    ;(window as any).IntersectionObserver = originalIntersectionObserver
+  })
+
+  it('is hidden before the page has scrolled past the threshold', () => {
+    render(<BackToTop />)
+    expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument()
+  })
+
+  it('appears once scrolled past 600px', () => {
+    render(<BackToTop />)
+    setScrollY(601)
+    fireEvent.scroll(window)
+    expect(screen.getByRole('button', { name: 'Back to top' })).toBeInTheDocument()
+  })
+
+  it('hides again if scrolling back above the threshold', () => {
+    render(<BackToTop />)
+    setScrollY(601)
+    fireEvent.scroll(window)
+    expect(screen.getByRole('button', { name: 'Back to top' })).toBeInTheDocument()
+
+    setScrollY(0)
+    fireEvent.scroll(window)
+    expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument()
+  })
+
+  it('scrolls smoothly on click when the user has no reduced-motion preference', () => {
+    mockMatchMedia(false)
+    render(<BackToTop />)
+    setScrollY(601)
+    fireEvent.scroll(window)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to top' }))
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
+  })
+
+  it('scrolls instantly on click when the user prefers reduced motion', () => {
+    mockMatchMedia(true)
+    render(<BackToTop />)
+    setScrollY(601)
+    fireEvent.scroll(window)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to top' }))
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' })
+  })
+
+  // The component hides itself once the page footer scrolls into view (so it
+  // never overlaps the footer's own links). jsdom has no real layout/viewport
+  // intersection, so this only proves the component wires up an
+  // IntersectionObserver against the footer and reacts to its callback —
+  // it does not exercise real browser intersection geometry.
+  it('hides when the (mocked) footer-intersection observer reports the footer is in view', () => {
+    mockMatchMedia(false)
+    let observedCallback: IntersectionObserverCallback | undefined
+    const observe = jest.fn()
+    const disconnect = jest.fn()
+    ;(window as any).IntersectionObserver = jest.fn().mockImplementation((callback) => {
+      observedCallback = callback
+      return { observe, disconnect, unobserve: jest.fn() }
+    })
+
+    const footer = document.createElement('footer')
+    document.body.appendChild(footer)
+
+    try {
+      render(<BackToTop />)
+      setScrollY(601)
+      fireEvent.scroll(window)
+      expect(screen.getByRole('button', { name: 'Back to top' })).toBeInTheDocument()
+      expect(observe).toHaveBeenCalledWith(footer)
+
+      // Simulate the footer scrolling into view.
+      act(() => {
+        observedCallback?.(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver
+        )
+      })
+
+      expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument()
+    } finally {
+      document.body.removeChild(footer)
+    }
+  })
+})

--- a/frontend/__tests__/components/ReadNext.test.tsx
+++ b/frontend/__tests__/components/ReadNext.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import { ReadNext } from '@/components/ui/ReadNext'
+import { ARTICLES } from '@/lib/articles'
+
+describe('ReadNext', () => {
+  it.each(ARTICLES.map((article) => [article.slug]))(
+    'for slug %s: renders exactly 3 links, never itself, each pointing at /blog/<slug>',
+    (slug) => {
+      render(<ReadNext currentSlug={slug} />)
+      const links = screen.getAllByRole('link')
+      expect(links).toHaveLength(ARTICLES.length - 1)
+
+      const hrefs = links.map((link) => link.getAttribute('href'))
+      expect(hrefs).not.toContain(`/blog/${slug}`)
+
+      hrefs.forEach((href) => {
+        expect(href).toMatch(/^\/blog\/[^/]+$/)
+      })
+
+      const otherSlugs = ARTICLES.filter((a) => a.slug !== slug).map(
+        (a) => `/blog/${a.slug}`
+      )
+      expect(new Set(hrefs)).toEqual(new Set(otherSlugs))
+    }
+  )
+})

--- a/frontend/__tests__/lib/articles.test.ts
+++ b/frontend/__tests__/lib/articles.test.ts
@@ -56,9 +56,22 @@ describe('ARTICLES registry', () => {
 })
 
 describe('getArticle', () => {
-  it('returns the matching article for a known slug', () => {
-    const target = ARTICLES[0]
-    expect(getArticle(target.slug)).toEqual(target)
+  // Comparing a lookup's result against the registry it reads from is tautological,
+  // so pin the flagship article's real values independently of the registry.
+  it('returns the article identified by the slug, with its own values', () => {
+    const article = getArticle('ethereum-client-bakeoff')
+    expect(article.slug).toBe('ethereum-client-bakeoff')
+    expect(article.ogImage).toBe('/og-bakeoff.png')
+    expect(article.datePublished).toBe('2026-07-19')
+    expect(article.navTitle).toBe('Ethereum client bake-off')
+  })
+
+  it('maps each slug to a distinct article, never a shared or default one', () => {
+    for (const target of ARTICLES) {
+      expect(getArticle(target.slug).slug).toBe(target.slug)
+    }
+    const images = ARTICLES.map((article) => getArticle(article.slug).ogImage)
+    expect(new Set(images).size).toBe(ARTICLES.length)
   })
 
   it('throws on an unknown slug', () => {

--- a/frontend/__tests__/lib/articles.test.ts
+++ b/frontend/__tests__/lib/articles.test.ts
@@ -1,0 +1,104 @@
+import { ARTICLES, getArticle, buildArticleMetadata } from '@/lib/articles'
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+describe('ARTICLES registry', () => {
+  it('has at least one article', () => {
+    expect(ARTICLES.length).toBeGreaterThan(0)
+  })
+
+  it.each(ARTICLES.map((article) => [article.slug, article]))(
+    '%s has all required non-empty fields',
+    (_slug, article) => {
+      expect(article.slug).toBeTruthy()
+      expect(article.pageTitle).toBeTruthy()
+      expect(article.pageDescription).toBeTruthy()
+      expect(article.navTitle).toBeTruthy()
+      expect(article.indexDescription).toBeTruthy()
+      expect(article.ogImage).toBeTruthy()
+      expect(article.ogAlt).toBeTruthy()
+      expect(article.datePublished).toBeTruthy()
+    }
+  )
+
+  it('has unique slugs', () => {
+    const slugs = ARTICLES.map((a) => a.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+  })
+
+  it('has datePublished matching YYYY-MM-DD for every article', () => {
+    ARTICLES.forEach((article) => {
+      expect(article.datePublished).toMatch(DATE_RE)
+    })
+  })
+
+  it('has ogImage paths that are site-relative PNGs', () => {
+    ARTICLES.forEach((article) => {
+      expect(article.ogImage.startsWith('/')).toBe(true)
+      expect(article.ogImage.endsWith('.png')).toBe(true)
+    })
+  })
+
+  // SEO length guards: these caught real bugs (a title or description that
+  // silently grew past what search engines display in full).
+  it('has pageTitle no longer than 60 characters', () => {
+    ARTICLES.forEach((article) => {
+      expect(article.pageTitle.length).toBeLessThanOrEqual(60)
+    })
+  })
+
+  it('has pageDescription between 120 and 165 characters', () => {
+    ARTICLES.forEach((article) => {
+      expect(article.pageDescription.length).toBeGreaterThanOrEqual(120)
+      expect(article.pageDescription.length).toBeLessThanOrEqual(165)
+    })
+  })
+})
+
+describe('getArticle', () => {
+  it('returns the matching article for a known slug', () => {
+    const target = ARTICLES[0]
+    expect(getArticle(target.slug)).toEqual(target)
+  })
+
+  it('throws on an unknown slug', () => {
+    expect(() => getArticle('not-a-real-slug')).toThrow(
+      /unknown article slug/i
+    )
+  })
+})
+
+describe('buildArticleMetadata', () => {
+  it('builds the canonical url as /blog/<slug>', () => {
+    const article = ARTICLES[0]
+    const metadata = buildArticleMetadata(article.slug)
+    expect(metadata.alternates?.canonical).toBe(`/blog/${article.slug}`)
+  })
+
+  it('sets openGraph.type to article', () => {
+    const article = ARTICLES[0]
+    const metadata = buildArticleMetadata(article.slug)
+    expect((metadata.openGraph as any)?.type).toBe('article')
+  })
+
+  it('provides an image with 1200x630 dimensions and non-empty alt', () => {
+    const article = ARTICLES[0]
+    const metadata = buildArticleMetadata(article.slug)
+    const images = metadata.openGraph?.images
+    expect(Array.isArray(images)).toBe(true)
+    const image = (images as any[])[0]
+    expect(image.width).toBe(1200)
+    expect(image.height).toBe(630)
+    expect(image.alt).toBeTruthy()
+  })
+
+  it('sets twitter.card to summary_large_image', () => {
+    const article = ARTICLES[0]
+    const metadata = buildArticleMetadata(article.slug)
+    expect((metadata.twitter as any)?.card).toBe('summary_large_image')
+  })
+
+  it('throws when built for an unknown slug', () => {
+    expect(() => buildArticleMetadata('nope')).toThrow(/unknown article slug/i)
+  })
+})

--- a/frontend/__tests__/lib/utils.test.ts
+++ b/frontend/__tests__/lib/utils.test.ts
@@ -20,12 +20,81 @@ describe('cn utility', () => {
 })
 
 describe('copyToClipboard', () => {
-  it('is a function', () => {
-    expect(typeof copyToClipboard).toBe('function')
+  const originalIsSecureContext = window.isSecureContext
+  const originalExecCommand = document.execCommand
+  const originalClipboard = navigator.clipboard
+
+  afterEach(() => {
+    Object.defineProperty(window, 'isSecureContext', {
+      value: originalIsSecureContext,
+      configurable: true,
+    })
+    // execCommand may not exist at all in this jsdom environment; restore
+    // faithfully rather than always reassigning a function.
+    if (originalExecCommand === undefined) {
+      // Deleting a possibly-absent jsdom API to restore baseline.
+      delete (document as any).execCommand
+    } else {
+      document.execCommand = originalExecCommand
+    }
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+      writable: true,
+    })
+    jest.restoreAllMocks()
   })
 
-  it('returns a promise', () => {
-    const result = copyToClipboard('test')
-    expect(result).toBeInstanceOf(Promise)
+  it('uses navigator.clipboard.writeText and resolves true in a secure context', async () => {
+    Object.defineProperty(window, 'isSecureContext', {
+      value: true,
+      configurable: true,
+    })
+    const writeText = jest.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+
+    const result = await copyToClipboard('hello secure world')
+
+    expect(writeText).toHaveBeenCalledWith('hello secure world')
+    expect(result).toBe(true)
+  })
+
+  it('falls back to document.execCommand and resolves true when it succeeds', async () => {
+    Object.defineProperty(window, 'isSecureContext', {
+      value: false,
+      configurable: true,
+    })
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+    document.execCommand = jest.fn().mockReturnValue(true)
+
+    const result = await copyToClipboard('hello fallback world')
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy')
+    expect(result).toBe(true)
+  })
+
+  it('resolves false when both clipboard and execCommand are unavailable/fail', async () => {
+    Object.defineProperty(window, 'isSecureContext', {
+      value: false,
+      configurable: true,
+    })
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+    document.execCommand = jest.fn().mockReturnValue(false)
+
+    const result = await copyToClipboard('hello failing world')
+
+    expect(result).toBe(false)
   })
 })

--- a/frontend/app/blog/bakeoff-harness/page.tsx
+++ b/frontend/app/blog/bakeoff-harness/page.tsx
@@ -1,38 +1,17 @@
 import type { Metadata } from 'next'
 import { AnchorHeading } from '@/components/ui/AnchorHeading'
 import { ArticleJsonLd } from '@/components/ui/ArticleJsonLd'
+import { ArticleToc } from '@/components/ui/ArticleToc'
 import { BackToTop } from '@/components/ui/BackToTop'
 import { Badge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { ReadNext } from '@/components/ui/ReadNext'
+import { buildArticleMetadata } from '@/lib/articles'
 import { SITE_CONFIG } from '@/lib/constants'
 import { ArrowDown, ArrowRight } from 'lucide-react'
 
-const PAGE_TITLE = 'The Bake-off Harness — ETH2 Quick Start'
-const PAGE_DESCRIPTION =
-  'A function-level engineering reference for the bake-off harness: every script under test/bakeoff/, every function it calls, every flag it reads, and the data files it produces.'
-const PAGE_OG_ALT = 'The bake-off harness — a function-level engineering reference'
-
-export const metadata: Metadata = {
-  title: PAGE_TITLE,
-  description: PAGE_DESCRIPTION,
-  alternates: { canonical: '/blog/bakeoff-harness' },
-  openGraph: {
-    type: 'article',
-    siteName: 'ETH2 Quick Start',
-    images: [{ url: '/og-harness.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
-    url: '/blog/bakeoff-harness',
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [{ url: '/og-harness.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
-}
+export const metadata: Metadata = buildArticleMetadata('bakeoff-harness')
 
 const tocLinks = [
   { label: '1. Layout', href: '#layout' },
@@ -310,13 +289,7 @@ export default function BakeoffHarnessPage() {
   return (
     <div className="min-h-screen py-12 sm:py-16 md:py-24">
       <div className="mx-auto max-w-5xl px-4 sm:px-6">
-        <ArticleJsonLd
-          title={PAGE_TITLE}
-          description={PAGE_DESCRIPTION}
-          slug="bakeoff-harness"
-          image="/og-harness.png"
-          datePublished="2026-07-21"
-        />
+        <ArticleJsonLd slug="bakeoff-harness" />
         <header id="article-top" tabIndex={-1} className="focus:outline-none">
           <p className="font-mono text-sm text-muted-foreground uppercase tracking-wide">
             Engineering &middot; Companion to the bake-off writeup
@@ -350,18 +323,7 @@ export default function BakeoffHarnessPage() {
           </div>
         </header>
 
-        <nav aria-label="Table of contents" className="mt-8 rounded-lg border border-border p-4 sm:p-5">
-          <p className="font-mono text-xs text-muted-foreground uppercase tracking-wide">Contents</p>
-          <ul className="mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-sm">
-            {tocLinks.map((link) => (
-              <li key={link.href}>
-                <a href={link.href} className="text-primary hover:underline">
-                  {link.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        <ArticleToc links={tocLinks} />
 
         {/* 1. Layout */}
         <section className="mt-10 sm:mt-16">

--- a/frontend/app/blog/bakeoff-results/page.tsx
+++ b/frontend/app/blog/bakeoff-results/page.tsx
@@ -2,37 +2,16 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { AnchorHeading } from '@/components/ui/AnchorHeading'
 import { ArticleJsonLd } from '@/components/ui/ArticleJsonLd'
+import { ArticleToc } from '@/components/ui/ArticleToc'
 import { BackToTop } from '@/components/ui/BackToTop'
 import { Badge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
 import { ReadNext } from '@/components/ui/ReadNext'
+import { buildArticleMetadata } from '@/lib/articles'
 import { SITE_CONFIG } from '@/lib/constants'
 import { ArrowRight } from 'lucide-react'
 
-const PAGE_TITLE = 'Bake-off Results — ETH2 Quick Start'
-const PAGE_DESCRIPTION =
-  'The full raw results doc from the 23-day Ethereum client bake-off: every Stage A triage row, every Stage B disk-footprint measurement, the CL matrix on two anchors, client limitations, and every gotcha — verbatim from docs/CLIENT_BAKEOFF_RESULTS.md.'
-const PAGE_OG_ALT = 'Bake-off results — the raw data'
-
-export const metadata: Metadata = {
-  title: PAGE_TITLE,
-  description: PAGE_DESCRIPTION,
-  alternates: { canonical: '/blog/bakeoff-results' },
-  openGraph: {
-    type: 'article',
-    siteName: 'ETH2 Quick Start',
-    images: [{ url: '/og-results.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
-    url: '/blog/bakeoff-results',
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [{ url: '/og-results.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
-}
+export const metadata: Metadata = buildArticleMetadata('bakeoff-results')
 
 /**
  * Small dependency-free inline parser for the markdown-lite emphasis used
@@ -303,13 +282,7 @@ export default function BakeoffResultsPage() {
   return (
     <div className="min-h-screen py-12 sm:py-16 md:py-24">
       <div className="mx-auto max-w-5xl px-4 sm:px-6">
-        <ArticleJsonLd
-          title={PAGE_TITLE}
-          description={PAGE_DESCRIPTION}
-          slug="bakeoff-results"
-          image="/og-results.png"
-          datePublished="2026-07-21"
-        />
+        <ArticleJsonLd slug="bakeoff-results" />
         <header id="article-top" tabIndex={-1} className="focus:outline-none">
           <p className="font-mono text-sm text-muted-foreground uppercase tracking-wide">
             Raw results
@@ -347,18 +320,7 @@ export default function BakeoffResultsPage() {
           </div>
         </header>
 
-        <nav aria-label="Table of contents" className="mt-8 rounded-lg border border-border p-4 sm:p-5">
-          <p className="font-mono text-xs text-muted-foreground uppercase tracking-wide">Contents</p>
-          <ul className="mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-sm">
-            {tocLinks.map((link) => (
-              <li key={link.href}>
-                <a href={link.href} className="text-primary hover:underline">
-                  {link.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        <ArticleToc links={tocLinks} />
 
         {/* ---------------------------------------------------------------- */}
         <section className="mt-10 sm:mt-16">

--- a/frontend/app/blog/ethereum-client-bakeoff/page.tsx
+++ b/frontend/app/blog/ethereum-client-bakeoff/page.tsx
@@ -2,38 +2,16 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { AnchorHeading } from '@/components/ui/AnchorHeading'
 import { ArticleJsonLd } from '@/components/ui/ArticleJsonLd'
+import { ArticleToc } from '@/components/ui/ArticleToc'
 import { Badge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { ReadNext } from '@/components/ui/ReadNext'
+import { buildArticleMetadata } from '@/lib/articles'
 import { SITE_CONFIG } from '@/lib/constants'
 import { ArrowRight } from 'lucide-react'
 
-const PAGE_TITLE = 'Ethereum Client Bake-off - ETH2 Quick Start'
-const PAGE_DESCRIPTION =
-  'The full write-up: results from a 23-day Ethereum execution and consensus client sync campaign, including the restart-resilience findings the headline numbers hide.'
-const PAGE_OG_ALT =
-  'The fastest Ethereum client is one almost nobody runs — a 23-day client bake-off'
-
-export const metadata: Metadata = {
-  title: PAGE_TITLE,
-  description: PAGE_DESCRIPTION,
-  alternates: { canonical: '/blog/ethereum-client-bakeoff' },
-  openGraph: {
-    type: 'article',
-    siteName: 'ETH2 Quick Start',
-    images: [{ url: '/og-bakeoff.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
-    url: '/blog/ethereum-client-bakeoff',
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [{ url: '/og-bakeoff.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
-}
+export const metadata: Metadata = buildArticleMetadata('ethereum-client-bakeoff')
 
 const tocLinks = [
   { label: 'TL;DR', href: '#tldr' },
@@ -230,14 +208,8 @@ export default function EthereumClientBakeoffPage() {
   return (
     <div className="min-h-screen py-12 sm:py-16 md:py-24">
       <div className="mx-auto max-w-5xl px-4 sm:px-6">
-        <ArticleJsonLd
-          title={PAGE_TITLE}
-          description={PAGE_DESCRIPTION}
-          slug="ethereum-client-bakeoff"
-          image="/og-bakeoff.png"
-          datePublished="2026-07-19"
-        />
-        <header>
+        <ArticleJsonLd slug="ethereum-client-bakeoff" />
+        <header id="article-top" tabIndex={-1} className="focus:outline-none">
           <p className="font-mono text-sm text-muted-foreground uppercase tracking-wide">
             Blog
           </p>
@@ -284,18 +256,7 @@ export default function EthereumClientBakeoffPage() {
           </p>
         </Card>
 
-        <nav aria-label="Table of contents" className="mt-8 rounded-lg border border-border p-4 sm:p-5">
-          <p className="font-mono text-xs text-muted-foreground uppercase tracking-wide">Contents</p>
-          <ul className="mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-sm">
-            {tocLinks.map((link) => (
-              <li key={link.href}>
-                <a href={link.href} className="text-primary hover:underline">
-                  {link.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        <ArticleToc links={tocLinks} />
 
         <section className="mt-10 sm:mt-16">
           <AnchorHeading id="tldr" className="text-lg sm:text-xl font-semibold text-foreground">

--- a/frontend/app/blog/how-we-tested-with-claude/page.tsx
+++ b/frontend/app/blog/how-we-tested-with-claude/page.tsx
@@ -1,37 +1,16 @@
 import type { Metadata } from 'next'
 import { AnchorHeading } from '@/components/ui/AnchorHeading'
 import { ArticleJsonLd } from '@/components/ui/ArticleJsonLd'
+import { ArticleToc } from '@/components/ui/ArticleToc'
 import { Badge } from '@/components/ui/Badge'
 import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { ReadNext } from '@/components/ui/ReadNext'
+import { buildArticleMetadata } from '@/lib/articles'
 import { SITE_CONFIG } from '@/lib/constants'
 import { ArrowDown, ArrowRight, ArrowUp } from 'lucide-react'
 
-const PAGE_TITLE = 'How We Ran a 23-Day Ethereum Client Bake-off With Claude - ETH2 Quick Start'
-const PAGE_DESCRIPTION =
-  'The agent orchestration model, the harness, and what actually breaks when a benchmark runs for three weeks on a shared host with an AI in the driver’s seat.'
-const PAGE_OG_ALT = 'How we ran a 23-day Ethereum client bake-off with Claude'
-
-export const metadata: Metadata = {
-  title: PAGE_TITLE,
-  description: PAGE_DESCRIPTION,
-  alternates: { canonical: '/blog/how-we-tested-with-claude' },
-  openGraph: {
-    type: 'article',
-    siteName: 'ETH2 Quick Start',
-    images: [{ url: '/og-how-we-tested.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
-    url: '/blog/how-we-tested-with-claude',
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [{ url: '/og-how-we-tested.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
-    title: PAGE_TITLE,
-    description: PAGE_DESCRIPTION,
-  },
-}
+export const metadata: Metadata = buildArticleMetadata('how-we-tested-with-claude')
 
 const tocLinks = [
   { label: 'TL;DR', href: '#tldr' },
@@ -299,14 +278,8 @@ export default function HowWeTestedWithClaudePage() {
   return (
     <div className="min-h-screen py-12 sm:py-16 md:py-24">
       <div className="mx-auto max-w-5xl px-4 sm:px-6">
-        <ArticleJsonLd
-          title={PAGE_TITLE}
-          description={PAGE_DESCRIPTION}
-          slug="how-we-tested-with-claude"
-          image="/og-how-we-tested.png"
-          datePublished="2026-07-22"
-        />
-        <header>
+        <ArticleJsonLd slug="how-we-tested-with-claude" />
+        <header id="article-top" tabIndex={-1} className="focus:outline-none">
           <p className="font-mono text-sm text-muted-foreground uppercase tracking-wide">
             Blog &middot; Companion to the bake-off writeup
           </p>
@@ -346,18 +319,7 @@ export default function HowWeTestedWithClaudePage() {
           </p>
         </Card>
 
-        <nav aria-label="Table of contents" className="mt-8 rounded-lg border border-border p-4 sm:p-5">
-          <p className="font-mono text-xs text-muted-foreground uppercase tracking-wide">Contents</p>
-          <ul className="mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-sm">
-            {tocLinks.map((link) => (
-              <li key={link.href}>
-                <a href={link.href} className="text-primary hover:underline">
-                  {link.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        <ArticleToc links={tocLinks} />
 
         <section className="mt-10 sm:mt-16">
           <AnchorHeading id="tldr" className="text-lg sm:text-xl font-semibold text-foreground">TL;DR</AnchorHeading>

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from 'next'
 import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
+import { ARTICLES } from '@/lib/articles'
+import { SITE_CONFIG } from '@/lib/constants'
 
 const BLOG_TITLE = 'Blog - ETH2 Quick Start'
-const BLOG_DESCRIPTION = 'Notes and results from the ETH2 Quick Start lab.'
+const BLOG_DESCRIPTION =
+  'Field notes and benchmarks from the ETH2 Quick Start lab: the 23-day Ethereum client bake-off, how we tested it with Claude, the harness, and raw results.'
 
 const BLOG_OG_ALT = 'ETH2 Quick Start — from the lab'
 
@@ -14,7 +17,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: 'website',
     url: '/blog',
-    siteName: 'ETH2 Quick Start',
+    siteName: SITE_CONFIG.shortName,
     title: BLOG_TITLE,
     description: BLOG_DESCRIPTION,
     images: [{ url: '/og.png', width: 1200, height: 630, alt: BLOG_OG_ALT }],
@@ -27,36 +30,12 @@ export const metadata: Metadata = {
   },
 }
 
-const posts = [
-  {
-    eyebrow: 'Client research',
-    title: 'Ethereum client bake-off',
-    description:
-      'Results from a 23-day execution and consensus client sync campaign: disk, speed, and restart resilience across the full client roster.',
-    href: '/blog/ethereum-client-bakeoff',
-  },
-  {
-    eyebrow: 'Methodology',
-    title: 'How we tested with Claude',
-    description:
-      'The orchestration model and harness behind the 23-day campaign — how a fleet of agents ran, sampled, and gated every client sync.',
-    href: '/blog/how-we-tested-with-claude',
-  },
-  {
-    eyebrow: 'Engineering',
-    title: 'The bake-off harness',
-    description:
-      'A function-level engineering reference for the harness: the orchestrator, the per-candidate state machine, resource caps, and the probe/sample/gate library.',
-    href: '/blog/bakeoff-harness',
-  },
-  {
-    eyebrow: 'Data',
-    title: 'Bake-off results',
-    description:
-      'The raw results: Stage A pass matrix, final synced disk footprints, the consensus-client matrices, and operational-viability notes.',
-    href: '/blog/bakeoff-results',
-  },
-]
+const posts = ARTICLES.map((article) => ({
+  eyebrow: article.eyebrow,
+  title: article.navTitle,
+  description: article.indexDescription,
+  href: `/blog/${article.slug}`,
+}))
 
 export default function BlogPage() {
   return (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -2,8 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap');
-
 :root {
   --background: #09090b;
   --foreground: #fafafa;
@@ -33,7 +31,7 @@ body {
   color: var(--foreground);
   background: var(--background);
   position: relative;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: var(--font-sans), -apple-system, BlinkMacSystemFont, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   line-height: 1.6;
@@ -83,7 +81,7 @@ body::before {
 }
 
 code {
-  font-family: 'JetBrains Mono', 'SF Mono', monospace;
+  font-family: var(--font-mono), 'SF Mono', monospace;
 }
 
 /* Inline code - allow wrapping at word boundaries to prevent overflow */

--- a/frontend/app/icon.svg
+++ b/frontend/app/icon.svg
@@ -1,0 +1,11 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="ETH2 Quick Start">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#c084fc"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="7" fill="#09090b"/>
+  <path d="M8 11 L14 16 L8 21" fill="none" stroke="url(#g)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="17" y="19" width="8" height="3" rx="1.5" fill="url(#g)"/>
+</svg>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,23 @@
 import type { Metadata } from 'next'
+import { Inter, JetBrains_Mono } from 'next/font/google'
 import './globals.css'
 import { Navbar } from '@/components/layout/Navbar'
 import { Footer } from '@/components/layout/Footer'
+import { MotionProvider } from './motion-provider'
+
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  display: 'swap',
+  variable: '--font-sans',
+})
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  display: 'swap',
+  variable: '--font-mono',
+})
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://eth2quickstart.com'),
@@ -28,11 +44,21 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" className={`dark ${inter.variable} ${jetbrainsMono.variable}`}>
       <body className="min-h-screen bg-background text-foreground antialiased overflow-x-hidden">
-        <Navbar />
-        <main className="overflow-x-hidden">{children}</main>
-        <Footer />
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-3 focus:z-[60] focus:rounded focus:bg-background focus:px-4 focus:py-2 focus:text-foreground focus:outline focus:outline-2 focus:outline-primary"
+        >
+          Skip to content
+        </a>
+        <MotionProvider>
+          <Navbar />
+          <main id="main-content" tabIndex={-1} className="overflow-x-hidden focus:outline-none">
+            {children}
+          </main>
+          <Footer />
+        </MotionProvider>
       </body>
     </html>
   )

--- a/frontend/app/motion-provider.tsx
+++ b/frontend/app/motion-provider.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { MotionConfig } from 'framer-motion'
+
+export function MotionProvider({ children }: { children: React.ReactNode }) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 import { Hero } from '@/components/sections/Hero'
 import { Install } from '@/components/sections/Install'
 import { Workflow } from '@/components/sections/Workflow'
@@ -5,6 +6,32 @@ import { Agents } from '@/components/sections/Agents'
 import { Features } from '@/components/sections/Features'
 import { Blog } from '@/components/sections/Blog'
 import { CallToAction } from '@/components/sections/CallToAction'
+import { SITE_CONFIG } from '@/lib/constants'
+
+const PAGE_TITLE = 'ETH2 Quick Start - Ethereum Node Setup in Minutes'
+const PAGE_DESCRIPTION =
+  'Transform a fresh server into a fully-configured Ethereum node. 12 clients, automated security, MEV integration.'
+const PAGE_OG_ALT = 'ETH2 Quick Start — turn a fresh server into a fully-configured Ethereum node'
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: '/' },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_CONFIG.shortName,
+    url: '/',
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [{ url: '/og.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [{ url: '/og.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
+  },
+}
 
 /**
  * Homepage component

--- a/frontend/app/quickstart/page.tsx
+++ b/frontend/app/quickstart/page.tsx
@@ -12,9 +12,29 @@ import {
 } from '@/lib/constants'
 import { ArrowRight, Server, HardDrive, Cpu, ExternalLink } from 'lucide-react'
 
+const PAGE_TITLE = 'Get Started - ETH2 Quick Start'
+const PAGE_DESCRIPTION =
+  'Get your Ethereum node running in 30 minutes. One-liner or manual install with run_1.sh and run_2.sh.'
+const PAGE_OG_ALT = 'Get your Ethereum node running in 30 minutes — one-liner or manual install'
+
 export const metadata: Metadata = {
-  title: 'Get Started - ETH2 Quick Start',
-  description: 'Get your Ethereum node running in 30 minutes. One-liner or manual install with run_1.sh and run_2.sh.',
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: '/quickstart' },
+  openGraph: {
+    type: 'website',
+    siteName: SITE_CONFIG.shortName,
+    url: '/quickstart',
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [{ url: '/og.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [{ url: '/og.png', width: 1200, height: 630, alt: PAGE_OG_ALT }],
+  },
 }
 
 const RECOMMENDED_SPECS = [

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,9 +1,10 @@
 import type { MetadataRoute } from 'next'
+import { SITE_CONFIG } from '@/lib/constants'
 
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: '*', allow: '/' },
-    sitemap: 'https://eth2quickstart.com/sitemap.xml',
-    host: 'https://eth2quickstart.com',
+    sitemap: `${SITE_CONFIG.url}/sitemap.xml`,
+    host: SITE_CONFIG.url,
   }
 }

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,23 +1,29 @@
 import type { MetadataRoute } from 'next'
-
-const BASE = 'https://eth2quickstart.com'
+import { ARTICLES } from '@/lib/articles'
+import { SITE_CONFIG } from '@/lib/constants'
 
 // Static routes worth indexing. Blog articles get a higher priority since
 // they're the pages we want people to find and share.
-const routes: { path: string; priority: number }[] = [
+const staticRoutes: { path: string; priority: number }[] = [
   { path: '', priority: 1 },
   { path: '/quickstart', priority: 0.7 },
   { path: '/blog', priority: 0.7 },
-  { path: '/blog/ethereum-client-bakeoff', priority: 0.9 },
-  { path: '/blog/how-we-tested-with-claude', priority: 0.8 },
-  { path: '/blog/bakeoff-harness', priority: 0.8 },
-  { path: '/blog/bakeoff-results', priority: 0.8 },
+]
+
+const blogRoutes: { path: string; priority: number }[] = ARTICLES.map((article) => ({
+  path: `/blog/${article.slug}`,
+  priority: article.sitemapPriority,
+}))
+
+const routes: { path: string; priority: number }[] = [
+  ...staticRoutes,
+  ...blogRoutes,
   { path: '/deck/bakeoff.html', priority: 0.6 },
 ]
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return routes.map(({ path, priority }) => ({
-    url: `${BASE}${path}`,
+    url: `${SITE_CONFIG.url}${path}`,
     changeFrequency: 'monthly',
     priority,
   }))

--- a/frontend/components/layout/Navbar.tsx
+++ b/frontend/components/layout/Navbar.tsx
@@ -38,9 +38,10 @@ export function Navbar() {
       <div className="mx-auto max-w-6xl px-4 sm:px-6">
         <div className="flex h-14 items-center justify-between">
           {/* Logo */}
-          <Link 
-            href="/" 
+          <Link
+            href="/"
             className="font-mono text-sm font-medium text-foreground"
+            onClick={() => setMobileMenuOpen(false)}
           >
             {SITE_CONFIG.shortName}
           </Link>
@@ -81,7 +82,11 @@ export function Navbar() {
             aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
             aria-expanded={mobileMenuOpen}
           >
-            {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+            {mobileMenuOpen ? (
+              <X className="h-5 w-5" aria-hidden="true" />
+            ) : (
+              <Menu className="h-5 w-5" aria-hidden="true" />
+            )}
           </button>
         </div>
       </div>
@@ -90,8 +95,9 @@ export function Navbar() {
       <div
         className={cn(
           'border-t border-border bg-background md:hidden overflow-hidden transition-all duration-200 ease-out',
-          mobileMenuOpen ? 'max-h-80 opacity-100' : 'max-h-0 opacity-0 border-t-0'
+          mobileMenuOpen ? 'visible max-h-80 opacity-100' : 'invisible max-h-0 opacity-0 border-t-0'
         )}
+        aria-hidden={!mobileMenuOpen}
       >
         <div className="px-4 sm:px-6 py-4 space-y-1 mobile-menu-enter">
           {NAV_LINKS.map((link) => (

--- a/frontend/components/ui/ArticleJsonLd.tsx
+++ b/frontend/components/ui/ArticleJsonLd.tsx
@@ -1,40 +1,52 @@
-const SITE_URL = 'https://eth2quickstart.com'
+import { getArticle } from '@/lib/articles'
+import { SITE_CONFIG } from '@/lib/constants'
 
 const ORGANIZATION = {
   '@type': 'Organization',
-  name: 'ETH2 Quick Start',
-  url: SITE_URL,
+  name: SITE_CONFIG.shortName,
+  url: SITE_CONFIG.url,
 } as const
 
 export interface ArticleJsonLdProps {
-  title: string
-  description: string
-  /** Blog post slug, e.g. 'ethereum-client-bakeoff' — used to build the canonical URL. */
+  /** Blog post slug, e.g. 'ethereum-client-bakeoff' — all other fields are resolved from the article registry. */
   slug: string
-  /** Site-relative image path, e.g. '/og-bakeoff.png' — resolved to an absolute URL. */
-  image: string
-  /** ISO date string, e.g. '2026-07-19'. */
-  datePublished: string
 }
 
 /**
- * Renders a schema.org BlogPosting JSON-LD block for a blog article. Organization-only
+ * Renders schema.org JSON-LD for a blog article: a BlogPosting plus a
+ * Home → Blog → Article BreadcrumbList, as a single `@graph`. Organization-only
  * attribution (author + publisher) — no invented person byline.
  */
-export function ArticleJsonLd({ title, description, slug, image, datePublished }: ArticleJsonLdProps) {
-  const url = `${SITE_URL}/blog/${slug}`
+export function ArticleJsonLd({ slug }: ArticleJsonLdProps) {
+  const article = getArticle(slug)
+  const url = `${SITE_CONFIG.url}/blog/${article.slug}`
 
   const schema = {
     '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    headline: title,
-    description,
-    image: `${SITE_URL}${image}`,
-    datePublished,
-    mainEntityOfPage: url,
-    url,
-    author: ORGANIZATION,
-    publisher: ORGANIZATION,
+    '@graph': [
+      {
+        '@type': 'BlogPosting',
+        headline: article.headline,
+        description: article.pageDescription,
+        image: `${SITE_CONFIG.url}${article.ogImage}`,
+        datePublished: article.datePublished,
+        // No updates tracked separately yet — reusing datePublished is explicitly
+        // allowed by Google's structured-data guidance when nothing has changed.
+        dateModified: article.datePublished,
+        mainEntityOfPage: url,
+        url,
+        author: ORGANIZATION,
+        publisher: ORGANIZATION,
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_CONFIG.url },
+          { '@type': 'ListItem', position: 2, name: 'Blog', item: `${SITE_CONFIG.url}/blog` },
+          { '@type': 'ListItem', position: 3, name: article.navTitle, item: url },
+        ],
+      },
+    ],
   }
 
   return (

--- a/frontend/components/ui/ArticleToc.tsx
+++ b/frontend/components/ui/ArticleToc.tsx
@@ -1,0 +1,29 @@
+export interface ArticleTocLink {
+  label: string
+  href: string
+}
+
+export interface ArticleTocProps {
+  links: ArticleTocLink[]
+}
+
+/**
+ * Shared "Table of contents" nav shell used by every blog article. The markup is
+ * byte-identical across articles; only the `links` data differs per page.
+ */
+export function ArticleToc({ links }: ArticleTocProps) {
+  return (
+    <nav aria-label="Table of contents" className="mt-8 rounded-lg border border-border p-4 sm:p-5">
+      <p className="font-mono text-xs text-muted-foreground uppercase tracking-wide">Contents</p>
+      <ul className="mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-sm">
+        {links.map((link) => (
+          <li key={link.href}>
+            <a href={link.href} className="text-primary hover:underline">
+              {link.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/frontend/components/ui/CodeBlock.tsx
+++ b/frontend/components/ui/CodeBlock.tsx
@@ -2,9 +2,14 @@
 
 import { useState } from 'react'
 import { cn, copyToClipboard } from '@/lib/utils'
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter'
+import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash'
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { Copy, Check } from 'lucide-react'
+
+// Only bash is used anywhere in this repo (verified via grep across app/components).
+// Register any additional language here if a new call site ever needs one.
+SyntaxHighlighter.registerLanguage('bash', bash)
 
 export interface CodeBlockProps {
   code: string
@@ -40,7 +45,11 @@ export function CodeBlock({ code, language = 'bash', showCopy = true, className 
           className="absolute right-2 top-2 rounded p-1.5 text-zinc-500 opacity-0 transition-all hover:text-zinc-300 group-hover:opacity-100 focus:opacity-100"
           aria-label={copied ? 'Copied!' : 'Copy code'}
         >
-          {copied ? <Check className="h-4 w-4 text-green-400" /> : <Copy className="h-4 w-4" />}
+          {copied ? (
+            <Check className="h-4 w-4 text-green-400" aria-hidden="true" />
+          ) : (
+            <Copy className="h-4 w-4" aria-hidden="true" />
+          )}
         </button>
       )}
       <div className="overflow-x-auto p-4">

--- a/frontend/components/ui/ReadNext.tsx
+++ b/frontend/components/ui/ReadNext.tsx
@@ -1,15 +1,9 @@
 import Link from 'next/link'
-
-const ARTICLES = [
-  { slug: 'ethereum-client-bakeoff', title: 'Ethereum client bake-off' },
-  { slug: 'how-we-tested-with-claude', title: 'How we tested with Claude' },
-  { slug: 'bakeoff-harness', title: 'The bake-off harness' },
-  { slug: 'bakeoff-results', title: 'Bake-off results' },
-] as const
+import { ARTICLES } from '@/lib/articles'
 
 export interface ReadNextProps {
   /** The slug of the article this component is rendered on — excluded from the list. */
-  currentSlug: (typeof ARTICLES)[number]['slug']
+  currentSlug: string
 }
 
 /**
@@ -18,7 +12,9 @@ export interface ReadNextProps {
  * one it's rendered on.
  */
 export function ReadNext({ currentSlug }: ReadNextProps) {
-  const others = ARTICLES.filter((article) => article.slug !== currentSlug)
+  const others = ARTICLES.filter((article) => article.slug !== currentSlug).map(
+    ({ slug, navTitle }) => ({ slug, navTitle })
+  )
 
   return (
     <section className="mt-10 sm:mt-16 border-t border-border pt-6">
@@ -27,7 +23,7 @@ export function ReadNext({ currentSlug }: ReadNextProps) {
         {others.map((article) => (
           <li key={article.slug}>
             <Link href={`/blog/${article.slug}`} className="text-primary hover:underline">
-              {article.title}
+              {article.navTitle}
             </Link>
           </li>
         ))}

--- a/frontend/components/ui/Terminal.tsx
+++ b/frontend/components/ui/Terminal.tsx
@@ -1,8 +1,13 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter'
+import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash'
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism'
+
+// Only bash is used anywhere in this repo (verified via grep across app/components).
+// Register any additional language here if a new call site ever needs one.
+SyntaxHighlighter.registerLanguage('bash', bash)
 
 export interface TerminalProps {
   code?: string

--- a/frontend/lib/articles.ts
+++ b/frontend/lib/articles.ts
@@ -1,0 +1,129 @@
+import type { Metadata } from 'next'
+import { SITE_CONFIG } from './constants'
+
+/**
+ * Single source of truth for per-article identity: everything that used to be
+ * duplicated across each article's page.tsx, ArticleJsonLd, ReadNext, the blog
+ * index, and the sitemap.
+ *
+ * `pageTitle`/`pageDescription` (full SEO <title>/OG copy) and `navTitle`/
+ * `indexDescription` (short display copy for ReadNext + the blog index/homepage
+ * card) are separately authored strings — do not derive one from the other.
+ */
+export interface Article {
+  slug: string
+  /** Full SEO <title> / OG title, e.g. 'Ethereum Client Bake-off - ETH2 Quick Start'. */
+  pageTitle: string
+  /** Full SEO meta description / OG description. */
+  pageDescription: string
+  /** Short display title used by ReadNext and the blog index. */
+  navTitle: string
+  /** Blog-index + homepage card description. */
+  indexDescription: string
+  eyebrow: string
+  /** Site-relative OG/twitter image path, e.g. '/og-bakeoff.png'. */
+  ogImage: string
+  ogAlt: string
+  /** JSON-LD headline — pageTitle with the trailing site-name suffix stripped. */
+  headline: string
+  datePublished: string
+  sitemapPriority: number
+}
+
+export const ARTICLES: Article[] = [
+  {
+    slug: 'ethereum-client-bakeoff',
+    pageTitle: 'Ethereum Client Bake-off - ETH2 Quick Start',
+    pageDescription:
+      'The full write-up: results from a 23-day Ethereum execution and consensus client sync campaign, including the restart-resilience findings the headline numbers hide.',
+    navTitle: 'Ethereum client bake-off',
+    indexDescription:
+      'Results from a 23-day execution and consensus client sync campaign: disk, speed, and restart resilience across the full client roster.',
+    eyebrow: 'Client research',
+    ogImage: '/og-bakeoff.png',
+    ogAlt: 'The fastest Ethereum client is one almost nobody runs — a 23-day client bake-off',
+    headline: 'Ethereum Client Bake-off',
+    datePublished: '2026-07-19',
+    sitemapPriority: 0.9,
+  },
+  {
+    slug: 'how-we-tested-with-claude',
+    pageTitle: 'How We Ran a 23-Day Bake-off With Claude - ETH2 Quick Start',
+    pageDescription:
+      'The agent orchestration model, the harness, and what actually breaks when a benchmark runs for three weeks on a shared host with an AI in the driver’s seat.',
+    navTitle: 'How we tested with Claude',
+    indexDescription:
+      'The orchestration model and harness behind the 23-day campaign — how a fleet of agents ran, sampled, and gated every client sync.',
+    eyebrow: 'Methodology',
+    ogImage: '/og-how-we-tested.png',
+    ogAlt: 'How we ran a 23-day Ethereum client bake-off with Claude',
+    headline: 'How We Ran a 23-Day Bake-off With Claude',
+    datePublished: '2026-07-22',
+    sitemapPriority: 0.8,
+  },
+  {
+    slug: 'bakeoff-harness',
+    pageTitle: 'The Bake-off Harness — ETH2 Quick Start',
+    pageDescription:
+      'A function-level engineering reference for the bake-off harness: every script under test/bakeoff/, every function it calls, every flag, and data file.',
+    navTitle: 'The bake-off harness',
+    indexDescription:
+      'A function-level engineering reference for the harness: the orchestrator, the per-candidate state machine, resource caps, and the probe/sample/gate library.',
+    eyebrow: 'Engineering',
+    ogImage: '/og-harness.png',
+    ogAlt: 'The bake-off harness — a function-level engineering reference',
+    headline: 'The Bake-off Harness',
+    datePublished: '2026-07-21',
+    sitemapPriority: 0.8,
+  },
+  {
+    slug: 'bakeoff-results',
+    pageTitle: 'Bake-off Results — ETH2 Quick Start',
+    pageDescription:
+      'The raw results from the 23-day Ethereum client bake-off — every triage row, footprint measurement, and gotcha — verbatim from CLIENT_BAKEOFF_RESULTS.md.',
+    navTitle: 'Bake-off results',
+    indexDescription:
+      'The raw results: Stage A pass matrix, final synced disk footprints, the consensus-client matrices, and operational-viability notes.',
+    eyebrow: 'Data',
+    ogImage: '/og-results.png',
+    ogAlt: 'Bake-off results — the raw data',
+    headline: 'Bake-off Results',
+    datePublished: '2026-07-21',
+    sitemapPriority: 0.8,
+  },
+]
+
+export function getArticle(slug: string): Article {
+  const article = ARTICLES.find((a) => a.slug === slug)
+  if (!article) {
+    throw new Error(`getArticle: unknown article slug "${slug}"`)
+  }
+  return article
+}
+
+/** Builds the exact metadata shape every article page.tsx previously hand-wrote. */
+export function buildArticleMetadata(slug: string): Metadata {
+  const article = getArticle(slug)
+  const url = `/blog/${article.slug}`
+  const images = [{ url: article.ogImage, width: 1200, height: 630, alt: article.ogAlt }]
+
+  return {
+    title: article.pageTitle,
+    description: article.pageDescription,
+    alternates: { canonical: url },
+    openGraph: {
+      type: 'article',
+      siteName: SITE_CONFIG.shortName,
+      images,
+      url,
+      title: article.pageTitle,
+      description: article.pageDescription,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      images,
+      title: article.pageTitle,
+      description: article.pageDescription,
+    },
+  }
+}

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -7,6 +7,7 @@ export const SITE_CONFIG = {
   shortName: 'ETH2 Quick Start',
   description: 'Transform a fresh cloud server into a fully-configured Ethereum node.',
   github: 'https://github.com/chimera-defi/eth2-quickstart',
+  url: 'https://eth2quickstart.com',
 }
 
 export const NAV_LINKS = [

--- a/frontend/public/deck/bakeoff.html
+++ b/frontend/public/deck/bakeoff.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="icon" href="/icon.svg">
 <meta name="description" content="A 13-slide deck of the 23-day Ethereum client bake-off: findings, the restart-resilience twist, and the AI-agent methodology.">
 <meta property="og:title" content="Ethereum Client Bake-off — deck">
 <meta property="og:description" content="A 13-slide deck of the 23-day Ethereum client bake-off — findings, the twist, and how AI agents ran it.">
@@ -15,7 +16,7 @@
 <style>
   :root{
     --ground:#0a0b12; --panel:#13141f; --panel-2:#191b28;
-    --ink:#e9eaf2; --muted:#8b8ea8; --faint:#767a97;
+    --ink:#e9eaf2; --muted:#8b8ea8; --faint:#8085a3;
     --line:#23253a; --line-2:#2e3150;
     --accent:#a78bfa; --accent-dim:#7c6bd6;
     --signal:#f5a524; --good:#34d399; --bad:#fb7185;

--- a/frontend/public/deck/bakeoff.html
+++ b/frontend/public/deck/bakeoff.html
@@ -15,20 +15,22 @@
 <style>
   :root{
     --ground:#0a0b12; --panel:#13141f; --panel-2:#191b28;
-    --ink:#e9eaf2; --muted:#8b8ea8; --faint:#5a5d76;
+    --ink:#e9eaf2; --muted:#8b8ea8; --faint:#767a97;
     --line:#23253a; --line-2:#2e3150;
     --accent:#a78bfa; --accent-dim:#7c6bd6;
     --signal:#f5a524; --good:#34d399; --bad:#fb7185;
+    --hatch-a:#3c3f5c; --hatch-b:#2a2c44;
     --mono:ui-monospace,"JetBrains Mono","SF Mono",Menlo,Consolas,monospace;
     --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
     --maxw:1080px;
   }
   :root[data-theme="light"]{
     --ground:#f3f2ef; --panel:#ffffff; --panel-2:#f7f6f3;
-    --ink:#191a24; --muted:#5c6072; --faint:#9498ac;
+    --ink:#191a24; --muted:#5c6072; --faint:#676c85;
     --line:#e2e0da; --line-2:#d3d1c9;
     --accent:#6d47d9; --accent-dim:#8b6bea;
-    --signal:#b3730a; --good:#0f9d6a; --bad:#d1425a;
+    --signal:#966008; --good:#0c7c54; --bad:#c7304a;
+    --hatch-a:#d3d1c9; --hatch-b:#b9b6ac;
   }
   *{box-sizing:border-box}
   html,body{margin:0;height:100%}
@@ -96,7 +98,7 @@
     background:linear-gradient(90deg,var(--accent-dim),var(--accent));
     transform-origin:left;transform:scaleX(var(--v,0));transition:transform 1s cubic-bezier(.2,.7,.2,1)}
   .slide:not(.active) .bar .fill{transform:scaleX(0)}
-  .bar.muted .fill{background:repeating-linear-gradient(45deg,#3c3f5c,#3c3f5c 5px,#2a2c44 5px,#2a2c44 10px)}
+  .bar.muted .fill{background:repeating-linear-gradient(45deg,var(--hatch-a),var(--hatch-a) 5px,var(--hatch-b) 5px,var(--hatch-b) 10px)}
   .bar.sig .fill{background:linear-gradient(90deg,#c07d12,var(--signal))}
   .bar .val{font-family:var(--mono);font-size:13px;color:var(--muted);font-variant-numeric:tabular-nums;white-space:nowrap}
   .bar .val b{color:var(--ink);font-weight:600}
@@ -448,12 +450,24 @@
   }
   var notesEl=document.getElementById('notes');
   function toggleNotes(){notesEl.classList.toggle('show')}
-  document.getElementById('notesBtn').addEventListener('click',toggleNotes);
+  // Chrome buttons (next/prev/notes/theme) keep focus after a mouse click,
+  // which would otherwise make e.target a <button> for every subsequent
+  // keydown and (a) get swallowed by the guard below and/or (b) let a later
+  // Space keypress both re-activate the focused button *and* advance the
+  // slide. Blurring right after the click side-steps both failure modes.
+  function blurAfter(fn){
+    return function(e){ fn(); if(e&&e.currentTarget&&e.currentTarget.blur){e.currentTarget.blur();} };
+  }
+  document.getElementById('notesBtn').addEventListener('click',blurAfter(toggleNotes));
   function next(){go(i+1)} function prev(){go(i-1)}
-  document.getElementById('next').addEventListener('click',next);
-  document.getElementById('prev').addEventListener('click',prev);
+  document.getElementById('next').addEventListener('click',blurAfter(next));
+  document.getElementById('prev').addEventListener('click',blurAfter(prev));
   document.addEventListener('keydown',function(e){
-    if(e.target.closest&&e.target.closest('a,button,input,textarea,select,[contenteditable]'))return;
+    // Only genuine text-entry widgets should block slide-nav shortcuts.
+    // Buttons (next/prev/notes/theme) must NOT be in this list: they can
+    // retain focus after a click, and excluding them here would silently
+    // swallow every arrow/N/P keypress until the user clicks elsewhere.
+    if(e.target.closest&&e.target.closest('input,textarea,select,[contenteditable]'))return;
     if(e.key==='ArrowRight'||e.key==='PageDown'||e.key===' '){e.preventDefault();next()}
     else if(e.key==='ArrowLeft'||e.key==='PageUp'){e.preventDefault();prev()}
     else if(e.key==='Home'){go(0)} else if(e.key==='End'){go(n-1)}
@@ -465,15 +479,27 @@
     if(e.target.closest('a,button'))return;
     (e.clientX > window.innerWidth*0.5) ? next() : prev();
   });
-  // theme toggle
+  // theme toggle (persisted in localStorage; defaults to dark when unset
+  // or when storage is unavailable, e.g. privacy mode / file:// contexts)
   var root=document.documentElement;
-  document.getElementById('themeBtn').addEventListener('click',function(){
+  var THEME_KEY='bakeoff-theme';
+  function readStoredTheme(){
+    try{ return localStorage.getItem(THEME_KEY); }catch(e){ return null; }
+  }
+  function writeStoredTheme(t){
+    try{ localStorage.setItem(THEME_KEY, t); }catch(e){ /* ignore */ }
+  }
+  var stored=readStoredTheme();
+  if(stored==='light'||stored==='dark'){ root.setAttribute('data-theme', stored); }
+  document.getElementById('themeBtn').addEventListener('click',blurAfter(function(){
     var cur=root.getAttribute('data-theme');
     // The deck's default render is committed-dark (no prefers-color-scheme:light
     // override), so treat "unset" as dark — first click always reaches light.
     var isDark = cur ? cur==='dark' : true;
-    root.setAttribute('data-theme', isDark?'light':'dark');
-  });
+    var next=isDark?'light':'dark';
+    root.setAttribute('data-theme', next);
+    writeStoredTheme(next);
+  }));
   var start=parseInt((location.hash||'').slice(1),10);
   go(isNaN(start)?0:start-1);
   addEventListener('hashchange',function(){var h=parseInt(location.hash.slice(1),10);if(!isNaN(h)&&h-1!==i)go(h-1)});

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -29,8 +29,8 @@ module.exports = {
         border: 'rgba(255, 255, 255, 0.06)',
       },
       fontFamily: {
-        mono: ['JetBrains Mono', 'SF Mono', 'monospace'],
-        sans: ['Inter', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
+        mono: ['var(--font-mono)', 'SF Mono', 'monospace'],
+        sans: ['var(--font-sans)', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
       },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(ellipse at center, var(--tw-gradient-stops))',


### PR DESCRIPTION
A review-and-refine pass over the frontend: six parallel audits (refactor, tests, accessibility, performance, SEO, and an adversarial bug hunt), then the findings implemented and re-reviewed adversarially until two independent reviewers returned **SHIP**.

## Bugs found and fixed

- **Fonts were never loading.** `globals.css` imported Inter and JetBrains Mono via `@import` placed *after* the `@tailwind` directives, so per the CSS spec browsers dropped it — the site has been rendering in system fallbacks the whole time. Now self-hosted via `next/font/google` (13 woff2 files emitted, 41 `@font-face` rules, zero dead imports). **This visibly changes typography — it's the design finally shipping as intended.**
- **Mobile menu could strand users.** Tapping the logo navigated home but left the menu open and `body` overflow locked, so the next page was unscrollable. The logo now closes the menu.
- **Closed mobile menu was keyboard-focusable** — four invisible links in the tab order on every page. Now `invisible` + `aria-hidden`, animation preserved.
- **The deck's own keyboard shortcuts broke** after any on-screen button click, because the keydown guard matched `button` and the chrome buttons keep focus. Guard narrowed to text-entry elements; buttons blur after click.
- **No favicon** — every page load 404'd on `/favicon.ico`. Added `app/icon.svg` (and linked it from the standalone deck).
- **`/quickstart`'s social card showed the homepage's** title, description and image, because a partial `openGraph` override inherits the parent wholesale. It (and `/`) now have their own card and canonical.

## Performance

`react-syntax-highlighter` shipped the full Prism build (290+ grammars, ~217 kB gzip) although every call site passes `language="bash"`. Switched to `PrismLight` with bash registered; styling unchanged.

| Route | Before | After |
|---|---|---|
| `/` | 366 kB | **162 kB** (−56%) |
| `/quickstart` | 323 kB | **119 kB** (−63%) |

## Accessibility

Skip-to-content link, focusable `<main>`, `MotionConfig reducedMotion="user"` so Framer Motion respects the OS setting, `aria-hidden` on decorative icons, and WCAG AA contrast fixes in the deck (`--faint` was 3.05:1 dark / 2.55:1 light on real text; light-theme status pills and emphasis were 3.10–3.91:1 — all now ≥4.5:1, verified by computed ratio). Deck theme choice now persists.

## Refactor

Article identity was duplicated across up to nine files. `lib/articles.ts` is now the single source of truth for the four articles, the blog index, `ReadNext`, `ArticleJsonLd` and the sitemap; the identical TOC block became `ArticleToc`; the production URL moved into `SITE_CONFIG.url`. JSON-LD gained `dateModified` and a `BreadcrumbList` and drops the redundant site-name suffix from `headline`. Three over-length titles/descriptions were trimmed (one was 249 chars).

**No article prose, numbers, or claims changed.**

## Tests

The components added recently had no coverage at all. **30 → 83 tests**, statements **11% → 28%**, with the new files at or near 100%. Guards include: the sitemap must have an entry for every registered article, the domain must never regress to the hyphenated form that shipped once before, and `AnchorHeading` must show its copied state only when the clipboard write actually succeeded.

## Verification

`bunx tsc --noEmit`, `bunx next lint`, `bun run test` (83), and `bun run build` all clean. Reviewed in headless Chrome across `/`, `/quickstart`, `/blog`, all four articles and the deck: zero console errors or hydration warnings, no horizontal overflow at 375/768/1440px, code blocks still syntax-highlighted, reduced-motion content still visible, all 40 TOC links resolving.

Deliberately skipped: an `InlineCode` codemod (513 call sites — a large diff across files another session is actively editing) and an RSS feed (one-off campaign, no publishing cadence). `twitter:site` is still omitted because no handle exists to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGFtDbx3D739eprAKUUk9w