### PR TITLE
fix(docs,deck): surface nethermind minimal-history default and anchor-qualify CL claims

### DIFF
--- a/docs/blog/CLIENT_BAKEOFF_OPERATOR_GUIDE.md
+++ b/docs/blog/CLIENT_BAKEOFF_OPERATOR_GUIDE.md
@@ -16,7 +16,7 @@ Two clients cleared every bar we care about — snap-sync to a validating tip, a
 
 | EL | Sync time | Steady-state footprint | Mainnet share | Verdict |
 |----|-----------|------------------------|---------------|---------|
-| **nethermind** | ~14.5h | **~1.06 TiB** (re-measured 2026-08-01: state ~226–230 GiB + ~843 GiB post-merge bodies/receipts + ~19 GiB headers/code; ~251 GiB at snap-sync, before backfill) | 36.0% | **Diversity pick** — on par with geth once full post-merge history is counted, not a disk winner. Compact flat-storage state; a minority client; restart-resume now measured (2026-08-01: closed a 10,607-block/~35h gap in 35m09s, no re-snap). |
+| **nethermind** | ~14.5h | **~1.06 TiB** full-history (re-measured 2026-08-01: state ~226–230 GiB + ~843 GiB post-merge bodies/receipts + ~19 GiB headers/code; ~251 GiB at snap-sync, before backfill). **The shipped installer now defaults to minimal-history** (`NETHERMIND_FULL_HISTORY=false`) → **~250–280 GiB, with no historical RPC**; set `=true` on a fresh datadir to restore the ~1.06 TiB full-history configuration above. | 36.0% | **Diversity pick** — on par with geth once full post-merge history is counted, not a disk winner. Compact flat-storage state; a minority client; restart-resume now measured (2026-08-01: closed a 10,607-block/~35h gap in 35m09s, no re-snap). |
 | **geth** | ~8h28m | ~1.13 TiB | 44.9% | **Conservative default** — biggest ecosystem, most docs, resumes cleanly from multi-day downtime (measured 2026-07-10). |
 
 There is no disk winner between these two — they converge once you count full post-merge history. If you run one EL for the long haul, run one of these. Pick **nethermind** for its genuinely compact flat-storage state and to improve client diversity; pick **geth** if you want the most boring, best-documented option on the network.
@@ -31,15 +31,15 @@ There is no disk winner between these two — they converge once you count full 
 
 ## Consensus client: any of the five, lighthouse as the lean default
 
-The CL layer is the healthy half of the network. Every consensus client we swept checkpoint-synced to a validating head in ~22–23 minutes with zero crashes. None of them *failed* — so your choice is footprint and preference, not survival. Smaller is better:
+The CL layer is the healthy half of the network. Every consensus client we swept checkpoint-synced to a validating head in ~22–23 minutes with zero crashes. None of them *failed* — so your choice is footprint and preference, not survivability — which we only measured for prysm, the constant anchor. Smaller is better:
 
-**lighthouse (~739 MiB) < lodestar (~827 MiB) < grandine (~946 MiB) < teku (~2.1 GiB) < nimbus (~5.0 GiB)**
+On the ethrex anchor: **lighthouse (~739 MiB) < lodestar (~827 MiB) < grandine (~946 MiB) < teku (~2.1 GiB) < nimbus (~5.0 GiB)** (lodestar is smallest on the geth and nethermind anchors — absolute size tracks the measurement window).
 
 Two operational caveats worth knowing:
 
 - **teku** needs a generously sized JVM heap on a shared host (`TEKU_CACHE`). Undersized, its garbage collection spilled onto co-resident services and poisoned one of our runs.
 - **grandine** needs `--prune-storage` or it stores *every* state — the single most important flag for it.
-- **nimbus** is simply the heaviest (~6.8× lighthouse), but otherwise clean.
+- **nimbus** is simply the heaviest (~6.9× lighthouse), but otherwise clean.
 
 We ran this whole sweep three times — anchored to ethrex, then geth, then nethermind — and the same three tiers held: lightweight {lodestar, lighthouse}, mid {teku, grandine}, heavy {nimbus}. Absolute sizes shifted by anchor, and lodestar/lighthouse swapped which one was smallest (lighthouse on ethrex; lodestar on geth and nethermind), so the evidence supports broad EL/CL decoupling without claiming an identical total order.
 
