### PR TITLE
fix(bakeoff): let the anchor watchdog tolerate a bounded head lag

### DIFF
--- a/docs/CLIENT_BAKEOFF_HARNESS.md
+++ b/docs/CLIENT_BAKEOFF_HARNESS.md
@@ -176,7 +176,14 @@ Each iteration:
    loop `break`s immediately (before the anchor/stall/synced checks below even run for that tick).
 4. **Anchor watchdog** (anchor mode only, and only while `.anchor-poisoned` doesn't already exist):
    detects if the anchor EL silently dropped out of sync (service down, or `eth_syncing` no longer
-   reporting caught-up). Two consecutive misses (`anchor_miss_streak -ge 2`) touches
+   reporting caught-up). "Caught-up" allows the anchor to trail the network head by up to
+   `ETH2QS_BAKEOFF_ANCHOR_LAG_BLOCKS` (default 128): some ELs (nethermind) keep returning an
+   `eth_syncing` object at tip with `highestBlock` = network head, so while a CL is still warming up
+   and nothing is driving forkchoice the anchor legitimately trails by a few blocks. Demanding
+   `currentBlock >= highestBlock` there poisoned healthy rows (it is what produced the teku
+   `anchor_synced=no` false positive on the nethermind anchor). A real re-snap drops `currentBlock`
+   to ~0, millions of blocks out, so it still trips well inside the tolerance.
+   Two consecutive misses (`anchor_miss_streak -ge 2`) touches
    `.anchor-poisoned` and logs an error — **detection only, it never restarts or kills anything**,
    because the anchor EL is shared state across the whole CL sweep and killing it would invalidate
    every remaining candidate in the rotation.

--- a/frontend/app/blog/bakeoff-harness/page.tsx
+++ b/frontend/app/blog/bakeoff-harness/page.tsx
@@ -674,7 +674,12 @@ export default function BakeoffHarnessPage() {
             <li>
               <strong>Anchor watchdog</strong> (anchor mode only, and only while <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">.anchor-poisoned</code> doesn&apos;t
               already exist): detects if the anchor EL silently dropped out of sync (service down, or{' '}
-              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">eth_syncing</code> no longer reporting caught-up). Two consecutive misses (
+              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">eth_syncing</code> no longer reporting caught-up). &ldquo;Caught-up&rdquo; allows the anchor to trail
+              the network head by up to <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">ETH2QS_BAKEOFF_ANCHOR_LAG_BLOCKS</code> (default 128) &mdash; some ELs
+              keep returning an <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">eth_syncing</code> object at tip with <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">highestBlock</code> set to the network
+              head, so while a CL is still warming up and nothing drives forkchoice the anchor legitimately trails by
+              a few blocks. Demanding an exact catch-up there poisoned healthy rows. A real re-snap drops 
+              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">currentBlock</code> to ~0, so it still trips far inside the tolerance. Two consecutive misses (
               <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">anchor_miss_streak -ge 2</code>) touches <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">.anchor-poisoned</code> and logs
               an error — <strong>detection only, it never restarts or kills anything</strong>, because the anchor EL
               is shared state across the whole CL sweep and killing it would invalidate every remaining candidate in

--- a/test/bakeoff/run_candidate.sh
+++ b/test/bakeoff/run_candidate.sh
@@ -25,6 +25,13 @@ stall_max_restarts="${ETH2QS_BAKEOFF_STALL_MAX_RESTARTS:-3}"
 # healthy candidate ever sees (~0 restarts across a run) but far below a real
 # crash loop (hundreds within minutes) — see incident note at the watchdog site.
 crash_loop_max_restarts="${ETH2QS_BAKEOFF_MAX_RESTARTS:-20}"
+# How far the anchor EL may trail the network head before a sample counts as a
+# miss. Some ELs (nethermind) keep returning an eth_syncing OBJECT at tip with
+# highestBlock = network head, so while a CL is still warming up and nothing is
+# driving forkchoice, the anchor legitimately trails by a few blocks. Requiring
+# currentBlock >= highestBlock there poisons healthy rows. A real re-snap drops
+# currentBlock to ~0, which is millions of blocks out and still trips this.
+anchor_lag_tolerance="${ETH2QS_BAKEOFF_ANCHOR_LAG_BLOCKS:-128}"
 caps="$REPO_ROOT/test/bakeoff/apply_resource_caps.sh"
 
 # Anchor mode: when set, preserves this EL across the entire CL sweep.
@@ -289,7 +296,7 @@ if [[ "$install_rc" -eq 0 ]]; then
       else
         _snap_check="$(cat "$out/tmp/execution-sync.json" 2>/dev/null || true)"
         # Non-empty payload that does NOT parse as "synced" is a miss.
-        if [[ -n "$_snap_check" ]] && ! echo "$_snap_check" | jq -e '
+        if [[ -n "$_snap_check" ]] && ! echo "$_snap_check" | jq -e --argjson tol "$anchor_lag_tolerance" '
           def h2n:
             if . == null then 0
             else (ltrimstr("0x")
@@ -305,7 +312,7 @@ if [[ "$install_rc" -eq 0 ]]; then
           (.result == false)
           or ( ((.result|type) == "object")
                and (.result.highestBlock != "0x0")
-               and ((.result.currentBlock | h2n) >= (.result.highestBlock | h2n)) )
+               and (((.result.highestBlock | h2n) - (.result.currentBlock | h2n)) <= $tol) )
         ' >/dev/null 2>&1; then
           anchor_miss="yes"
         fi


### PR DESCRIPTION
Fixes the root cause of teku's `anchor_synced=no` false positive — the last open item from the third-anchor sweep.

## The bug

The anchor watchdog required `currentBlock >= highestBlock`. Some execution clients — nethermind among them — keep returning an `eth_syncing` **object** at tip with `highestBlock` set to the network head. While a consensus client is still warming up and nothing is driving forkchoice, the anchor legitimately trails by a few blocks. Two such samples in a row poisoned an otherwise healthy row.

That is precisely what happened to teku on the nethermind anchor, twice. **Re-running would not have helped** — the cause was the watchdog, not the client, so each attempt reproduced it.

## Proof, replayed through the recorded samples

| Sample | Anchor state | Old | New |
|---|---|---|---|
| 18:14:13Z | 56 blocks behind | MISS | ok |
| 18:16:51Z | 21 blocks behind (teku itself at `sync_distance=49`) | MISS | ok |
| 18:19:30Z → 18:22:45Z | clean | ok | ok |

**Old → poisoned. New → not poisoned.**

## It still catches real failures

Verified against synthetic payloads:

| Case | Result |
|---|---|
| warmup lag, 56 blocks | not flagged ✅ (the false positive) |
| re-snap from genesis (`currentBlock=0`) | **flagged** ✅ |
| re-snap 200k blocks in | **flagged** ✅ |
| stalled 512 blocks behind | **flagged** ✅ |
| fully synced (`false`) / exactly at head | not flagged ✅ |

Tolerance is `ETH2QS_BAKEOFF_ANCHOR_LAG_BLOCKS`, default **128** — the same servable-state window the campaign uses elsewhere. A real re-snap drops `currentBlock` to ~0, millions of blocks out, so it trips far inside the tolerance.

Documented in `CLIENT_BAKEOFF_HARNESS.md` and the on-site harness reference, including why the exact-catch-up rule was wrong.

`bash -n`, `shellcheck -x`, `tsc --noEmit` clean; 99 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGFtDbx3D739eprAKUUk9w