### PR TITLE
docs(blog): plain-language DataFlowDiagram + timeline/duration fixes

### DIFF
--- a/frontend/app/blog/bakeoff-harness/page.tsx
+++ b/frontend/app/blog/bakeoff-harness/page.tsx
@@ -267,57 +267,51 @@ const dataModelRows: { file: string; writtenBy: React.ReactNode; contents: React
   },
 ]
 
-// Renders the same edges as the source flowchart (kept in git history):
-//   candidates.tsv --> run_bakeoff.sh --> run_candidate.sh
-//   run_anchor_rotation.sh --> run_candidate.sh
+// Plain-language retelling of the same flowchart (identifiers kept as sub-labels,
+// full script-by-script edges documented in git history and in the sections below):
+//   [candidates.tsv -> run_bakeoff.sh]  \
+//   run_anchor_rotation.sh (2nd entry) /--> run_candidate.sh
 //   run_candidate.sh --> systemd EL/CL services
-//   run_candidate.sh --> artifacts/run-id/ --> summarize.sh --> summary.csv & report.md
+//   run_candidate.sh --> artifacts/<run-id>/ --> [summarize.sh -> summary.csv & report.md]
 function DataFlowDiagram() {
   return (
     <div className="mt-3">
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="flex flex-col items-center">
           <div className="w-full rounded-lg border border-border bg-muted/30 px-4 py-3 text-center text-sm text-foreground">
-            <span className="font-mono text-xs">candidates.tsv</span>
-            <span className="block text-xs text-muted-foreground">manifest</span>
-          </div>
-          <ArrowDown className="my-1.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-          <div className="w-full rounded-lg border border-border bg-muted/30 px-4 py-3 text-center text-sm text-foreground">
-            <span className="font-mono text-xs">run_bakeoff.sh</span>
-            <span className="block text-xs text-muted-foreground">sequential multi-candidate sweep</span>
+            Pick the next client pair to test
+            <span className="block text-xs text-muted-foreground font-mono">candidates.tsv &rarr; run_bakeoff.sh</span>
           </div>
         </div>
         <div className="flex flex-col items-center justify-end">
           <div className="w-full rounded-lg border border-border bg-muted/30 px-4 py-3 text-center text-sm text-foreground">
-            <span className="font-mono text-xs">run_anchor_rotation.sh</span>
-            <span className="block text-xs text-muted-foreground">anchor-preserving CL sweep (separate entry point)</span>
+            Or: reuse one synced EL, swap the consensus client
+            <span className="block text-xs text-muted-foreground font-mono">run_anchor_rotation.sh</span>
           </div>
         </div>
       </div>
       <ArrowDown className="mx-auto my-1.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <div className="mx-auto max-w-sm rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-center text-sm text-foreground">
-        <span className="font-mono text-xs text-primary">run_candidate.sh</span>
-        <span className="block text-xs text-muted-foreground">single-candidate driver: reset → install → cap → sample</span>
+        Reset, install, and resource-cap one candidate
+        <span className="block text-xs text-muted-foreground font-mono">run_candidate.sh</span>
       </div>
       <ArrowDown className="mx-auto my-1.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-center text-sm text-foreground">
-          <span className="font-mono text-xs">systemd EL &amp; CL services</span>
-          <span className="block text-xs text-muted-foreground">the running node</span>
+          Run the node
+          <span className="block text-xs text-muted-foreground font-mono">systemd eth1 + cl services</span>
         </div>
         <div className="flex flex-col items-center">
           <div className="w-full rounded-lg border border-border bg-muted/30 px-4 py-3 text-center text-sm text-foreground">
-            <span className="font-mono text-xs">artifacts/run-id/</span>
-            <span className="block text-xs text-muted-foreground">env.txt, samples.jsonl, disk snapshots</span>
+            Record everything as it runs
+            <span className="block text-xs text-muted-foreground font-mono">
+              {'artifacts/<run-id>/ (env.txt, samples, disk snapshots)'}
+            </span>
           </div>
           <ArrowDown className="my-1.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
           <div className="w-full rounded-lg border border-border bg-muted/30 px-4 py-3 text-center text-sm text-foreground">
-            <span className="font-mono text-xs">summarize.sh</span>
-            <span className="block text-xs text-muted-foreground">aggregation</span>
-          </div>
-          <ArrowDown className="my-1.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-          <div className="w-full rounded-lg border border-border bg-muted/30 px-4 py-3 text-center text-sm text-foreground">
-            <span className="font-mono text-xs">summary.csv &amp; report.md</span>
+            Aggregate into the results table
+            <span className="block text-xs text-muted-foreground font-mono">summarize.sh &rarr; summary.csv + report.md</span>
           </div>
         </div>
       </div>

--- a/frontend/app/blog/how-we-tested-with-claude/page.tsx
+++ b/frontend/app/blog/how-we-tested-with-claude/page.tsx
@@ -99,7 +99,7 @@ const campaignTimeline = [
   { date: '2026-07-06', label: 'CL sweep vs ethrex anchor, 5 CLs' },
   { date: '2026-07-08', label: 'CL cross-check vs geth anchor' },
   { date: '2026-07-10', label: 'ethrex restart-cliff bisected, geth 52h resume verified' },
-  { date: '2026-07-12', label: 'Installer / config correctness fixes shipped' },
+  { date: '2026-07-13', label: 'Installer / config correctness fixes shipped' },
   { date: '2026-07-13', label: 'nimbus_eth1 72h capped run completes' },
   { date: '2026-07-14', label: 'Initial campaign closes — harness and results docs shipped' },
   { date: '2026-07-26', label: 'Third anchor: CL sweep re-run against nethermind' },
@@ -110,6 +110,7 @@ const campaignTimeline = [
   { date: '2026-08-01', label: 'EXP-A: nethermind resumes a 10,607-block gap in 35 min — restart-resume measured' },
   { date: '2026-08-03', label: 'EXP-A bisection: no cliff at any gap (12 min → ~35h); prysm clean-resume measured, n=4' },
   { date: '2026-08-03', label: 'EXP-C: nethermind prune tuning → minimal-history default (~250–280 GiB, no-history tier) measured and shipped as a human-reviewed PR' },
+  { date: '2026-08-04', label: 'Minimal-history default merged to master, live on eth2quickstart.com (#227→#229)' },
 ]
 
 // What's actually implemented (test/bakeoff/lib.sh, run_candidate.sh) — no peer-count check
@@ -437,7 +438,8 @@ export default function HowWeTestedWithClaudePage() {
           </ul>
           <p className="mt-4 text-sm text-muted-foreground">
             Multiply that across the whole supported field of clients and the 23-day initial campaign
-            (which later grew into six weeks of follow-on measurement) and you have a task defined less by
+            (which grew, with the steady-state and restart-resume follow-ups, into a roughly six-week
+            campaign end to end) and you have a task defined less by
             any single hard step than by <em>sustained correctness</em> &mdash; the discipline to run the
             same careful protocol dozens of times, preserve the terminal measurement before teardown, and
             never let a shared-host quirk masquerade as a client property.
@@ -449,11 +451,10 @@ export default function HowWeTestedWithClaudePage() {
           <p className="mt-2 text-sm text-muted-foreground">
             The core design choice: decouple node wall-clock from agent wall-clock, and decouple durable
             state from agent context. Get those two right and a multi-week campaign stops needing a
-            multi-week attention span &mdash; and this claim has since been stress-tested harder than the
-            article originally described: the campaign has now run across multiple sessions spanning six
-            weeks, not three, with no change to the architecture. That&apos;s the point sharpened, not
-            softened: the bottleneck was never wall-clock, it&apos;s agent context, and a design that holds
-            at three weeks holds just as well at six.
+            multi-week attention span &mdash; and that held up in practice: the campaign ran across
+            multiple sessions spanning roughly six weeks end to end, with no change to the orchestration
+            model. The bottleneck was never wall-clock, it&apos;s agent context, and a design that holds at
+            three weeks holds just as well at six.
           </p>
 
           <AnchorHeading id="node-runs-agent-doesnt-watch" as="h3" className="mt-6 font-medium text-foreground">


### PR DESCRIPTION
**Agent:** Claude Sonnet 5
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary

Two independent doc/frontend fixes bundled per the brief.

### Part 1 — `frontend/app/blog/bakeoff-harness/page.tsx`, `DataFlowDiagram()` (~line 275)

The diagram had the hierarchy inverted: the prominent line was a mono script/file name, the plain meaning was a muted subtitle — backwards from the house principle ("explain stages, not just expose variable names"). Flipped every box: plain stage description is now `text-sm text-foreground` (the div's own base style, no wrapper needed), the identifier is a muted mono sub-label (`text-xs text-muted-foreground font-mono`).

**Box-count note:** the spec supplied exactly 6 plain-language phrasings for what was originally 8 boxes — 4 map 1:1 to a standalone box (`run_anchor_rotation.sh`, `run_candidate.sh`, the systemd box, the artifacts box), but 2 phrasings ("Pick the next client pair to test", "Aggregate into the results table") each covered a *pair* of boxes joined by an internal arrow (`candidates.tsv → run_bakeoff.sh`, and `summarize.sh → summary.csv & report.md`). Item 3's explicit "(keep the two-box fan)" parenthetical only makes sense as a call-out if the default elsewhere is to merge — so I merged those two pairs into one box each (chained mono sub-label showing both identifiers), keeping the two-entry-point shape and the two-box systemd/artifacts fan exactly as specified. Box count: 8 → 6. If the intent was instead to keep all 8 boxes and duplicate one phrase across a pair, that's an easy follow-up — flagged for your review.

Before → after (per box):
| Box (topology position) | Before (prominent / sub) | After (prominent / sub) |
|---|---|---|
| Entry A (merged) | `candidates.tsv` / `run_bakeoff.sh` (2 boxes) | "Pick the next client pair to test" / `candidates.tsv → run_bakeoff.sh` (1 box) |
| Entry B | `run_anchor_rotation.sh` / "anchor-preserving CL sweep…" | "Or: reuse one synced EL, swap the consensus client" / `run_anchor_rotation.sh` |
| Driver | `run_candidate.sh` / "single-candidate driver…" | "Reset, install, and resource-cap one candidate" / `run_candidate.sh` |
| Fan A | `systemd EL & CL services` / "the running node" | "Run the node" / `systemd eth1 + cl services` |
| Fan B (merged) | `artifacts/run-id/` → `summarize.sh` → `summary.csv & report.md` (3 boxes) | "Record everything as it runs" / `artifacts/<run-id>/ (env.txt, samples, disk snapshots)`, then "Aggregate into the results table" / `summarize.sh → summary.csv + report.md` (2 boxes) |

Updated the doc comment above the function to match the rendered edges.

### Part 2 — `frontend/app/blog/how-we-tested-with-claude/page.tsx`

1. `timeline`: `'2026-07-12'` ("Installer / config correctness fixes shipped") → `'2026-07-13'` (ships in PR #192, merged 07-13; nothing installer/config landed 07-12). Kept in place, right before the existing 07-13 nimbus entry.
2. Added a new final timeline entry: `{ date: '2026-08-04', label: 'Minimal-history default merged to master, live on eth2quickstart.com (#227→#229)' }` — the 08-03 entry was the measurement, not the ship.
3. `(which later grew into six weeks of follow-on measurement)` → `(which grew, with the steady-state and restart-resume follow-ups, into a roughly six-week campaign end to end)` — six weeks is the total span, not follow-on time added to the 23-day campaign.
4. Reworded the self-referential seam ("stress-tested harder than the article originally described… six weeks, not three") that referenced the article's own earlier draft — a reader can't parse that. Restated the fact directly: the campaign ran across multiple sessions spanning roughly six weeks end to end, with no change to the orchestration model.

## Verification (all green)

- `bun install` — ok
- `bunx tsc --noEmit` — clean, no errors
- `bun run build` — compiles; `/blog/bakeoff-harness` and `/blog/how-we-tested-with-claude` both built (static)
- `bun run test` — 103/103 passing, 18/18 suites

## Notes for review

- Not merged — feature branch only, per instructions.
- Please render-verify `DataFlowDiagram` on the dark theme, and weigh in on the 8→6 box-count judgment call above (documented rationale in the commit and this PR body).
- Base is `origin/master` (HEAD at `d8ad32b`), confirmed no conflict with the still-open `docs/harness-diagram-plain-language` branch (that one touches `ObservationLoopDiagram`, a different function on the same page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)