@@ -49,7 +49,7 @@ Cold-sync benchmarks measure day one. You operate a node for months, and you *re
 
 Clients split into three behaviors:
 
-1. **Graceful resume** — comes back, imports the blocks it missed, keeps its state. Minutes to catch up. (geth, measured after a 52-hour gap; nethermind and reth expected here by design.)
+1. **Graceful resume** — comes back, imports the blocks it missed, keeps its state. Minutes to catch up. (geth, measured after a 52-hour gap; **nethermind, measured and bisected across 12 min → ~35 h gaps**; reth never reached a synced datadir to restart.)
 2. **Re-snap cliff** — after a gap past a threshold, discards its synced state and re-syncs from scratch. (**ethrex**, past ~25 minutes.)
 3. **Mid-sync deadlock** — if the CL stops driving the engine during an unfinished sync, the sync wedges permanently while the process still answers RPC. (**besu**, when a stale CL stalled ~28h.)
 
@@ -59,8 +59,8 @@ Behaviors #2 and #3 come from the *same* root cause: the network only serves rec
 
 ## TL;DR
 
-- **Run geth or nethermind.** They converge on disk (~1.06 vs ~1.13 TiB); pick nethermind for its compact flat-storage state and diversity, geth if you want boring and well-documented. besu only if you're an enterprise shop that babysits its CL.
-- **Any CL works.** lighthouse is the lean default (~739 MiB); lodestar and grandine are close; teku and nimbus are heavier but fine.
+- **Run geth or nethermind.** The shipped installer now defaults nethermind to minimal-history (`NETHERMIND_FULL_HISTORY=false`) → **~250–280 GiB, with no historical RPC**; set `=true` on a fresh datadir to restore the ~1.06 TiB full-history configuration that converges with geth's ~1.13 TiB. Pick nethermind for its compact flat-storage state and diversity, geth if you want boring and well-documented. besu only if you're an enterprise shop that babysits its CL.
+- **Any CL works.** lighthouse is the lean default on the ethrex anchor (~739 MiB; lodestar is smallest on the geth and nethermind anchors); grandine is close; teku and nimbus are heavier but fine.
 - **Restart-resilience beats cold-sync speed.** Fast initial sync (ethrex) and small archive-context footprints do not make a client operationally viable — surviving restarts and uptime does, and that's an EL-layer problem.
 - **Keep your consensus client updated.** A stale CL is how the one un-recoverable failure we saw actually happened.
 

--- a/frontend/public/deck/bakeoff.html
+++ b/frontend/public/deck/bakeoff.html
@@ -260,7 +260,7 @@
         <div class="bar muted"><div class="name">Geth</div><div class="track"><div class="fill" style="--v:.893"></div></div><div class="val"><b>~1.13 TiB</b> · floor, can't go lower</div></div>
       </div>
       <div class="axis">0 ————————————————— 1.3 TiB</div>
-      <p class="kicker"><strong class="win">Config-determined cuts both ways.</strong> Drop post-merge history and nethermind's new default lands at ~250–280 GiB — the smallest measured no-history staking configuration, roughly half ethrex's no-history datadir and a floor geth can't reach. The price is no historical RPC (old blocks return null); <code>NETHERMIND_FULL_HISTORY=true</code> on a fresh/rebuilt datadir keeps full history for a public RPC. A within-tier win, not "4× leaner than geth" — that would score a no-history node against a with-history one.</p>
+      <p class="kicker"><strong class="win">Config-determined cuts both ways.</strong> Drop post-merge history and nethermind's new default lands at ~250–280 GiB — the smaller of the two no-history configurations we measured, roughly half ethrex's no-history datadir and a floor geth can't reach (not a perfectly controlled comparison — different state encodings). The price is no historical RPC (old blocks return null); <code>NETHERMIND_FULL_HISTORY=true</code> on a fresh/rebuilt datadir keeps full history for a public RPC. A within-tier win, not "4× leaner than geth" — that would score a no-history node against a with-history one.</p>
     </div>
   </section>
 
