### PR TITLE
docs(geo): GEO/AEO discoverability plan, off-site checklist, and MCP registry manifest

### DIFF
--- a/docs/GEO_AEO_DISCOVERABILITY_PLAN.md
+++ b/docs/GEO_AEO_DISCOVERABILITY_PLAN.md
@@ -1,0 +1,178 @@
+# GEO / AEO + SEO Discoverability Plan — eth2-quickstart
+
+**Status:** APPROVED (2026-07-29) — chimera_defi approved the plan. Decisions: **(A)** build it out now via a Sonnet builder subagent + Devin adversarial-review delegate → one PR (no self-merge); **(B)** dedicated `/agents` page = YES; **(C)** also scope a hosted/remote MCP as a follow-up. Website code scope is being implemented on branch `feat/geo-aeo-agent-discoverability`. Off-site/auth-gated items (A1 repo metadata, A4 registries, A5 backlinks) and the hosted-MCP scope are captured in companion docs.
+**Author:** Claude Opus 4.8 (cloud agent session `ah-eth2qs-orch-0729-1649`).
+**Goal:** make this Ethereum node-setup tooling + its website maximally discoverable and *usable* by AI agents (GEO/AEO), on top of traditional SEO for humans — so that when a user tells *their* agent "set up an Ethereum validator," ours is found, chosen, and driven end-to-end.
+
+---
+
+## TL;DR — the one strategic insight
+
+The **repo already has a mature agent-operability layer** (a skill-creator-format skill, an MCP server, a stable `./scripts/eth2qs.sh` wrapper with `--json` everywhere, `llms.txt` + `llms-full.txt`, ClawHub/Claude-plugin packaging). The "an agent CAN drive it" half is **largely solved and should not be rebuilt.**
+
+The gap is **discovery and the website**, in three specific ways:
+
+1. **FIND (off-site) is neglected.** The GitHub repo — the single most likely thing an agent actually lands on — has a dated one-line description, **zero topics**, no homepage URL, and no custom social image. The MCP server/skill are in **no public registry**. This is the cheapest, highest-leverage work and it's almost entirely untouched.
+2. **The website (eth2quickstart.com) exposes none of the agent layer** and lacks the structured data + prompt-aligned content that answer-engines actually reward. `eth2quickstart.com/llms.txt` returns **404** (verified). No `SoftwareApplication`/`HowTo`/`FAQPage` JSON-LD. No "For AI Agents" surface.
+3. **The two surfaces are half-bridged.** README → website link exists; website → agent-layer link does **not**. `llms.txt` never mentions the website.
+
+**Honest framing (grounded in mid-2026 research, not hype):** `llms.txt` today has ~6–10% adoption and AI crawlers rarely fetch it — it's a cheap, forward-looking, no-downside complement, **not** a citation-lift lever. Generative engines crawl **HTML directly**, so the real AEO wins are **structured data + question-shaped content + off-site distribution**. `SoftwareApplication` schema is the defensible centerpiece; `FAQPage`/`HowTo` help **LLM answer extraction** (Google curtailed FAQ rich-results to gov/health and deprecated HowTo rich-results ~2023 — do not promise Google snippets).
+
+---
+
+## Framework: the user's own three verbs
+
+Every recommendation maps to one stage of the target scenario:
+
+| Verb | Question it answers | Where it lives |
+|------|--------------------|----------------|
+| **FIND** | Does the agent surface us at all? | Off-site distribution, SEO, structured data |
+| **CHOOSE** | Once found, does the agent pick us? | Prompt-aligned content, comparison, credibility |
+| **DRIVE** | Once chosen, can the agent operate us end-to-end? | The repo agent layer (**already strong** — gaps only) |
+
+---
+
+## Current-state audit (credit where due — do NOT rebuild)
+
+**Already in place (DRIVE — mature):**
+- `skills/eth2-quickstart/SKILL.md` — Anthropic skill-creator format, strong trigger-phrase `description`, routing, safety rules, 10 reference docs (`workflow`, `operator`, `commands`, `safety`, `sizing`, `outputs`, `examples`, `mcp`, `improvement`, `evals`).
+- `mcp_server/` — Python MCP server (`eth2qs_mcp_server.py` + tools), `run_eth2qs_mcp.sh`, `scripts/install_claude_eth2qs_mcp.sh`. Read-only funds-safety contract (`eth2qs_validators`, `eth2qs_validator_op_preview`).
+- `scripts/eth2qs.sh` — one wrapper, ~28 subcommands, `--json` on `doctor`/`stats`/`plan`/`debug`/`update-check`/`monitor export`/`client-options`/`validators`. Non-interactive `bootstrap --non-interactive`, `phase1`, `phase2 --execution=… --consensus=… --mev=…`.
+- `llms.txt` + `llms-full.txt` at repo root — valid llms.txt format, links to skill/refs/MCP.
+- `.claude-plugin/{marketplace.json,plugin.json}`, `docs/AGENT_SKILL_LISTING.md`, `docs/AGENT_SKILL_PLAN.md` — packaging + listing groundwork.
+- `README.md` — keyword-rich `# Ethereum Node Quick Setup`, a "For External Agents" section, links to the website.
+
+**Already in place (SEO — good baseline):**
+- `frontend/app/layout.tsx` — correct `metadataBase: https://eth2quickstart.com`, OpenGraph + Twitter `summary_large_image`, `next/font` (fonts load), skip-to-content.
+- `frontend/app/sitemap.ts` + `robots.ts` — dynamic, cover homepage/quickstart/blog/4 articles/deck.
+- `frontend/components/ui/ArticleJsonLd.tsx` — `BlogPosting` + `BreadcrumbList` JSON-LD on all 4 blog articles, per-article OG cards.
+- `frontend/lib/articles.ts` — single source of truth for article identity; `SITE_CONFIG.url`.
+
+**The gaps this plan fills** are enumerated below by verb.
+
+---
+
+## TRACK A — FIND (highest ROI, mostly off-site, mostly cheap)
+
+### A1. GitHub repo metadata *(P0 — trivial, high impact)*
+The repo is the most likely agent landing point and its metadata is weak.
+- **Description** (current: `"Scripts to get a eth2 merge ready node setup in seconds "` — dated "merge" framing, trailing space). Proposed:
+  `Set up a production Ethereum validator/node (12 clients, MEV, hardening) via one script — with an AI-agent skill, MCP server & JSON CLI.`
+- **Topics** (current: **none**). Propose: `ethereum`, `ethereum-node`, `validator`, `staking`, `proof-of-stake`, `geth`, `prysm`, `lighthouse`, `mev-boost`, `node-operator`, `devops`, `ai-agents`, `mcp`, `claude`, `llms-txt`.
+- **Homepage URL** (current: empty) → `https://eth2quickstart.com`.
+- **Custom social-preview image** (`usesCustomOpenGraphImage: false`) → upload a branded 1280×640 (reuse `frontend/public/og.png` styling).
+- **Execution:** GitHub *settings*, not repo files. `gh repo edit chimera-defi/eth2-quickstart --description "…" --homepage "…" --add-topic ethereum …` (topics/description/homepage); social image is a web-UI upload (Settings → General). **Needs repo-admin auth.**
+- **Verify:** `gh repo view --json description,repositoryTopics,homepageUrl` reflects the changes.
+
+### A2. Serve `/llms.txt` + `/llms-full.txt` on the website *(P0 — cheap; honest framing)*
+Today only in repo root; `eth2quickstart.com/llms.txt` = 404. Agents that land on the site can't find the agent layer.
+- **Change:** add `frontend/app/llms.txt/route.ts` (a Next route handler returning `text/plain`) **generated from the repo-root `llms.txt`** — do **not** hand-copy into `frontend/public/` (that forks maintenance). Same for `llms-full.txt`.
+- **Anti-drift:** the route reads the canonical repo-root file at build time (or a small `frontend/scripts/sync-llms.mjs` copies it into `public/` as a prebuild step with a CI check that they match). Pick one; document it so the two never diverge.
+- **Also:** the website copy should add a top line pointing back to `https://eth2quickstart.com` and the repo, so the bridge works both directions.
+- **Verify:** `curl -sI https://eth2quickstart.com/llms.txt` → `200 text/plain`; content byte-matches repo root (modulo the added site header); add to `sitemap.ts`.
+- **Honesty note:** frame in the plan/PR as forward-looking hygiene, **not** a ranking/citation lever.
+
+### A3. `SoftwareApplication` JSON-LD on the homepage *(P0 — cheap, defensible)*
+The single most credible structured-data win — this *is* a software tool.
+- **Change:** new `frontend/components/ui/SoftwareAppJsonLd.tsx`, rendered in `app/page.tsx`. Fields: `@type: SoftwareApplication`, `applicationCategory: DeveloperApplication`, `operatingSystem: Linux (Ubuntu 20.04+)`, `name`, `description`, `url`, `sameAs: [github]`, `offers: {price:0}` (free/open-source), `softwareRequirements` (disk/RAM/CPU from `PREREQUISITES`), `featureList` (clients/MEV/hardening).
+- **Verify:** view-source shows one `application/ld+json`; passes validator.schema.org and Google Rich Results Test with no errors.
+
+### A4. Public registry / directory listings *(P1 — propose-only; the most *direct* "agent finds an invokable tool" path)*
+Plausibly higher real ROI than llms.txt because these are where agents look for tools.
+- **MCP registries:** submit the eth2qs MCP server to the emerging registries (Anthropic's MCP registry, `mcp.so`, PulseMCP, Smithery). Needs a short server manifest + README section.
+- **Skill directory:** publish the skill to ClawHub (already referenced as the intended path) and any Claude skill/plugin marketplace the `.claude-plugin/` files target.
+- **Verify:** the listing resolves and `install`/`add` instructions work from a clean environment.
+- **Ownership:** needs external accounts → **decision A** below (who executes).
+
+### A5. Backlinks from authority lists *(P1 — propose-only)*
+- Open PRs adding eth2-quickstart to `awesome-ethereum`, `awesome-staking`, and similar curated lists; check whether ethereum.org's "run a node / staking" resources can link it. These are read by both humans and the crawlers that feed answer-engines.
+- **Verify:** merged link present on the list's rendered page.
+
+### A6. Website structured-data + sitemap hygiene *(P1)*
+- Add `WebSite` + `Organization` JSON-LD in `layout.tsx` (`Organization.sameAs: [github]`; `WebSite.potentialAction` SearchAction only if a real search exists — otherwise omit, don't fake it).
+- Add `/llms.txt`, `/agents` (see B2) to `sitemap.ts`.
+- **Verify:** validator.schema.org clean; sitemap lists the new routes.
+
+---
+
+## TRACK B — CHOOSE (make the agent pick us once found)
+
+### B1. Prompt-aligned FAQ with `FAQPage` JSON-LD *(P1 — medium; frame as LLM extraction)*
+Answer-engines extract Q&A blocks. Add a visible FAQ (homepage or `/quickstart`) whose questions mirror real agent/user prompts, each with a tight, quotable answer:
+- "How do I set up an Ethereum validator?" / "…a node?" / "…an RPC endpoint?"
+- "Which Ethereum client should I choose?" (points to the bake-off) 
+- "How much disk / RAM / CPU does an Ethereum node need?"
+- "Is it safe? How are keys/secrets handled?"
+- "Can an AI agent set this up for me?" → yes, via the skill/MCP (bridges to B2).
+- **Schema:** `FAQPage` JSON-LD mirroring the visible Q&A.
+- **Verify:** validator.schema.org clean; each answer is self-contained and quotable in isolation.
+- **Honesty note:** value is AI answer-extraction, **not** Google FAQ rich snippets.
+
+### B2. A "For AI Agents" page on the website — `/agents` *(P1 — the most on-thesis new artifact)*
+Mirror the repo agent layer so an agent that lands on the site discovers how to drive the tool without spelunking GitHub:
+- Copy-paste **MCP add** command (`claude mcp add …`, `codex mcp add …`).
+- **Skill install** (ClawHub + GitHub-path fallback).
+- The **wrapper JSON** commands (`doctor --json`, `plan --json`, `phase2 --execution=…`).
+- Link to `llms.txt`, `SKILL.md`, `docs/VALIDATOR_MANAGEMENT.md`, the safety contract.
+- One-paragraph **safety contract** (no key-gen, no secret removal, human-confirm for root/reboot/destructive).
+- **Verify:** page renders, links resolve 200, commands copy correctly; add to nav/footer + sitemap.
+- Add `SoftwareApplication`/`HowTo` `potentialAction` or at least prominent internal links so crawlers associate the agent layer with the product.
+
+### B3. Homepage above-the-fold quick-answer + question-shaped headings *(P1 — content)*
+- Add a one- to two-sentence quick-answer block near the top ("eth2-quickstart turns a fresh Ubuntu server into a hardened Ethereum validator/RPC node in ~30 min, across 12 clients, with one script — drivable by humans or AI agents").
+- Reword some section H2s into question form where natural (helps extraction).
+- **Verify:** quick-answer appears in initial HTML (SSR), not client-only.
+
+### B4. Credibility signals *(P2)*
+- Surface the bake-off (empirical, measured client comparison) prominently from the homepage as an authority/credibility asset — it's exactly the differentiated, citation-worthy content GEO rewards.
+- Footer → Blog link (currently missing), homepage blog teaser (noted in prior session memory as remaining polish).
+
+---
+
+## TRACK C — DRIVE (already strong — gaps only)
+
+### C1. Bridge repo → website *(P0 — cheap)*
+- `llms.txt` / `llms-full.txt` never mention `eth2quickstart.com`. Add the site as a human-facing entrypoint line. (README already links the site — good.)
+- **Verify:** grep shows the URL present.
+
+### C2. MCP hosting model *(decision — see below)*
+- The MCP server is **stdio + requires a repo clone**. That's correct for an operator on the node, but a *remote/hosted* MCP would let an agent connect with zero clone — bigger lift, bigger discovery win. Flagged as **decision C**, not assumed.
+
+### C3. Non-interactive completeness spot-check *(P2)*
+- Confirm every operator path an agent would drive has a documented non-interactive form (bootstrap/phase2/mev already do). Audit `configure`/`select_clients` for a headless path; document any that still require a TTY.
+- **Verify:** each command runs to completion in the Docker test env with no TTY.
+
+---
+
+## Phasing (impact × effort)
+
+**P0 — quick wins (cheap, high-impact, low-risk, mostly reversible via one PR):**
+A1 (repo metadata), A2 (serve `/llms.txt`), A3 (`SoftwareApplication` JSON-LD), C1 (repo→site bridge).
+
+**P1 — the substantive discovery build:**
+A4 (registries), A5 (backlinks), A6 (site schema), B1 (FAQ+schema), B2 (`/agents` page), B3 (homepage content).
+
+**P2 — polish & durability:**
+B4 (credibility/blog nav), C3 (headless audit), llms.txt anti-drift mechanism hardening, RSS (previously deferred).
+
+---
+
+## Honesty caveats (this repo's review culture punishes overclaims)
+
+1. **llms.txt ≠ citations.** Low adoption, crawlers rarely fetch it. Ship it as no-downside hygiene, not a growth lever.
+2. **FAQPage/HowTo ≠ Google rich snippets** in 2026 (curtailed/deprecated). Value = LLM answer extraction.
+3. **SoftwareApplication** is the defensible schema win — lead with it.
+4. **GEO impact is hard to measure and geo-personalized.** Propose a lightweight before/after check (query ChatGPT/Perplexity/Claude-with-web for "set up an ethereum validator" and log whether we're cited), not a promised ranking gain.
+
+---
+
+## Decisions needed before implementation (the genuine forks)
+
+- **Decision A — implement vs hand-off + off-site ownership.** After approval, should this session implement the P0 quick wins now (single reviewable PR, no auto-merge), or purely hand off a task list? And the off-site items (A1 `gh repo edit`, A4 registries, A5 backlinks) need repo-admin/external auth — do you run those, or authorize me to?
+- **Decision B — dedicated `/agents` page (B2)?** Recommended yes (clean, linkable, on-thesis) vs. fold agent info into the existing `/quickstart` page.
+- **Decision C — MCP hosting.** Keep stdio-only (clone required) vs. also scope a hosted/remote MCP so agents connect with no clone.
+
+## Coordination / non-conflict notes
+- Open PRs #213/#215/#216 are all **bakeoff/harness/docs** — **no overlap** with this frontend/discovery work. Clear lane.
+- The earlier blog + clobbered-commits investigations already landed (#209 merged; git history confirmed intact).
+- This plan file is written to `docs/GEO_AEO_DISCOVERABILITY_PLAN.md`, **uncommitted**, pending approval. Nothing pushed.

--- a/docs/GEO_AEO_OFFSITE_CHECKLIST.md
+++ b/docs/GEO_AEO_OFFSITE_CHECKLIST.md
@@ -1,0 +1,99 @@
+# Off-Site Discoverability Checklist (auth-gated — not code)
+
+These items live outside the repo tree (GitHub settings, external registries, third-party lists) and need
+**repo-admin / external-account auth**, so they are NOT part of the website PR. Run them yourself, or
+authorize the agent to run the `gh` ones. Companion to `docs/GEO_AEO_DISCOVERABILITY_PLAN.md`.
+
+---
+
+## A1 — GitHub repo metadata — ✅ DONE 2026-07-29 (except the social image)
+
+**Applied and verified** by the agent on 2026-07-29 (authorized by chimera_defi: "do what you can
+autonomously"). Read back via `gh repo view --json description,homepageUrl,repositoryTopics`:
+
+- **description** → `Set up a production Ethereum validator/node (13 clients, MEV, hardening) via one script — with an AI-agent skill, MCP server & JSON CLI.` (was the dated *"Scripts to get a eth2 merge ready node setup in seconds "*). Note the count is **13**, matching `TOTAL_CLIENTS`; the old site copy said 12 and was wrong.
+- **homepageUrl** → `https://eth2quickstart.com` (was empty)
+- **topics** → 15 applied: `ai-agents, claude, devops, ethereum, ethereum-node, geth, lighthouse, llms-txt, mcp, mev-boost, node-operator, proof-of-stake, prysm, staking, validator` (was **none**)
+
+⬜ **STILL TODO — social preview image (human, web UI only).** GitHub exposes **no API** for this, so it
+could not be automated. Settings → General → "Social preview" → upload a 1280×640 PNG (reuse
+`frontend/public/og.png` styling). Until then link unfurls use GitHub's generic auto-image.
+
+Note: `gh repo edit` fails in some environments with a Projects-classic GraphQL deprecation error — the
+REST equivalents used here work: `gh api -X PATCH repos/OWNER/REPO -f description=... -f homepage=...`
+and `gh api -X PUT repos/OWNER/REPO/topics -f names[]=...`.
+
+<details><summary>Original state (for rollback)</summary>
+
+description: `Scripts to get a eth2 merge ready node setup in seconds ` · homepage: `null` · topics: none
+</details>
+
+---
+
+## A4 — Registry / directory listings (P1 — most direct "agent finds an invokable tool" path)
+
+The MCP server and skill are in **no public registry** today. These are where agents actually look for tools.
+
+### Official MCP registry — researched 2026-07-29, manifest PREPARED
+
+**The key question was whether we're even eligible**, since our MCP server is a Python script inside a git
+repo — **not** published to PyPI/npm, and stdio-only (not a remote URL). Verified answer: **yes, eligible.**
+The `server.json` spec supports servers with *no* `packages` and *no* `remotes`, using `websiteUrl` for
+"servers that follow a custom installation path" — exactly our case. So **PyPI packaging is NOT a
+prerequisite**, which is what the earlier draft of this checklist assumed.
+
+✅ **`server.json` created at the repo root** and validated against
+`https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json`:
+required fields are `name`, `description`, `version`; `name` matches the required reverse-DNS pattern
+(`io.github.chimera-defi/eth2-quickstart`); `description` is 92 chars (limit 100); `repository` carries the
+required `url` + `source`. No `packages`/`remotes` — deliberate, per the custom-install-path case.
+
+⬜ **Publishing still needs a human** (could not be automated): it requires the `mcp-publisher` CLI (not
+installed here) and an **interactive GitHub OAuth** login to prove ownership of the `io.github.chimera-defi`
+namespace. Steps:
+
+```bash
+# install mcp-publisher (see modelcontextprotocol/registry releases), then:
+mcp-publisher login github     # interactive OAuth; proves the io.github.chimera-defi namespace
+mcp-publisher publish          # reads ./server.json
+```
+
+- **Sequencing note:** `websiteUrl` currently points at `https://eth2quickstart.com` (live today) rather than
+  `/agents`, because the `/agents` route ships in **PR #218** and would 404 until that merges. After #218 is
+  merged and deployed, consider pointing `websiteUrl` at `https://eth2quickstart.com/agents` — it is the
+  purpose-built landing page for exactly this audience.
+- **Verify after publishing:** the server resolves in the registry and its listed install path works from a
+  clean environment.
+
+### Other directories (each needs its own account / submission)
+
+- [ ] **mcp.so** — community MCP directory listing.
+- [ ] **PulseMCP** — MCP server directory.
+- [ ] **Smithery** — MCP registry/host (also relevant if we pursue hosted MCP — see `HOSTED_MCP_SCOPE.md`).
+- [ ] **ClawHub** — publish the skill (already the intended packaging path per `llms.txt` / SKILL.md).
+      Note: no `clawhub` CLI is installed in the agent environment, so this needs a human or a published CLI.
+- [ ] Any Claude plugin marketplace the `.claude-plugin/{marketplace.json,plugin.json}` target.
+- **Verify (each):** the listing resolves and its `install`/`add` instructions work from a clean environment.
+- **Note:** listing requirements change; confirm each registry's current submission format before filing.
+
+---
+
+## A5 — Backlinks from authority lists (P1, propose-only)
+
+Read by humans and by the crawlers that feed answer-engines; also raise traditional SEO authority.
+
+- [ ] `awesome-ethereum` — PR adding eth2-quickstart under node/staking tooling.
+- [ ] `awesome-staking` (and similar curated staking lists) — PR.
+- [ ] Check whether ethereum.org "run a node" / "staking" resource pages accept a link or PR.
+- **Verify (each):** merged link is present on the list's rendered page.
+
+---
+
+## Lightweight GEO measurement (before/after, since GEO impact is hard to prove and geo-personalized)
+
+Not a promised ranking gain — just a sanity check. Before and ~2–4 weeks after shipping:
+
+- [ ] Ask ChatGPT (with web/SearchGPT), Perplexity, and Claude-with-web: *"How do I set up an Ethereum validator
+      on a Linux server?"* and *"What's a good script/tool to set up an Ethereum node?"* — log whether
+      eth2-quickstart / eth2quickstart.com is mentioned or cited, and in what position.
+- [ ] Re-check from at least one non-US IP (AI answers are geo-personalized).

--- a/docs/HOSTED_MCP_SCOPE.md
+++ b/docs/HOSTED_MCP_SCOPE.md
@@ -1,0 +1,82 @@
+# Hosted / Remote MCP — Scoping (follow-up, not built)
+
+**Status:** SCOPE ONLY (2026-07-29). chimera_defi asked to "also scope a hosted/remote MCP." This documents
+whether/how to do it and the hard constraints. No implementation here. Companion to
+`docs/GEO_AEO_DISCOVERABILITY_PLAN.md` (decision C).
+
+---
+
+## The goal and why it's a discovery win
+
+Today the eth2qs MCP server (`mcp_server/eth2qs_mcp_server.py`, `FastMCP`, `transport="stdio"`) requires the
+agent to **clone the repo and run a local process**. A *remote* MCP endpoint (a public URL) would let a user's
+agent connect with **zero clone** — the most direct "agent finds and invokes our tool" path, and it shows up in
+MCP registries as a hosted server (higher discovery than a stdio-only entry).
+
+## The hard constraint (this is the whole scoping problem)
+
+**This tool installs and operates validator infrastructure — with real ETH at stake — on a *specific* host.**
+The privileged, mutating operations inherently must execute **on the user's own server**:
+
+- `ensure_apply`, `repair_apply`, `start` / `stop` / `restart`, `monad_install` — mutate the host, gated by
+  `confirm` + a confirmation token.
+- `doctor`, `stats`, `logs`, `validators_list`, `debug` — read the *live local node* (systemd units, datadirs,
+  beacon API on localhost).
+
+A hosted endpoint at some URL **cannot and must not** reach into arbitrary user hosts to run these. Doing so
+would mean SSH/agent footholds into strangers' validator boxes — an unacceptable security and liability posture
+for a funds-bearing tool. So a hosted MCP can only safely offer the **host-independent, advisory/read-only
+subset**, and must defer all execution to the local surface.
+
+## Recommended architecture — two tiers, not a lift-and-shift
+
+**Tier 1 — Local execution MCP (unchanged, stays primary):** the current stdio server, run on the target host
+via `./mcp_server/run_eth2qs_mcp.sh`. This is where install/operate/validator actions actually happen. Correct
+as-is. Do not weaken it.
+
+**Tier 2 — Hosted *advisory* MCP (new, optional):** a public Streamable-HTTP endpoint exposing ONLY the
+host-independent tools:
+
+| Candidate hosted tool | Source today | Host-independent? |
+|-----------------------|-------------|-------------------|
+| `help` / `server_info` | static | ✅ |
+| `client_options` | `client-options --json` (reads repo config, not host) | ✅ |
+| sizing guidance | `skills/eth2-quickstart/references/sizing.md` | ✅ (static) |
+| `plan` preview | planner logic | ✅ if made host-agnostic (takes desired stack as args, returns the plan/commands) |
+| `validator_op_preview` | returns the exact node CLI command text | ✅ (generates text; never executes) |
+| "what command do I run?" | maps a goal → exact `./scripts/eth2qs.sh …` command | ✅ |
+
+Everything that reads a live node or mutates the host returns, instead of executing, a **precise command to run
+on the user's host** (or a pointer to add the local Tier-1 MCP). This mirrors the existing funds-safety contract
+(`validator_op_preview` already does exactly this).
+
+Net behavior: a user's agent connects to the hosted URL, gets sizing/client/plan advice and the **exact commands**,
+then runs them (or spins up the local MCP) on the user's actual server. Discovery win, no remote-execution risk.
+
+## Technical path (small code, real ops lift)
+
+- **Transport:** FastMCP supports Streamable HTTP — roughly `mcp.run(transport="streamable-http", host, port)`
+  behind a reverse proxy. A *separate* entrypoint (`eth2qs_mcp_server_http.py`) that registers only the Tier-2
+  tools keeps the privileged tools off the public surface entirely (defense in depth — don't just rely on a flag).
+- **Hosting:** small always-on container/VM behind TLS (the same CloudFront/edge story as the site, or a tiny
+  service). Stateless; no access to any node.
+- **Auth / abuse:** likely anonymous read-only + rate limiting (no secrets involved since nothing executes). If
+  any tool ever touches per-user state, add auth first.
+- **Registry:** list the hosted URL in the MCP registries from the off-site checklist (A4) — hosted servers are
+  first-class there.
+- **Anti-drift:** Tier-2 must reuse the same underlying functions/data as the CLI (`client-options`, sizing docs)
+  so hosted advice never diverges from what the repo actually does.
+
+## Effort / recommendation
+
+- **Code:** small (new HTTP entrypoint, tool subset, host-agnostic `plan`). ~1 focused PR.
+- **Ops:** non-trivial and ongoing (a public always-on service to run, monitor, secure, and keep in sync).
+- **Recommendation:** worth doing **as advisory-only Tier 2**, sequenced *after* the P0/P1 website + off-site
+  work lands and after the local MCP is registry-listed (cheaper discovery first). Treat it as its own
+  spec → plan → PR. Do **not** expose any mutating/host-reading tool remotely.
+
+## Open questions for chimera_defi
+1. Where would it host (reuse the CloudFront/AWS footprint, or a separate tiny service)?
+2. Is anonymous + rate-limited acceptable (recommended, since nothing executes), or do you want auth from day one?
+3. Should hosted `plan` accept a desired stack (execution/consensus/mev) as arguments and return commands, i.e.
+   fully decoupled from any host? (Recommended — that's what makes it safely remote.)

--- a/server.json
+++ b/server.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+  "name": "io.github.chimera-defi/eth2-quickstart",
+  "description": "Ethereum node ops: install, diagnose, and manage validators via the eth2-quickstart wrapper.",
+  "version": "0.1.0",
+  "websiteUrl": "https://eth2quickstart.com",
+  "repository": {
+    "url": "https://github.com/chimera-defi/eth2-quickstart",
+    "source": "github"
+  }
+}


### PR DESCRIPTION
**Agent:** Claude Opus 4.8 (research, planning, orchestration)
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary

Research/planning output for making this tooling and its website discoverable and usable by **AI agents** (GEO/AEO), on top of traditional SEO. Docs + one manifest only — **no code, no site behavior change**. The implementation half is the separate PR #218.

**Not merged — awaiting human review.**

## The finding that shaped the plan

The repo's **agent-operability layer is already mature** — the packaged skill (`skills/eth2-quickstart/`), the MCP server (`mcp_server/`), the `./scripts/eth2qs.sh` wrapper with `--json` throughout, and `llms.txt`/`llms-full.txt`. The "an agent *can* drive it" problem is largely solved, so nothing here rebuilds it. The real gaps were **discovery** and **the website**.

## Files

| File | What it is |
|---|---|
| `docs/GEO_AEO_DISCOVERABILITY_PLAN.md` | The approved plan, framed as **FIND / CHOOSE / DRIVE**, phased P0/P1/P2 with a verification per item |
| `docs/GEO_AEO_OFFSITE_CHECKLIST.md` | Auth-gated, non-code items; records what was applied and what still needs a human |
| `docs/HOSTED_MCP_SCOPE.md` | Scoping for a hosted/remote MCP (decision C) |
| `server.json` | MCP registry manifest |

## Already applied (GitHub repo settings, verified by read-back)

- **description** → `Set up a production Ethereum validator/node (13 clients, MEV, hardening) via one script — with an AI-agent skill, MCP server & JSON CLI.` (was the 2022-era *"Scripts to get a eth2 merge ready node setup in seconds "*). Uses **13**, matching `TOTAL_CLIENTS` — the old site copy said 12 and was wrong (also fixed in #218).
- **homepage** → `https://eth2quickstart.com` (was empty)
- **topics** → 15 added (was **zero**): `ai-agents, claude, devops, ethereum, ethereum-node, geth, lighthouse, llms-txt, mcp, mev-boost, node-operator, proof-of-stake, prysm, staking, validator`

Still needs a human: the **social preview image** — GitHub exposes no API for it (Settings → General → Social preview).

## `server.json` — the eligibility question, answered

The open question was whether the MCP server is even listable, since it is a Python script in a git repo — not on PyPI/npm, and stdio-only rather than a remote URL. **It is eligible:** the spec supports servers with no `packages` and no `remotes` via `websiteUrl`, for "servers that follow a custom installation path." **So PyPI packaging is not a prerequisite.**

Validated against `https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json`: required `name`/`description`/`version` present; `name` matches the reverse-DNS pattern; `description` is 92 chars (limit 100); `repository` has the required `url` + `source`.

Publishing still needs a human — `mcp-publisher` CLI plus interactive GitHub OAuth to prove the `io.github.chimera-defi` namespace. Exact commands are in the checklist.

`websiteUrl` deliberately points at `https://eth2quickstart.com` (**HTTP 200 today**) rather than `/agents`, since that route ships in #218 and would 404 until it merges. Worth repointing to `/agents` afterward.

## Honesty framing (carried through every doc)

- **`llms.txt` is forward-looking hygiene, not a citation lever** — ~6–10% adoption and AI crawlers rarely fetch it. Serving it fixes a real 404 and bridges repo↔site; nothing more is claimed.
- **FAQPage/HowTo schema aid LLM answer-extraction, not Google rich snippets** (Google curtailed/deprecated those ~2023).
- **`SoftwareApplication` is the defensible schema** — a literal description of the product.
- GEO impact is hard to measure and geo-personalized, so the checklist proposes a **before/after citation check**, not a promised ranking gain.

## Verification

- `bash ./test/ci_test_docs_consistency.sh` → passed (validates local markdown links)
- `server.json` parses; all schema constraints checked programmatically
- `curl` → `https://eth2quickstart.com` returns **200**
- Repo metadata re-read via `gh repo view --json description,homepageUrl,repositoryTopics`

## Relationship to other work

Companion to **#218** (the implementation). No overlap with the in-flight bake-off PRs (#213/#215/#216) — different files entirely.