### PR TITLE
fix(bakeoff): make the rerun queue able to actually dequeue and rerun

### DIFF
--- a/test/bakeoff/lib.sh
+++ b/test/bakeoff/lib.sh
@@ -192,14 +192,15 @@ bakeoff_write_sample() {
   fi
 }
 
-bakeoff_is_synced() {
-  # Returns 0 only when the node is fully synced to head.
-  local b e
-  b="$(bakeoff_probe_beacon_sync)"; e="$(bakeoff_probe_execution_sync)"
-  # Beacon: data present, sync_distance<=4, not optimistic, EL not offline.
-  echo "$b" | jq -e '.data and (.data.sync_distance|tonumber) <= 4 and (.data.is_optimistic==false) and (.data.el_offline==false)' >/dev/null 2>&1 || return 1
-  # Execution: synced when eth_syncing is boolean false OR when it returns a
-  # progress object where currentBlock==highestBlock (nethermind-style caught-up).
+# Returns 0 when the EXECUTION client alone is synced to head. Split out from
+# bakeoff_is_synced so anchor-mode callers can check the preserved EL without
+# also requiring a beacon: between anchor-mode candidates the CL is stopped and
+# its datadir purged, so any beacon-inclusive predicate can never pass there.
+bakeoff_is_execution_synced() {
+  local e
+  e="$(bakeoff_probe_execution_sync)"
+  # Synced when eth_syncing is boolean false OR when it returns a progress
+  # object where currentBlock==highestBlock (nethermind-style caught-up).
   # highestBlock != "0x0" guards against the pre-sync zero state.
   echo "$e" | jq -e '
     (.result == false)
@@ -207,6 +208,16 @@ bakeoff_is_synced() {
          and (.result.currentBlock == .result.highestBlock)
          and (.result.highestBlock != "0x0") )
   ' >/dev/null 2>&1 || return 1
+  return 0
+}
+
+bakeoff_is_synced() {
+  # Returns 0 only when BOTH the beacon and the execution client are synced.
+  local b
+  b="$(bakeoff_probe_beacon_sync)"
+  # Beacon: data present, sync_distance<=4, not optimistic, EL not offline.
+  echo "$b" | jq -e '.data and (.data.sync_distance|tonumber) <= 4 and (.data.is_optimistic==false) and (.data.el_offline==false)' >/dev/null 2>&1 || return 1
+  bakeoff_is_execution_synced || return 1
   return 0
 }
 

--- a/test/bakeoff/rerun_queue.tsv.example
+++ b/test/bakeoff/rerun_queue.tsv.example
@@ -22,3 +22,8 @@
 # geth	prysm	rerun after extract_archive -o fix (97541bd)
 # nethermind	lodestar	rerun: lodestar pruneHistory CLI-flag fix (77d939d)
 # erigon	teku	rerun: previous row crash-looped before the watchdog existed
+#
+# Rerunning a pair that has already been measured is the normal case here, so
+# run_queue.sh forces by default (ETH2QS_BAKEOFF_QUEUE_FORCE=yes) and the rerun
+# OVERWRITES that pair's previous artifacts. Set ETH2QS_BAKEOFF_QUEUE_FORCE=no to
+# skip pairs that are already complete instead.

--- a/test/bakeoff/run_candidate.sh
+++ b/test/bakeoff/run_candidate.sh
@@ -464,4 +464,13 @@ bakeoff_snapshot_disk "$out/disk-after-cleanup.tsv"
 
 echo "ended_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$out/env.txt"
 touch "$out/.done"
+
+# A crash-looped row is an invalid measurement, but install itself succeeded, so
+# install_rc is 0. Exiting 0 here would let run_queue.sh / run_bakeoff.sh record
+# the row as a clean run despite the .crash-looped marker and the error alert.
+# Cleanup and artifact capture above are preserved; only the terminal status
+# changes. 4 is distinct from 3 (anchor not synced) and from install failures.
+if [[ "${crash_loop_hit:-no}" == "yes" ]]; then
+  exit 4
+fi
 exit "$install_rc"

--- a/test/bakeoff/run_queue.sh
+++ b/test/bakeoff/run_queue.sh
@@ -21,6 +21,11 @@
 #   ETH2QS_BAKEOFF_QUEUE_WAIT_SECONDS  bounded wait per row for preconditions
 #                                      (default 7200)
 #   ETH2QS_BAKEOFF_QUEUE_POLL_SECONDS  poll interval while waiting (default 60)
+#   ETH2QS_BAKEOFF_QUEUE_FORCE         "yes" (default) reruns a pair even when it
+#                                      already has a .done marker, which is the point
+#                                      of a rerun queue; set "no" to skip completed
+#                                      pairs instead. Forcing overwrites that pair's
+#                                      previous artifacts.
 #   ETH2QS_BAKEOFF_RUN_ID              same run_id used by run_candidate.sh;
 #                                      determines the shared artifact dir
 #   ETH2QS_BAKEOFF_ALERT_LOG           advisor-alert JSONL path (see lib.sh);
@@ -131,7 +136,7 @@ if [[ "$dry_run" == "yes" ]]; then
   echo "[dry-run] queue file: $queue_file"
   echo "[dry-run] operator gate: ETH2QS_BAKEOFF_CONFIRMED=yes (checked)"
   if [[ -n "$anchor_el" ]]; then
-    echo "[dry-run] anchor precondition: eth1.service active AND bakeoff_is_synced (anchor_el=$anchor_el)"
+    echo "[dry-run] anchor precondition: eth1.service active AND bakeoff_is_execution_synced (execution-only; anchor_el=$anchor_el)"
   else
     echo "[dry-run] anchor precondition: none (ETH2QS_BAKEOFF_ANCHOR_EL not set)"
   fi

--- a/test/bakeoff/run_queue.sh
+++ b/test/bakeoff/run_queue.sh
@@ -86,14 +86,16 @@ _other_candidate_running() {
 }
 
 # True (exit 0) when the anchor precondition holds: no anchor configured, or
-# the anchor EL's unit is active AND the harness's OWN synced predicate
-# (bakeoff_is_synced, lib.sh) reports fully synced. Reuses the existing
-# predicate rather than re-deriving the sync-progress jq logic that lives
-# inline in run_candidate.sh's anchor-mode precondition block.
+# the anchor EL's unit is active AND the execution client is synced to head.
+# Deliberately EXECUTION-ONLY (bakeoff_is_execution_synced, lib.sh) rather than
+# bakeoff_is_synced: anchor-mode cleanup stops the CL and purges its datadir
+# between candidates, so a beacon-inclusive predicate could never be satisfied
+# here and every queued row would wait out the timeout and be skipped. This
+# matches run_candidate.sh's own anchor preflight, which also checks the EL only.
 _anchor_ready() {
   [[ -z "$anchor_el" ]] && return 0
   systemctl is-active --quiet eth1.service 2>/dev/null || return 1
-  bakeoff_is_synced
+  bakeoff_is_execution_synced
 }
 
 # wait_for_preconditions <pair-or-dash>
@@ -187,9 +189,15 @@ while IFS=$'\t' read -r execution consensus reason || [[ -n "${execution:-}" ]];
     continue
   fi
 
-  log_info "run_queue: row $row_count ($pair): preconditions met; running run_candidate.sh"
+  # The queue's purpose is re-measuring pairs that already have a .done marker
+  # (that is what a "rerun queue" is for), and run_candidate.sh exits 0 without
+  # running anything when .done exists and FORCE is unset. Without this the
+  # queue would record a successful rerun while taking no measurement at all.
+  # Opt out with ETH2QS_BAKEOFF_QUEUE_FORCE=no if a row should be skipped when
+  # already complete.
+  log_info "run_queue: row $row_count ($pair): preconditions met; running run_candidate.sh (force=${ETH2QS_BAKEOFF_QUEUE_FORCE:-yes})"
   set +e
-  "$run_candidate_bin" "$execution" "$consensus"
+  ETH2QS_BAKEOFF_FORCE="${ETH2QS_BAKEOFF_QUEUE_FORCE:-yes}" "$run_candidate_bin" "$execution" "$consensus"
   rc=$?
   set -e
   printf '%s\trow=%d\tpair=%s\trc=%d\treason=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$row_count" "$pair" "$rc" "$reason" >> "$queue_log"


### PR DESCRIPTION
Stacked onto #212. Fixes three defects Codex flagged there, all verified against the code, plus one small refactor.

## The two P1s would have made the queue silently useless

**1. The dequeue precondition can never be satisfied in anchor mode.** `_anchor_ready()` called `bakeoff_is_synced`, which requires a synced *beacon*. But anchor-mode cleanup stops the CL and purges its datadir between candidates — so there is no beacon to report synced. Every queued row would wait out its timeout and be skipped, while the preserved EL sat there perfectly healthy. Now checks the execution client only, matching `run_candidate.sh`'s own anchor preflight.

**2. The queue would report success without measuring anything.** It invoked `run_candidate.sh` with no `ETH2QS_BAKEOFF_FORCE`, but that script exits 0 without running when a `.done` marker exists. Every pair in a *rerun* queue has already been measured once, so that is the normal case — the queue would have logged `rc=0` for a rerun that never happened. Now forces by default; `ETH2QS_BAKEOFF_QUEUE_FORCE=no` opts out.

**3. (P2) Crash-looped rows exited 0**, because install itself had succeeded — so orchestration recorded an invalidated measurement as clean despite the `.crash-looped` marker and the error alert. Now exits `4` (distinct from `3` = anchor not synced). Cleanup and artifact capture are unchanged.

## Refactor

Extracted `bakeoff_is_execution_synced()` in `lib.sh` so the execution-only check has a single definition; `bakeoff_is_synced()` now composes it instead of repeating the jq.

## On Codex's fourth finding — it's a false positive

Codex reported that `summarize.sh`'s `$18!="no"` filter "omits every healthy row and includes rows explicitly marked as crash-looped", on the premise that column 18 is `crash_loop_detected`. It isn't. Counting the header:

```
... last_el_block(15), el_bytes(16), cl_bytes(17), anchor_synced(18), crash_loop_detected(19)
```

Column 18 is `anchor_synced`, so `$18!="no"` correctly keeps `yes` and `n/a` while excluding anchor-poisoned rows. `crash_loop_detected` was appended as column 19 precisely so existing awk indexes stayed valid. No change made.

There *is* a related design question — the ranked table doesn't exclude crash-looped rows at all — but that matches the existing `stall` precedent and is a deliberate call, not this bug.

## Verification

`bash -n` and `shellcheck -x` clean on all three files; `install/test/test_common_functions.sh` 19/19. Confirmed `crash_loop_hit` survives the sampling loop (plain `while`, not a subshell) and is read as `${crash_loop_hit:-no}` so `set -u` is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGFtDbx3D739eprAKUUk9w