### PR TITLE
ci(frontend): stop the deploy smoke check aborting on its first poll

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -167,6 +167,12 @@ jobs:
           SITE: https://eth2quickstart.com
           EXPECTED_SHA: ${{ github.sha }}
         run: |
+          # GitHub runs this step as `bash -e`, so a failing command aborts the
+          # whole script. The poll below EXPECTS curl to fail while the deploy is
+          # still propagating, so errexit has to be off or the first 404 kills the
+          # job instead of retrying — which is exactly what happened on the first
+          # run of this check.
+          set +e
           set -uo pipefail
 
           # Deploys normally land in ~2-3 minutes; allow well past that before


### PR DESCRIPTION
The post-deploy smoke check added in #225 failed on its first run. **The check was wrong, not the deploy.**

GitHub runs the step as `bash -e`. The polling loop deliberately calls `curl -f` against a marker that doesn't exist yet while the deploy propagates — so the first 404 exited 22 and errexit killed the script ~2 seconds in. The retry loop never ran. My `set -uo pipefail` didn't help: it doesn't clear the `-e` the runner already set.

Fix: `set +e` explicitly before polling.

## The mechanism itself worked

Worth stating, because it means only the guard logic was broken:

- `/build-info.json` published on that very deploy with sha **`40d79cf`** — exactly the merge commit
- So the external pipeline **does** run the prebuild step, and the SHA comparison works end to end
- All 12 routes were 200 the whole time

It just never got to make a second request.

## Verified

Reproduced the failure and the fix with the same loop shape under `bash -e`: with `set +e`, a 404 on the first poll no longer aborts and the second poll resolves the SHA. YAML parses.

This is the failure mode I flagged when merging #225 — a misfiring gate is worse than none — so it's fixed rather than left red on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGFtDbx3D739eprAKUUk9w