@@ -324,7 +324,7 @@
             <tr><td class="name-cell">Besu</td><td><span class="pill ok">synced</span></td><td class="n">19h18m</td><td class="n">~1.08 TiB · un-pruned</td><td class="n">17.4%</td></tr>
             <tr><td class="name-cell">Reth</td><td><span class="pill warn">72h cap</span></td><td class="n">—</td><td class="n">~0.98 TiB*</td><td class="n">1.5%</td></tr>
             <tr><td class="name-cell">Nimbus-eth1</td><td><span class="pill warn">72h cap</span></td><td class="n">—</td><td class="n">~40 GB*</td><td class="n">~0%</td></tr>
-            <tr><td class="name-cell">Erigon</td><td><span class="pill bad">no-sync</span></td><td class="n">deadlock</td><td class="n">—</td><td class="n">~0%</td></tr>
+            <tr><td class="name-cell">Erigon</td><td><span class="pill bad">no-sync</span></td><td class="n">deadlock</td><td class="n">~1.21 TiB · frozen</td><td class="n">~0%</td></tr>
           </tbody>
         </table>
       </div>
@@ -386,7 +386,7 @@
   <section class="slide">
     <div class="wrap">
       <p class="eyebrow">Four incidents, all caught &amp; documented</p>
-      <h2>What actually breaks in three weeks.</h2>
+      <h2>What actually breaks in the first 23 days.</h2>
       <div class="grid g2">
         <div class="panel"><span class="tag">nethermind</span><h3>13.3h silent stall</h3><p>Head frozen at block 4,651, 0 peers — everything else looked healthy. Root cause: P2P pinned to loopback. Fixed by advertising a routable external IP.</p></div>
         <div class="panel"><span class="tag">besu</span><h3>Mid-sync deadlock</h3><p>Downloader thread died, process stayed alive and kept answering RPC. Stale pinned CL stalled the beacon past the servable window.</p></div>
@@ -402,9 +402,9 @@
       <p class="eyebrow">If you run one node for the long haul</p>
       <h2>What to actually run.</h2>
       <ul class="clean">
