### PR TITLE
feat(frontend): build-safe RSS feed + MCP manifest websiteUrl → /agents

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -198,7 +198,7 @@ jobs:
           # The 2026-07-29 outage showed up as new routes 404ing while the old
           # build kept serving, so assert the routes exist, not just the origin.
           fail=0
-          for path in / /quickstart /blog /agents /llms.txt /sitemap.xml /robots.txt \
+          for path in / /quickstart /blog /agents /llms.txt /sitemap.xml /robots.txt /rss.xml \
                       /blog/ethereum-client-bakeoff /blog/bakeoff-results \
                       /blog/bakeoff-harness /blog/how-we-tested-with-claude \
                       /deck/bakeoff.html; do

--- a/frontend/__tests__/app/rss.test.ts
+++ b/frontend/__tests__/app/rss.test.ts
@@ -1,0 +1,40 @@
+import { renderFeed } from '@/lib/rss'
+import { ARTICLES } from '@/lib/articles'
+import { SITE_CONFIG } from '@/lib/constants'
+
+describe('rss.xml feed', () => {
+  const body = renderFeed()
+
+  it('is a well-formed RSS 2.0 body with a self link', () => {
+    expect(body.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true)
+    expect(body).toContain('<rss version="2.0"')
+    expect(body).toContain(`<atom:link href="${SITE_CONFIG.url}/rss.xml" rel="self"`)
+    expect(body.trimEnd().endsWith('</rss>')).toBe(true)
+  })
+
+  it('includes every article, newest first, with canonical links', () => {
+    expect(body.match(/<item>/g)?.length).toBe(ARTICLES.length)
+    for (const article of ARTICLES) {
+      expect(body).toContain(`<link>${SITE_CONFIG.url}/blog/${article.slug}</link>`)
+    }
+    const newest = [...ARTICLES].sort((a, b) => (a.datePublished < b.datePublished ? 1 : -1))[0]
+    const oldest = [...ARTICLES].sort((a, b) => (a.datePublished > b.datePublished ? 1 : -1))[0]
+    expect(body.indexOf(newest.slug)).toBeLessThan(body.indexOf(oldest.slug))
+  })
+
+  it('escapes XML metacharacters so the feed can never be malformed', () => {
+    // The channel title contains an ampersand ("Field notes & benchmarks"); it
+    // must be entity-encoded, and no raw " & " may survive anywhere in the body.
+    expect(body).toContain('Field notes &amp; benchmarks')
+    expect(body).not.toMatch(/ & /)
+  })
+
+  it('uses a deterministic lastBuildDate (newest dateModified, not the wall clock)', () => {
+    const newestModified = ARTICLES.reduce(
+      (latest, a) => (a.dateModified > latest ? a.dateModified : latest),
+      ARTICLES[0].dateModified,
+    )
+    const expected = new Date(`${newestModified}T00:00:00Z`).toUTCString()
+    expect(body).toContain(`<lastBuildDate>${expected}</lastBuildDate>`)
+  })
+})

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -33,6 +33,13 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://eth2quickstart.com'),
   title: SITE_TITLE,
   description: SITE_DESCRIPTION,
