### PR TITLE
docs(deck): scope the CL-solved claim and correct the erigon CPU-cap detail

### DIFF
--- a/frontend/public/deck/bakeoff.html
+++ b/frontend/public/deck/bakeoff.html
@@ -336,8 +336,8 @@
   <section class="slide">
     <div class="wrap">
       <p class="eyebrow">Consensus layer</p>
-      <h2>The CL layer is effectively solved.</h2>
-      <p class="lede">All five checkpoint-synced to a validating head in minutes — ~6–9 min on the geth anchor, ~7–10 min on the nethermind anchor, ~22–23 min on ethrex — with zero client-fault failures. Sync time is a tie, so <em>footprint</em> is the differentiator.</p>
+      <h2>The CL layer looks solved — on the axes we measured.</h2>
+      <p class="lede">All five checkpoint-synced to a validating head in minutes — ~6–9 min on the geth anchor, ~7–10 min on the nethermind anchor, ~22–23 min on ethrex — with zero client-fault failures. Sync time is a tie, so <em>footprint</em> is the differentiator. Scope: we swept the five for sync and footprint, not for restart-resume — the only CL we restart-tested is prysm, the constant anchor.</p>
       <div class="chart" style="margin-top:24px" aria-label="Consensus-client datadir footprint, geth anchor">
         <div class="bar"><div class="name">lodestar</div><div class="track"><div class="fill" style="--v:.147"></div></div><div class="val"><b>~177 MiB</b> · smallest</div></div>
         <div class="bar"><div class="name">lighthouse</div><div class="track"><div class="fill" style="--v:.431"></div></div><div class="val"><b>~518 MiB</b> · lean default</div></div>
@@ -391,7 +391,7 @@
         <div class="panel"><span class="tag">nethermind</span><h3>13.3h silent stall</h3><p>Head frozen at block 4,651, 0 peers — everything else looked healthy. Root cause: P2P pinned to loopback. Fixed by advertising a routable external IP.</p></div>
         <div class="panel"><span class="tag">besu</span><h3>Mid-sync deadlock</h3><p>Downloader thread died, process stayed alive and kept answering RPC. Stale pinned CL stalled the beacon past the servable window.</p></div>
         <div class="panel hot"><span class="tag">ethrex</span><h3>Restart-resync cliff</h3><p>Stalled just beyond ~25 min; longer measured gaps discarded state and re-snapped. Inherent to the current design.</p></div>
-        <div class="panel"><span class="tag">erigon</span><h3>Gap-close deadlock</h3><p>OtterSync + a checkpoint-synced CL never issue the forkchoice update that would close the gap. Raising CPU caps didn't help.</p></div>
+        <div class="panel"><span class="tag">erigon</span><h3>Gap-close deadlock</h3><p>OtterSync + a checkpoint-synced CL never issue the forkchoice update that would close the gap. Raising the CL CPU cap 200%&rarr;600% advanced it ~5k blocks, then it re-froze.</p></div>
       </div>
     </div>
   </section>
@@ -448,7 +448,7 @@
     "Because it hits a restart cliff. A 26-minute gap stalled; measured 1.5–2-hour gaps discarded state and triggered a full ~2-hour re-snap. That operability tax is the adoption story.",
     "The point of the whole talk: restart resilience is a third axis, and it predicts who people keep running better than speed or disk. Three behaviors — clean resume, re-snap cliff, mid-sync deadlock.",
     "The full field at a glance. Be fair to the clients: besu and ethrex synced fine but their footprints aren't pruned-comparable (besu un-pruned; ethrex a no-history plateau); reth and nimbus-eth1 are full-sync-only by design, not failures.",
-    "The consensus layer is effectively solved — all five sync in minutes, so footprint is the only differentiator. Lighthouse is the lean, safe default. The same three tiers held across three EL anchors, with a small within-tier order flip.",
+    "The consensus layer looks solved on the axes we measured — all five sync in minutes, so footprint is the only differentiator. Lighthouse is the lean, safe default. The same three tiers held across three EL anchors, with a small within-tier order flip. If asked: we swept the five for sync and footprint, not restart-resume — prysm is the only CL we restart-tested, so this earns 'prysm resumes cleanly', not 'the CL layer survives anything'.",
     "Pivot to methodology — the other story people want. Three tiers keep token cost sane and judgment where it belongs. Governance is the punchline: an agent cannot merge its own PR.",
     "The harness is what kept it honest: decouple node time from agent time, push conclusions into small durable files (not the context window), and gate every result on config-optimality.",
     "Four real incidents in three weeks — every one caught and documented. This is the concrete proof of 'we kept ourselves honest.'",


### PR DESCRIPTION
Two carry-overs from the article quality pass (#242–#246). PR #240 had matched the deck to the articles *as they were then*; those articles have since been corrected, so the deck needed a re-check.

### Fixed
- **"The CL layer is effectively solved."** asserted more than was measured. The five CLs were swept for checkpoint-sync and footprint, **not restart-resume** — prysm is the only CL we restart-tested. `CLIENT_BAKEOFF_RESULTS.md:271` explicitly refuses this generalization ("this earns *prysm resumes cleanly*, not *the CL layer is solved*"). Retitled to "looks solved — on the axes we measured" and scoped, on **both** the slide and the speaker note so the spoken script can't contradict the slide.
- **"Raising CPU caps didn't help."** overstated. `RESULTS.md:85` records the CL CPU cap 200%→600% advancing erigon **~5k blocks** before it re-froze.

### Already correct — checked, not changed
- The **restart cliff**: the deck separates the ~25-min stall from the state-discard at 1.5–2h gaps. This is exactly what the flagship article got *wrong* (fixed in #244) — the deck had it right.
- **Unit labels**: the deck quotes geth-anchor CL figures, which were always correctly `MiB`/`GiB`, so the binary-unit correction (#243/#246) doesn't apply here.

### Verification
- `bunx tsc --noEmit` clean · `bun run test` 103/103 · `bun run build` ok
- Both changed slides screenshot-rendered at 1280×720 via `chrome-headless-shell` — the longer heading wraps to three lines and the added scope sentence fits with no overflow; the erigon panel balances its neighbour at three lines.

**Agent:** Claude Opus 4.8
**Co-authored-by:** Chimera