### PR TITLE
docs(deck): match the deck to the corrected articles (accuracy touch-up)

### DIFF
--- a/frontend/public/deck/bakeoff.html
+++ b/frontend/public/deck/bakeoff.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="icon" href="/icon.svg">
-<meta name="description" content="A 13-slide deck of the six-week Ethereum client bake-off: findings, the restart-resilience twist, and the AI-agent methodology.">
+<meta name="description" content="A 14-slide deck of the six-week Ethereum client bake-off: findings, the restart-resilience twist, and the AI-agent methodology.">
 <meta property="og:title" content="Ethereum Client Bake-off — deck">
-<meta property="og:description" content="A 13-slide deck of the six-week Ethereum client bake-off — findings, the twist, and how AI agents ran it.">
+<meta property="og:description" content="A 14-slide deck of the six-week Ethereum client bake-off — findings, the twist, and how AI agents ran it.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://eth2quickstart.com/deck/bakeoff.html">
 <meta property="og:image" content="https://eth2quickstart.com/og-bakeoff.png">
@@ -254,13 +254,13 @@
       <p class="eyebrow">Result 01 · the disk lever</p>
       <h2>…but you can turn the knob down.</h2>
       <div class="chart" aria-label="Disk footprint by how much history you retain">
-        <div class="bar"><div class="name">Nethermind minimal</div><div class="track"><div class="fill" style="--v:.193"></div></div><div class="val"><strong class="win">~250 GiB</strong> · no history · new default</div></div>
-        <div class="bar muted"><div class="name">Ethrex</div><div class="track"><div class="fill" style="--v:.363"></div></div><div class="val"><b>~470 GiB</b> · no history</div></div>
+        <div class="bar"><div class="name">Nethermind minimal</div><div class="track"><div class="fill" style="--v:.193"></div></div><div class="val"><strong class="win">~250–280 GiB</strong> · no history · new default</div></div>
+        <div class="bar muted"><div class="name">Ethrex</div><div class="track"><div class="fill" style="--v:.363"></div></div><div class="val"><b>~470–476 GiB</b> · no history</div></div>
         <div class="bar muted"><div class="name">Nethermind full</div><div class="track"><div class="fill" style="--v:.837"></div></div><div class="val"><b>~1.06 TiB</b> · with history</div></div>
         <div class="bar muted"><div class="name">Geth</div><div class="track"><div class="fill" style="--v:.893"></div></div><div class="val"><b>~1.13 TiB</b> · floor, can't go lower</div></div>
       </div>
       <div class="axis">0 ————————————————— 1.3 TiB</div>
-      <p class="kicker"><strong class="win">Config-determined cuts both ways.</strong> Drop post-merge history and nethermind's new default lands at ~250 GiB — the smallest measured no-history staking configuration, roughly half ethrex's no-history datadir and a floor geth can't reach. The price is no historical RPC (old blocks return null); <code>NETHERMIND_FULL_HISTORY=true</code> on a fresh/rebuilt datadir keeps full history for a public RPC. A within-tier win, not "4× leaner than geth" — that would score a no-history node against a with-history one.</p>
+      <p class="kicker"><strong class="win">Config-determined cuts both ways.</strong> Drop post-merge history and nethermind's new default lands at ~250–280 GiB — the smallest measured no-history staking configuration, roughly half ethrex's no-history datadir and a floor geth can't reach. The price is no historical RPC (old blocks return null); <code>NETHERMIND_FULL_HISTORY=true</code> on a fresh/rebuilt datadir keeps full history for a public RPC. A within-tier win, not "4× leaner than geth" — that would score a no-history node against a with-history one.</p>
     </div>
   </section>
 
@@ -321,7 +321,7 @@
             <tr><td class="name-cell">Nethermind</td><td><span class="pill ok">synced</span></td><td class="n">~14.5h</td><td class="n">~1.06 TiB</td><td class="n">36.0%</td></tr>
             <tr><td class="name-cell">Geth</td><td><span class="pill ok">synced</span></td><td class="n">8h28m</td><td class="n">~1.13 TiB</td><td class="n">44.9%</td></tr>
             <tr><td class="name-cell">Ethrex</td><td><span class="pill ok">synced</span></td><td class="n">2h16m</td><td class="n">~470–476 GiB, no-history</td><td class="n">~0%</td></tr>
-            <tr><td class="name-cell">Besu</td><td><span class="pill warn">un-pruned</span></td><td class="n">19h18m</td><td class="n">~1.08 TiB</td><td class="n">17.4%</td></tr>
+            <tr><td class="name-cell">Besu</td><td><span class="pill ok">synced</span></td><td class="n">19h18m</td><td class="n">~1.08 TiB · un-pruned</td><td class="n">17.4%</td></tr>
             <tr><td class="name-cell">Reth</td><td><span class="pill warn">72h cap</span></td><td class="n">—</td><td class="n">~0.98 TiB*</td><td class="n">1.5%</td></tr>
             <tr><td class="name-cell">Nimbus-eth1</td><td><span class="pill warn">72h cap</span></td><td class="n">—</td><td class="n">~40 GB*</td><td class="n">~0%</td></tr>
             <tr><td class="name-cell">Erigon</td><td><span class="pill bad">no-sync</span></td><td class="n">deadlock</td><td class="n">—</td><td class="n">~0%</td></tr>
@@ -402,7 +402,7 @@
       <p class="eyebrow">If you run one node for the long haul</p>
       <h2>What to actually run.</h2>
       <ul class="clean">
