### PR TITLE
docs(blog): add ethrex servable-window figure, fix six-vs-eight scripts wording

### DIFF
--- a/frontend/app/blog/ethereum-client-bakeoff/page.tsx
+++ b/frontend/app/blog/ethereum-client-bakeoff/page.tsx
@@ -958,6 +958,66 @@ export default function EthereumClientBakeoffPage() {
             serves that same history; an ethrex endpoint does not, so it isn&apos;t a drop-in
             replacement for a public DeFi-facing RPC.
           </p>
+          <figure
+            className="mt-5 rounded-xl border border-border bg-muted/30 p-4 sm:p-6"
+            aria-label="Ethrex's servable RPC window: it returns null for all of Ethereum history from genesis through the snap-sync pivot, and serves only from the pivot forward to head"
+          >
+            <div className="flex items-stretch overflow-hidden rounded-lg border border-border">
+              <div
+                className="flex flex-1 items-center justify-center border-r-2 border-dashed border-[#e5726e]/40 px-3 py-3 text-center text-[11px] font-medium leading-snug text-[#e5726e] sm:text-xs"
+                style={{
+                  backgroundImage:
+                    'repeating-linear-gradient(45deg, rgba(229,114,110,0.10), rgba(229,114,110,0.10) 6px, transparent 6px, transparent 12px)',
+                }}
+              >
+                returns <code className="font-mono text-inherit">null</code> — all of Ethereum
+                history (genesis → pivot)
+              </div>
+              <div className="relative flex w-16 flex-shrink-0 items-center justify-center bg-[#a855f7]/[0.14] px-2 py-3 text-center text-[11px] font-medium text-[#a855f7] sm:w-24 sm:text-xs">
+                served
+                <span className="absolute inset-y-0 right-0 w-[3px] bg-[#a855f7]" aria-hidden="true" />
+              </div>
+            </div>
+            <div className="mt-2.5 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1 px-0.5 text-[11px] text-muted-foreground">
+              <span>genesis · block 0</span>
+              <span>merge · 15,537,394</span>
+              <span className="font-medium text-[#a855f7]">snap pivot · 25,634,445</span>
+              <span>head</span>
+            </div>
+            <div className="mt-3.5 flex flex-wrap gap-x-4 gap-y-2 text-[11px] text-muted-foreground">
+              <span className="inline-flex items-start gap-1.5">
+                <span
+                  className="mt-0.5 inline-block h-3 w-3 flex-shrink-0 rounded-sm border border-[#e5726e]/40 bg-[#e5726e]/10"
+                  aria-hidden="true"
+                />
+                <span>
+                  returns <code className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">null</code>{' '}
+                  — pre-pivot blocks/logs/receipts (indexers, portfolio history, tax exports break)
+                </span>
+              </span>
+              <span className="inline-flex items-start gap-1.5">
+                <span
+                  className="mt-0.5 inline-block h-3 w-3 flex-shrink-0 rounded-sm border border-[#a855f7]/50 bg-[#a855f7]/[0.14]"
+                  aria-hidden="true"
+                />
+                <span>served — pivot → head (~4,783 blk at measurement; grows forward, never backfills)</span>
+              </span>
+              <span className="inline-flex items-start gap-1.5">
+                <span className="mt-0.5 inline-block h-3 w-3 flex-shrink-0 rounded-sm bg-[#a855f7]" aria-hidden="true" />
+                <span>state only — last ~128 blk (~25 min)</span>
+              </span>
+            </div>
+            <p className="mt-2.5 text-center text-[11px] italic text-muted-foreground">
+              not to scale — the served window is ~0.02% of the chain (4,783 of 25.6M blocks)
+            </p>
+            <figcaption className="mt-3 text-xs text-muted-foreground">
+              ethrex answers from the block it snapped at, forward — the cutoff is <em>exactly</em>{' '}
+              the pivot (probed to single-block precision). Wallet reads at head work fine; anything
+              historical returns{' '}
+              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">null</code>. That&apos;s
+              why its ~470 GiB isn&apos;t a disk win — it keeps almost no chain.
+            </figcaption>
+          </figure>
         </section>
 
         <section className="mt-10 sm:mt-16">

--- a/frontend/app/blog/ethereum-client-bakeoff/page.tsx
+++ b/frontend/app/blog/ethereum-client-bakeoff/page.tsx
@@ -964,17 +964,19 @@ export default function EthereumClientBakeoffPage() {
           >
             <div className="flex items-stretch overflow-hidden rounded-lg border border-border">
               <div
-                className="flex flex-1 items-center justify-center border-r-2 border-dashed border-[#e5726e]/40 px-3 py-3 text-center text-[11px] font-medium leading-snug text-[#e5726e] sm:text-xs"
+                className="flex min-h-[2.75rem] flex-1 items-center justify-center border-r-2 border-dashed border-[#e5726e]/40 px-3 py-3 text-center text-[11px] font-medium leading-snug text-[#e5726e] sm:text-xs"
                 style={{
                   backgroundImage:
                     'repeating-linear-gradient(45deg, rgba(229,114,110,0.10), rgba(229,114,110,0.10) 6px, transparent 6px, transparent 12px)',
                 }}
               >
-                returns <code className="font-mono text-inherit">null</code> — all of Ethereum
-                history (genesis → pivot)
+                <span className="hidden sm:inline">
+                  returns <code className="mx-1 font-mono text-inherit">null</code> — all of
+                  Ethereum history (genesis → pivot)
+                </span>
               </div>
               <div className="relative flex w-16 flex-shrink-0 items-center justify-center bg-[#a855f7]/[0.14] px-2 py-3 text-center text-[11px] font-medium text-[#a855f7] sm:w-24 sm:text-xs">
-                served
+                <span className="hidden sm:inline">served</span>
                 <span className="absolute inset-y-0 right-0 w-[3px] bg-[#a855f7]" aria-hidden="true" />
               </div>
             </div>

--- a/frontend/app/blog/how-we-tested-with-claude/page.tsx
+++ b/frontend/app/blog/how-we-tested-with-claude/page.tsx
@@ -552,7 +552,7 @@ export default function HowWeTestedWithClaudePage() {
             <a href={`${SITE_CONFIG.github}/tree/master/test/bakeoff`} target="_blank" rel="noopener noreferrer" className="text-primary underline underline-offset-2">
               test/bakeoff
             </a>
-            . It&apos;s plain bash (~1,550 lines across eight scripts) &mdash; deliberately, so it has no runtime that can drift out from under a systemd service:
+            . It&apos;s plain bash (~1,550 lines across eight scripts) &mdash; deliberately, so it has no runtime that can drift out from under a systemd service. The core scripts:
           </p>
           <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
             {harnessScripts.map((script) => (


### PR DESCRIPTION
## Summary
- Adds a "chain strip" figure to `frontend/app/blog/ethereum-client-bakeoff/page.tsx` (disk-story section, right after the paragraph that already states ethrex's servable window ends `null` before the snap pivot). Shows the full chain as a horizontal strip: a large hatched red `null` region (genesis → snap pivot 25,634,445) and a small purple `served` segment (pivot → head, ~4,783 blk / ~0.02% of the chain), with genesis/merge/pivot/head ticks, a 3-item legend, an italic "not to scale" note, and a plain-text `<figcaption>`. Matches the "Option A" reference mockup and reuses the `#e5726e` / `#a855f7` color + Tailwind-arbitrary-value pattern already established by the "three fates" restart figure in the same file.
- Fixes a reader-facing inconsistency in `frontend/app/blog/how-we-tested-with-claude/page.tsx`: the prose said "eight scripts" directly above a list (`harnessScripts`) that renders only 6 (the core ones — `run_queue.sh` and `test_data_dirs_sync.sh` are intentionally omitted). Reworded the list's lead-in to "The core scripts:" so it reads as a subset; the `~1,550 lines across eight scripts` figures are untouched (they're accurate — 8 `.sh` files total).

## Files changed
- `frontend/app/blog/ethereum-client-bakeoff/page.tsx` — new figure inserted after the existing prose paragraph, ending at the closing `</section>` for the disk-story section (well clear of the "three fates" figure further down in the restart-resilience section).
- `frontend/app/blog/how-we-tested-with-claude/page.tsx` — one-line wording change to the lead-in sentence right before the `harnessScripts.map(...)` list.

## Verification
- `bun install` — clean (680 packages)
- `bunx tsc --noEmit` — clean, no errors
- `bun run build` — compiles; both `/blog/ethereum-client-bakeoff` and `/blog/how-we-tested-with-claude` build as static routes
- `bun run test` — 18 suites / 103 tests, all passing
- Manually confirmed in the built CSS (`.next/static/css/*.css`) that every arbitrary-value Tailwind class used in the new figure (`bg-[#a855f7]/[0.14]`, `bg-[#e5726e]/10`, `border-[#e5726e]/40`, `text-[#e5726e]`, etc.) actually emitted a rule — none were silently dropped by JIT.

## Data verified (hardcoded, per task spec)
genesis = block 0, merge = 15,537,394, snap pivot = 25,634,445, served window ≈ 4,783 blk (~0.02% of 25.6M blocks), state window ≈ last 128 blk (~25 min).

## Uncertain / for review
- The figure's visual rendering on the dark theme (hatch pattern legibility, mobile wrap behavior of ticks/legend, "served" segment width on narrow screens) has not been visually screenshotted — needs a render check.

**Agent:** Claude Sonnet 5
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)