### PR TITLE
docs(blog): fix series reading order and link narrative to raw results

### DIFF
--- a/frontend/app/blog/ethereum-client-bakeoff/page.tsx
+++ b/frontend/app/blog/ethereum-client-bakeoff/page.tsx
@@ -696,7 +696,9 @@ export default function EthereumClientBakeoffPage() {
             ))}
           </div>
           <p className="mt-3 text-xs text-muted-foreground">
-            Sourced from <a href={`${SITE_CONFIG.github}/blob/master/docs/CLIENT_BAKEOFF_RESULTS.md`} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2">CLIENT_BAKEOFF_RESULTS.md</a>, the campaign&apos;s source-of-truth data.
+            Sourced from <a href={`${SITE_CONFIG.github}/blob/master/docs/CLIENT_BAKEOFF_RESULTS.md`} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2">CLIENT_BAKEOFF_RESULTS.md</a>, the campaign&apos;s source-of-truth data — see the full{' '}
+            <Link href="/blog/bakeoff-results" className="text-primary underline underline-offset-2">results on-site</Link>{' '}
+            or the raw doc on GitHub.
           </p>
         </section>
 

--- a/frontend/lib/articles.ts
+++ b/frontend/lib/articles.ts
@@ -50,6 +50,22 @@ export const ARTICLES: Article[] = [
     sitemapPriority: 0.9,
   },
   {
+    slug: 'bakeoff-results',
+    pageTitle: 'Bake-off Results — ETH2 Quick Start',
+    pageDescription:
+      'The raw results from the six-week Ethereum client bake-off — every triage row, footprint measurement, and gotcha — verbatim from CLIENT_BAKEOFF_RESULTS.md.',
+    navTitle: 'Bake-off results',
+    indexDescription:
+      'The raw results: Stage A pass matrix, final synced disk footprints, the consensus-client matrices, and operational-viability notes.',
+    eyebrow: 'Data',
+    ogImage: '/og-results.png',
+    ogAlt: 'Bake-off results — the raw data',
+    headline: 'Bake-off Results',
+    datePublished: '2026-07-21',
+    dateModified: '2026-08-06',
+    sitemapPriority: 0.8,
+  },
+  {
     slug: 'how-we-tested-with-claude',
     pageTitle: 'How We Ran a 6-Week Bake-off With Claude - ETH2 Quick Start',
     pageDescription:
@@ -79,22 +95,6 @@ export const ARTICLES: Article[] = [
     headline: 'The Bake-off Harness',
     datePublished: '2026-07-21',
     dateModified: '2026-08-01',
-    sitemapPriority: 0.8,
-  },
-  {
-    slug: 'bakeoff-results',
-    pageTitle: 'Bake-off Results — ETH2 Quick Start',
-    pageDescription:
-      'The raw results from the six-week Ethereum client bake-off — every triage row, footprint measurement, and gotcha — verbatim from CLIENT_BAKEOFF_RESULTS.md.',
-    navTitle: 'Bake-off results',
-    indexDescription:
-      'The raw results: Stage A pass matrix, final synced disk footprints, the consensus-client matrices, and operational-viability notes.',
-    eyebrow: 'Data',
-    ogImage: '/og-results.png',
-    ogAlt: 'Bake-off results — the raw data',
-    headline: 'Bake-off Results',
-    datePublished: '2026-07-21',
-    dateModified: '2026-08-06',
     sitemapPriority: 0.8,
   },
 ]


### PR DESCRIPTION
## Summary
- Reorder `ARTICLES` in `frontend/lib/articles.ts` so the raw `bakeoff-results` data lands right after the narrative and the deep-engineering `bakeoff-harness` reference lands last: `ethereum-client-bakeoff → bakeoff-results → how-we-tested-with-claude → bakeoff-harness`. This array drives `/blog`, every `ReadNext` block, and the sitemap — all three now surface the new order.
- Add an inline on-site link to `/blog/bakeoff-results` next to the existing `CLIENT_BAKEOFF_RESULTS.md` GitHub link in the "Additional run details" section of `frontend/app/blog/ethereum-client-bakeoff/page.tsx` (~line 698), so readers can reach the raw data without leaving the site. The existing GitHub link is kept.

## Test plan
- [x] `cd frontend && bun install`
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — compiles: blog index, all 4 articles (`ethereum-client-bakeoff`, `bakeoff-results`, `how-we-tested-with-claude`, `bakeoff-harness`), and `sitemap.xml`
- [x] `bun run test` — 18 suites / 103 tests pass, including `articles.test.ts`

**Agent:** Claude Sonnet 5
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)