-        <li><b>Diversity pick → Nethermind.</b> Compact flat-storage state, restart-resume now measured (2026-08-01: closed a 10,607-block/~35h gap in 35m09s, no re-snap), and a minority-client diversity bonus — on disk it's on par with geth (~1.06 vs ~1.13 TiB) once full post-merge history is counted, not the space-saver its snap-sync-tip snapshot suggested. It now ships <b>minimal-history by default</b> — ~250–280 GiB, the smallest measured no-history staking configuration, if you don't need historical RPC (<code>NETHERMIND_FULL_HISTORY=true</code> keeps full history for an RPC provider). Costs a bit more sync time (~14.5h vs geth's ~8.5h).</li>
+        <li><b>Diversity pick → Nethermind.</b> Compact flat-storage state, restart-resume now measured (2026-08-01: closed a 10,607-block/~35h gap in 35m09s, no re-snap), and a minority-client diversity bonus — on disk it's on par with geth (~1.06 vs ~1.13 TiB) once full post-merge history is counted, not the space-saver its snap-sync-tip snapshot suggested. It now ships <b>minimal-history by default</b> — ~250–280 GiB, the smaller of the two no-history configurations we measured, if you don't need historical RPC (<code>NETHERMIND_FULL_HISTORY=true</code> keeps full history for an RPC provider). Costs a bit more sync time (~14.5h vs geth's ~8.5h).</li>
         <li><b>The boring default → Geth.</b> Largest ecosystem, most docs, cleanest ~8h28m snap sync — its ~1.13 TiB disk footprint is on par with the rest of the field, not a downside unique to geth.</li>
-        <li><b>Consensus → Lighthouse.</b> The lean, safe default: ~518 MiB, checkpoint-syncs in minutes, blob pruning on by default.</li>
+        <li><b>Consensus → Lighthouse.</b> The lean, safe default: ~518 MiB on the geth anchor, checkpoint-syncs in minutes, blob pruning on by default.</li>
       </ul>
       <p class="kicker">The real lesson: operational risk in an Ethereum node lives in the <em>execution</em> layer, not the consensus layer.</p>
     </div>
@@ -443,7 +443,7 @@
     "Open on the paradox: the fastest Ethereum client is one almost nobody runs. The hook — we let a fleet of AI agents run a real six-week mainnet benchmark.",
     "A fair fight: every client got its most disk-efficient mode, a fixed partner, and a hard 72-hour cap. Two headline numbers each — disk and sync — then the third axis nobody benchmarks.",
     "The field converges on disk — no clean winner. Nethermind, besu, and geth all land in the same ~1.0-1.2 TiB band once they carry full post-merge history; nethermind's early ~251 GiB reading was pre-backfill, not steady-state. The hatched bars aren't comparable: Nimbus-eth1's ~40 GB never finished (only ~21% of a sync), while ethrex's ~470–476 GiB is a settled plateau — smaller only because it's a no-history node, not because it's more efficient.",
-    "Config-determined cuts both ways — so turn it down. Nethermind's new default drops post-merge history: ~250–280 GiB, the smallest measured no-history staking configuration (roughly half ethrex, and a floor geth can't reach), at the cost of serving no historical RPC. NETHERMIND_FULL_HISTORY=true on a fresh/rebuilt datadir restores full history for a public RPC. Frame it as a within-tier win, not '4x leaner than geth' — that would score a no-history node against a with-history one.",
+    "Config-determined cuts both ways — so turn it down. Nethermind's new default drops post-merge history: ~250–280 GiB, the smaller of the two no-history configurations we measured (roughly half ethrex, and a floor geth can't reach; not a perfectly controlled comparison — different state encodings), at the cost of serving no historical RPC. NETHERMIND_FULL_HISTORY=true on a fresh/rebuilt datadir restores full history for a public RPC. Frame it as a within-tier win, not '4x leaner than geth' — that would score a no-history node against a with-history one.",
     "ethrex is nearly 4× faster than anything else in the field. Land the question and pause: so why does almost nobody actually run it?",
     "Because it hits a restart cliff. A 26-minute gap stalled; measured 1.5–2-hour gaps discarded state and triggered a full ~2-hour re-snap. That operability tax is the adoption story.",
     "The point of the whole talk: restart resilience is a third axis, and it predicts who people keep running better than speed or disk. Three behaviors — clean resume, re-snap cliff, mid-sync deadlock.",
@@ -451,8 +451,8 @@
     "The consensus layer looks solved on the axes we measured — all five sync in minutes, so footprint is the only differentiator. Lighthouse is the lean, safe default. The same three tiers held across three EL anchors, with a small within-tier order flip. If asked: we swept the five for sync and footprint, not restart-resume — prysm is the only CL we restart-tested, so this earns 'prysm resumes cleanly', not 'the CL layer survives anything'.",
     "Pivot to methodology — the other story people want. Three tiers keep token cost sane and judgment where it belongs. Governance is the punchline: an agent cannot merge its own PR.",
     "The harness is what kept it honest: decouple node time from agent time, push conclusions into small durable files (not the context window), and gate every result on config-optimality.",
-    "Four real incidents in three weeks — every one caught and documented. This is the concrete proof of 'we kept ourselves honest.'",
-    "The takeaways to leave them with: diversity pick run Nethermind, boring default run Geth, consensus run Lighthouse — and operational risk lives in the execution layer, not consensus.",
+    "Four real incidents in the initial 23-day campaign — every one caught and documented. This is the concrete proof of 'we kept ourselves honest.'",
+    "The takeaways to leave them with: diversity pick run Nethermind, boring default run Geth, consensus run Lighthouse (~518 MiB on the geth anchor; ~739 MiB on the ethrex anchor — absolute size tracks the measurement window) — and operational risk lives in the execution layer, not consensus.",
     "Close on the CTA: it's all on eth2quickstart.com/blog, one-line install for a hardened node. Thank the room, open for questions."
   ];
   var noteText=document.getElementById('noteText');


### PR DESCRIPTION
**Agent:** Claude Sonnet 5
**Co-authored-by:** Chimera

Corrections from two independent adversarial reviews, verified against `docs/CLIENT_BAKEOFF_RESULTS.md` (ground truth, not edited by this PR). Scope was limited to exactly two files: `docs/blog/CLIENT_BAKEOFF_OPERATOR_GUIDE.md` and `frontend/public/deck/bakeoff.html`.

## docs/blog/CLIENT_BAKEOFF_OPERATOR_GUIDE.md

- **A1 [HIGH]** — the guide sized nethermind for the retired ~1.06 TiB full-history config. Added: the shipped installer now defaults nethermind to minimal-history (`NETHERMIND_FULL_HISTORY=false`) → ~250–280 GiB with no historical RPC; `=true` on a fresh datadir restores the ~1.06 TiB full-history configuration. Applied to the nethermind table row and the TL;DR bullet.
- **A2 [MED]** — "nethermind and reth expected here by design" downgraded a measured, bisected result. Fixed to "nethermind, measured and bisected across 12 min → ~35 h gaps; reth never reached a synced datadir to restart."
- **A3 [MED]** — unscoped survivability claim ("not survival") for all 5 CLs, only prysm was restart-tested. Fixed to "not survivability — which we only measured for prysm, the constant anchor."
- **A4 [MED]** — "lighthouse is smallest" CL ranking stated with no anchor (lodestar is smallest on the other two anchors). Anchor-qualified both the ranking list and the TL;DR bullet.
- **A5 [LOW]** — nimbus/lighthouse ratio: 5,302,005,871 ÷ 773,282,157 = 6.856 → fixed "~6.8×" to "~6.9×".

## frontend/public/deck/bakeoff.html

- **B1 [MED]** — recommendations slide gave lighthouse "~518 MiB" (geth anchor) with no anchor stated, vs. ~739 MiB (ethrex anchor) elsewhere. Slide text now reads "~518 MiB on the geth anchor"; the speaker note carries the full ethrex-anchor comparison to stay in sync without overloading the slide.
- **B2 [MED]** — unsourced superlative "the smallest measured no-history staking configuration" (only two no-history configs were ever measured: nethermind-minimal and ethrex). Fixed to "the smaller of the two no-history configurations we measured" plus the doc's not-perfectly-controlled-comparison caveat, on the disk-lever slide and its speaker note. **Also applied to a third instance of the identical phrase on the recommendations slide (~line 405)** that the reviews' line citations (~263, ~446) didn't individually name — same defect, same file, and it sat on the same slide already being corrected for B1, so leaving it would have put the corrected and uncorrected framing side by side on one slide.
- **B3 [LOW]** — EL scorecard blanked erigon's footprint (`—`) even though the disk chart on an earlier slide plots it at ~1.21 TiB. Filled in as "~1.21 TiB · frozen" (distinct from the `*partial` reth/nimbus-eth1 footnote, since erigon's story is a structural deadlock, not a 72h-cap-in-progress partial).
- **B4 [LOW]** — deck stated two unreconciled campaign durations ("six weeks" vs. "three weeks" for the same incident window). Per the review's resolution, "three weeks" refers to the initial 23-day measurement phase — reworded the "what broke" slide heading and its speaker note to "the first 23 days" / "the initial 23-day campaign". All "six-week" mentions elsewhere are correct and untouched.