-        <li><b>Diversity pick → Nethermind.</b> Compact flat-storage state, restart-resume now measured (2026-08-01: closed a 10,607-block/~35h gap in 35m09s, no re-snap), and a minority-client diversity bonus — on disk it's on par with geth (~1.06 vs ~1.13 TiB) once full post-merge history is counted, not the space-saver its snap-sync-tip snapshot suggested. It now ships <b>minimal-history by default</b> — ~250 GiB, the smallest measured no-history staking configuration, if you don't need historical RPC (<code>NETHERMIND_FULL_HISTORY=true</code> keeps full history for an RPC provider). Costs a bit more sync time (~14.5h vs geth's ~8.5h).</li>
+        <li><b>Diversity pick → Nethermind.</b> Compact flat-storage state, restart-resume now measured (2026-08-01: closed a 10,607-block/~35h gap in 35m09s, no re-snap), and a minority-client diversity bonus — on disk it's on par with geth (~1.06 vs ~1.13 TiB) once full post-merge history is counted, not the space-saver its snap-sync-tip snapshot suggested. It now ships <b>minimal-history by default</b> — ~250–280 GiB, the smallest measured no-history staking configuration, if you don't need historical RPC (<code>NETHERMIND_FULL_HISTORY=true</code> keeps full history for an RPC provider). Costs a bit more sync time (~14.5h vs geth's ~8.5h).</li>
         <li><b>The boring default → Geth.</b> Largest ecosystem, most docs, cleanest ~8h28m snap sync — its ~1.13 TiB disk footprint is on par with the rest of the field, not a downside unique to geth.</li>
         <li><b>Consensus → Lighthouse.</b> The lean, safe default: ~518 MiB, checkpoint-syncs in minutes, blob pruning on by default.</li>
       </ul>
@@ -429,7 +429,7 @@
 </div>
 
 <div class="hint"><b>← →</b> navigate &nbsp;·&nbsp; <b>N</b> notes &nbsp;·&nbsp; <b>P</b> print / PDF</div>
-<div class="hud"><span class="live" aria-hidden="true"></span> SLIDE <b id="cur">01</b> / <span id="tot">13</span></div>
+<div class="hud"><span class="live" aria-hidden="true"></span> SLIDE <b id="cur">01</b> / <span id="tot">14</span></div>
 <div class="nav"><button id="notesBtn" aria-label="Toggle speaker notes">☰</button><button id="prev" aria-label="Previous slide">‹</button><button id="next" aria-label="Next slide">›</button></div>
 <div class="notes" id="notes"><p class="lab">Speaker notes</p><p id="noteText"></p></div>
 <div class="rail"><i id="railfill"></i></div>
@@ -443,7 +443,7 @@
     "Open on the paradox: the fastest Ethereum client is one almost nobody runs. The hook — we let a fleet of AI agents run a real six-week mainnet benchmark.",
     "A fair fight: every client got its most disk-efficient mode, a fixed partner, and a hard 72-hour cap. Two headline numbers each — disk and sync — then the third axis nobody benchmarks.",
     "The field converges on disk — no clean winner. Nethermind, besu, and geth all land in the same ~1.0-1.2 TiB band once they carry full post-merge history; nethermind's early ~251 GiB reading was pre-backfill, not steady-state. The hatched bars aren't comparable: Nimbus-eth1's ~40 GB never finished (only ~21% of a sync), while ethrex's ~470–476 GiB is a settled plateau — smaller only because it's a no-history node, not because it's more efficient.",
-    "Config-determined cuts both ways — so turn it down. Nethermind's new default drops post-merge history: ~250 GiB, the smallest measured no-history staking configuration (roughly half ethrex, and a floor geth can't reach), at the cost of serving no historical RPC. NETHERMIND_FULL_HISTORY=true on a fresh/rebuilt datadir restores full history for a public RPC. Frame it as a within-tier win, not '4x leaner than geth' — that would score a no-history node against a with-history one.",
+    "Config-determined cuts both ways — so turn it down. Nethermind's new default drops post-merge history: ~250–280 GiB, the smallest measured no-history staking configuration (roughly half ethrex, and a floor geth can't reach), at the cost of serving no historical RPC. NETHERMIND_FULL_HISTORY=true on a fresh/rebuilt datadir restores full history for a public RPC. Frame it as a within-tier win, not '4x leaner than geth' — that would score a no-history node against a with-history one.",
     "ethrex is nearly 4× faster than anything else in the field. Land the question and pause: so why does almost nobody actually run it?",
     "Because it hits a restart cliff. A 26-minute gap stalled; measured 1.5–2-hour gaps discarded state and triggered a full ~2-hour re-snap. That operability tax is the adoption story.",
     "The point of the whole talk: restart resilience is a third axis, and it predicts who people keep running better than speed or disk. Three behaviors — clean resume, re-snap cliff, mid-sync deadlock.",


### PR DESCRIPTION
Accuracy touch-up so the live deck matches the corrected on-site articles (adversarial review found 0 P1s — it was updated in lockstep — plus 2 consistency + 3 nits).

- nethermind minimal-history ~250 GiB → **~250–280 GiB** (4 spots; source gives the range, compaction-oscillating)
- besu scorecard Result pill **un-pruned→synced** (it snap-synced cleanly; un-pruned moved to the footprint cell)
- slide count **13→14** (2 meta tags + no-JS #tot fallback)
- ethrex **~470→~470–476 GiB** on slide 3b (matches slides 3/7)

Static deck file only; well-formed (balanced divs); the correctly-framed ~251 GiB pre-backfill note is untouched.

**Agent:** Claude Opus 4.8 (Anthropic), cloud coding agent
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)