### PR TITLE
docs(blog): add harness LOC stat across bake-off writeups

### DIFF
--- a/frontend/app/blog/bakeoff-harness/page.tsx
+++ b/frontend/app/blog/bakeoff-harness/page.tsx
@@ -465,6 +465,11 @@ export default function BakeoffHarnessPage() {
           <AnchorHeading id="layout" className="text-lg sm:text-xl font-semibold text-foreground">1. Layout</AnchorHeading>
           <StaticCodeBlock code={layoutTree} className="mt-4" />
           <p className="mt-4 text-sm text-muted-foreground">
+            All told, the harness is about <strong>1,550 lines of shell across eight scripts</strong> —{' '}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">run_candidate.sh</code> (~480) and{' '}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">lib.sh</code> (~380) carry most of the logic.
+          </p>
+          <p className="mt-4 text-sm text-muted-foreground">
             The executable driver scripts (<code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">run_bakeoff.sh</code>, <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">run_candidate.sh</code>,{' '}
             <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">run_anchor_rotation.sh</code>, <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">apply_resource_caps.sh</code>,{' '}
             <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">summarize.sh</code>) each set <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">set -Eeuo pipefail</code> and source{' '}

--- a/frontend/app/blog/how-we-tested-with-claude/page.tsx
+++ b/frontend/app/blog/how-we-tested-with-claude/page.tsx
@@ -551,7 +551,7 @@ export default function HowWeTestedWithClaudePage() {
             <a href={`${SITE_CONFIG.github}/tree/master/test/bakeoff`} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2">
               test/bakeoff
             </a>
-            . It&apos;s plain bash &mdash; deliberately, so it has no runtime that can drift out from under a systemd service:
+            . It&apos;s plain bash (~1,550 lines across eight scripts) &mdash; deliberately, so it has no runtime that can drift out from under a systemd service:
           </p>
           <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
             {harnessScripts.map((script) => (

--- a/frontend/public/deck/bakeoff.html
+++ b/frontend/public/deck/bakeoff.html
@@ -375,6 +375,9 @@
         <div class="panel"><span class="tag">Durable state</span><h3>Small files, not context</h3><p>Conclusions pushed down to markdown + CSV so a fresh session recovers the run — no context-window bottleneck.</p></div>
         <div class="panel"><span class="tag">Config-optimality gate</span><h3>Fair by construction</h3><p>Before a result counts, the harness verifies the client ran its most disk-efficient mode — else it rejects the run, not the client.</p></div>
       </div>
+      <div class="stat-row">
+        <div class="stat"><div class="n">~1,550</div><div class="l">lines of shell — the whole harness</div></div>
+      </div>
       <p class="kicker">A real benchmark, not a lab result: shared semi-production host, footprint from the final near-cap sample — never a mid-sync peak.</p>
     </div>
   </section>


### PR DESCRIPTION
## Summary

Adds one verified, round figure — the bake-off harness (`test/bakeoff/`) is **about 1,550 lines of shell across eight scripts** (1,553 exact; `run_candidate.sh` ~480 lines, `lib.sh` ~380 lines carry most of the logic) — to three surfaces:

- `frontend/app/blog/bakeoff-harness/page.tsx` — new sentence right after the §1 Layout file tree: "All told, the harness is about **1,550 lines of shell across eight scripts** — `run_candidate.sh` (~480) and `lib.sh` (~380) carry most of the logic."
- `frontend/public/deck/bakeoff.html` — new `.stat` tile (`~1,550` / "lines of shell — the whole harness") on the "Two clocks, and a gate" methodology slide, matching the existing `.stat-row`/`.stat` markup used elsewhere in the deck.
- `frontend/app/blog/how-we-tested-with-claude/page.tsx` — brief parenthetical in the harness intro paragraph: "It's plain bash (~1,550 lines across eight scripts) — deliberately, ...".

Line counts verified directly against the repo (`wc -l test/bakeoff/*.sh`): 59+377+105+80+483+226+201+22 = 1,553 total; `run_candidate.sh`=483, `lib.sh`=377 — both match the ~480/~380 figures used.

## Test plan

- [x] `cd frontend && bun install`
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — compiles, all routes prerender
- [x] `bun run test` — 18 suites / 103 tests, all pass
- [x] Deck HTML edit reviewed for well-formedness (single `.stat-row`/`.stat` block, no markup breakage)

**Agent:** Claude Sonnet 5
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)