Nothing in the DO NOT TOUCH list was touched: the restart-cliff content, the already-scoped CL-solved wording (slides ~339/~340, note ~451), and the CL chart's geth-anchor MiB/GiB figures are all unchanged.

## Verify gate (frontend/)

All four commands run separately, actual exit codes (not piped):
- `bun install --frozen-lockfile` → exit 0
- `bunx tsc --noEmit` → exit 0
- `bun run test` → exit 0 (18 suites / 103 tests passed, 0 snapshots — no deck snapshot test exists)
- `bun run build` → exit 0 (Next.js production build, all 15 static routes generated)

`git status` after the build showed only the two intended files modified (build-time regeneration of `public/llms.txt` etc. is byte-identical / not re-staged).

## Visual verification

Rendered all four slides with markup changes via `chrome-headless-shell --no-sandbox`, confirmed each footer reads the expected "SLIDE NN / 14" (hash and footer number are 1:1 in this deck), and checked for overflow:

- **#4** (disk lever) — the added kicker-paragraph text wraps to 4 lines, stays inside the panel, no overflow. (A pre-existing, unrelated minor right-edge clipping of "new default" on the Nethermind-minimal bar-value label exists on `master` too — confirmed by rendering master's slide 4 for comparison — and is out of scope for this PR.)
- **#8** (EL scorecard) — erigon's new "~1.21 TiB · frozen" cell renders cleanly in the table.
- **#12** (what broke) — "What actually breaks in the first 23 days." fits the heading area with no truncation.
- **#13** (recommendations) — "Consensus → Lighthouse. The lean, safe default: ~518 MiB on the geth anchor, …" fits on one line; all three bullets stay within the panel.

Not merging per instructions.