### PR TITLE
fix(frontend): stop the llms.txt prebuild step from breaking deploys

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "packageManager": "bun@latest",
   "scripts": {
-    "predev": "bun scripts/sync-llms.mjs",
+    "predev": "node scripts/sync-llms.mjs",
     "dev": "next dev",
-    "prebuild": "bun scripts/sync-llms.mjs",
+    "prebuild": "node scripts/sync-llms.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/frontend/scripts/sync-llms.mjs
+++ b/frontend/scripts/sync-llms.mjs
@@ -67,7 +67,11 @@ function withBridgeLine(source) {
 for (const file of SOURCE_FILES) {
   const sourcePath = path.join(REPO_ROOT, file)
   if (!existsSync(sourcePath)) {
-    throw new Error(`sync-llms: expected repo-root file not found: ${sourcePath}`)
+    // Deploy environments don't always have the repo root available (some build
+    // only the frontend/ subtree). These files are a nice-to-have mirror, so warn
+    // and carry on rather than failing the whole build over a missing asset.
+    console.warn(`[sync-llms] skipping ${file}: repo-root source not found at ${sourcePath}`)
+    continue
   }
 
   const source = readFileSync(sourcePath, 'utf8')


### PR DESCRIPTION
**Nothing has deployed since #218 merged.** The live site still serves #219's build: `/agents`, `/llms.txt` and `/llms-full.txt` return 404 (`x-cache: Error from cloudfront`) and the homepage has zero `SoftwareApplication`/`FAQPage` JSON-LD — ~35 minutes after merge, where every earlier deploy propagated in about two minutes.

The code itself is fine — `bun run build` from master emits `/agents` and writes both llms files. The problem is that #218 added the frontend's **first `prebuild` step**, and it fails closed in two ways a deploy pipeline can hit:

1. **It requires `bun`.** `"prebuild": "bun scripts/sync-llms.mjs"` — the build environment isn't guaranteed to have bun, and if it runs the build through npm/node the step dies with `bun: command not found`, taking `next build` with it. The script is plain ESM and runs fine under `node`.
2. **It throws when the repo root isn't there.** The script reads `llms.txt` from one level above `frontend/` and `throw`s if it's absent — which is exactly what happens if the pipeline builds only the `frontend/` subtree. A missing convenience asset then takes down the whole build.

This makes both non-fatal: run the step with `node`, and warn-and-skip a missing source instead of throwing.

## Verified both ways

- **Frontend-only tree, no repo root:** skips both files with a warning, exits 0 (previously: threw, failing the build).
- **Normal tree:** still writes `public/llms.txt` and `public/llms-full.txt`, build compiles, `/agents` still emitted, 99 tests pass.

## Caveat

The deploy pipeline lives outside this repo and I can't see its logs. This fixes the fragility that is visible from here and matches the symptom exactly, but if the build is failing there for some other reason, this alone won't be enough — worth checking the pipeline's output after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGFtDbx3D739eprAKUUk9w