+  // Feed-reader autodiscovery: emits <link rel="alternate" type="application/rss+xml">
+  // in <head> so readers find /rss.xml from any page.
+  alternates: {
+    types: {
+      'application/rss+xml': [{ url: '/rss.xml', title: 'ETH2 Quick Start — Field notes & benchmarks' }],
+    },
+  },
   openGraph: {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,

--- a/frontend/app/rss.xml/route.ts
+++ b/frontend/app/rss.xml/route.ts
@@ -1,0 +1,20 @@
+import { renderFeed, RSS_CONTENT_TYPE } from '@/lib/rss'
+
+/**
+ * RSS 2.0 feed for the blog, served at /rss.xml.
+ *
+ * `force-static` pre-renders the feed at build time into the static output the
+ * deploy serves behind CloudFront — the same model as sitemap.ts / robots.ts.
+ * The feed-building logic and its build-safety guarantee live in lib/rss.ts
+ * (a route module may only export the framework's reserved names).
+ */
+export const dynamic = 'force-static'
+
+export function GET(): Response {
+  return new Response(renderFeed(), {
+    headers: {
+      'Content-Type': RSS_CONTENT_TYPE,
+      'Cache-Control': 'public, max-age=3600',
+    },
+  })
+}

--- a/frontend/components/layout/Footer.tsx
+++ b/frontend/components/layout/Footer.tsx
@@ -7,6 +7,7 @@ const footerLinks = [
   { label: 'Agents', href: '/agents', internal: true },
   { label: 'GitHub', href: SITE_CONFIG.github },
   { label: 'Issues', href: `${SITE_CONFIG.github}/issues` },
+  { label: 'RSS', href: '/rss.xml' },
 ]
 
 export function Footer() {

--- a/frontend/lib/rss.ts
+++ b/frontend/lib/rss.ts
@@ -1,0 +1,107 @@
+import { ARTICLES } from './articles'
+import { SITE_CONFIG } from './constants'
+
+/**
+ * RSS 2.0 feed builder for the blog. Lives in lib/ (not the route file) because
+ * a Next.js route module may only export the framework's reserved names
+ * (GET, dynamic, ...) — exporting a helper from route.ts fails `next build`.
+ *
+ * BUILD SAFETY (incident 2026-07-29): the route pre-renders this at build time,
+ * and a throw would fail `next build` — a failed publish is invisible (the site
+ * keeps serving the old build and answering 200). So `renderFeed()` can never
+ * throw: any error falls back to a valid item-less feed.
+ */
+
+export const RSS_CONTENT_TYPE = 'application/rss+xml; charset=utf-8'
+
+const FEED_TITLE = 'ETH2 Quick Start — Field notes & benchmarks'
+const FEED_DESCRIPTION =
+  'Real results from a six-week Ethereum client bake-off: disk footprints, sync times, restart resilience, and the harness behind them.'
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+/** Article dates are `YYYY-MM-DD`; pin to UTC midnight for a stable RFC-822 string. */
+function toRfc822(iso: string): string {
+  const date = new Date(`${iso}T00:00:00Z`)
+  return Number.isNaN(date.getTime()) ? new Date(0).toUTCString() : date.toUTCString()
+}
+
+function buildFeed(): string {
+  const base = SITE_CONFIG.url
+  const items = [...ARTICLES]
+    // Newest first — the order a reader expects in a feed.
+    .sort((a, b) => (a.datePublished < b.datePublished ? 1 : -1))
+    .map((article) => {
+      const url = `${base}/blog/${article.slug}`
+      return [
+        '    <item>',
+        `      <title>${escapeXml(article.navTitle)}</title>`,
+        `      <link>${url}</link>`,
+        `      <guid isPermaLink="true">${url}</guid>`,
+        `      <description>${escapeXml(article.indexDescription)}</description>`,
+        `      <pubDate>${toRfc822(article.datePublished)}</pubDate>`,
+        '    </item>',
+      ].join('\n')
+    })
+    .join('\n')
+
+  // Deterministic lastBuildDate: the most recent article edit, not the wall
+  // clock — so an unchanged corpus produces a byte-identical feed each build.
+  const lastBuild = ARTICLES.reduce(
+    (latest, a) => (a.dateModified > latest ? a.dateModified : latest),
+    ARTICLES[0]?.dateModified ?? '1970-01-01',
+  )
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    `    <title>${escapeXml(FEED_TITLE)}</title>`,
+    `    <link>${base}/blog</link>`,
+    `    <description>${escapeXml(FEED_DESCRIPTION)}</description>`,
+    '    <language>en-us</language>',
+    `    <atom:link href="${base}/rss.xml" rel="self" type="application/rss+xml" />`,
+    `    <lastBuildDate>${toRfc822(lastBuild)}</lastBuildDate>`,
+    items,
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n')
+}
+
+/** Valid, item-less feed used only if buildFeed() ever throws — never fail the build. */
+function fallbackFeed(): string {
+  const base = SITE_CONFIG.url
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    '  <channel>',
+    `    <title>${escapeXml(FEED_TITLE)}</title>`,
+    `    <link>${base}/blog</link>`,
+    `    <description>${escapeXml(FEED_DESCRIPTION)}</description>`,
+    '    <language>en-us</language>',
+    `    <atom:link href="${base}/rss.xml" rel="self" type="application/rss+xml" />`,
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n')
+}
+
+/**
+ * The feed body as a string. The try/catch is the build-safety guarantee: any
+ * error yields a valid item-less feed rather than throwing.
+ */
+export function renderFeed(): string {
+  try {
+    return buildFeed()
+  } catch {
+    return fallbackFeed()
+  }
+}

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.chimera-defi/eth2-quickstart",
   "description": "Ethereum node ops: install, diagnose, and manage validators via the eth2-quickstart wrapper.",
   "version": "0.1.0",
-  "websiteUrl": "https://eth2quickstart.com",
+  "websiteUrl": "https://eth2quickstart.com/agents",
   "repository": {
     "url": "https://github.com/chimera-defi/eth2-quickstart",
     "source": "github"


### PR DESCRIPTION
## What

Adds a build-safe **RSS 2.0 feed** at `/rss.xml` and repoints the MCP registry manifest's `websiteUrl` at `/agents`.

The blog (the six-week bake-off) is the most citation-worthy content on the site but had no feed. This closes that gap.

### Changes
- **`frontend/lib/rss.ts`** — `renderFeed()` builds the feed from the `ARTICLES` single-source-of-truth (same source `sitemap.ts` uses). Logic lives in `lib/` because a Next route module may only export the framework's reserved names.
- **`frontend/app/rss.xml/route.ts`** — thin route handler, `export const dynamic = 'force-static'` so the feed pre-renders at build into the static output the deploy serves (same model as `sitemap.ts`/`robots.ts`).
- **`frontend/app/layout.tsx`** — `<link rel="alternate" type="application/rss+xml">` autodiscovery in `<head>`, emitted site-wide.
- **`frontend/components/layout/Footer.tsx`** — visible "RSS" link.
- **`frontend/__tests__/app/rss.test.ts`** — 4 tests (well-formedness, one item per article newest-first, XML escaping, deterministic `lastBuildDate`).
- **`.github/workflows/frontend.yml`** — `/rss.xml` added to the post-deploy smoke-check route list.
- **`server.json`** — `websiteUrl` → `https://eth2quickstart.com/agents` (the MCP manifest is not a frontend build input).

### Build safety (incident 2026-07-29)
A route handler that throws fails `next build`, and a failed publish is invisible (the site keeps serving the old build at 200). So `renderFeed()` **can never throw** — any error yields a valid item-less feed. Verified locally:
- `bun run build` green; `/rss.xml` prerenders as `○ (Static)`.
- Standalone server serves it at 200 with `Content-Type: application/rss+xml; charset=utf-8`.
- Feed is well-formed XML (4 items, escaped, deterministic date).
- **103 Jest tests pass** (4 new); `bunx tsc --noEmit` clean.

## Review / merge
Please review before merging — **merging is a human call.** No behavior change to existing pages.

---
*Authored by Claude Opus 4.8 (Anthropic), running as a cloud coding agent, at chimera_defi's direction. Human review requested before merge.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116CXJJ5SGvTcUE1Q7MogKD
