### PR TITLE
test(ci): add campaign-constants consistency check (issue #230 item 3)

### DIFF
--- a/.github/workflows/campaign-constants.yml
+++ b/.github/workflows/campaign-constants.yml
@@ -48,5 +48,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache apt packages
+        uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives
+          key: apt-${{ runner.os }}-ripgrep
+          restore-keys: apt-${{ runner.os }}-
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Verify measured campaign constants are consistent
         run: bash ./test/ci_test_campaign_constants.sh

--- a/.github/workflows/campaign-constants.yml
+++ b/.github/workflows/campaign-constants.yml
@@ -1,0 +1,52 @@
+# Guards the bake-off campaign's measured constants (issue #230 item 3): the corpus spans
+# docs, the operator guide, four rendered frontend blog pages, and the deck, and none of the
+# other workflows' path filters union all three — a docs-only or frontend/deck-only PR would
+# otherwise skip this check entirely (the exact blind spot that let the deck silently re-stale
+# after the articles were corrected).
+name: Campaign Constants Consistency
+
+on:
+  push:
+    branches: [ main, master, develop ]
+    paths:
+      - 'docs/CLIENT_BAKEOFF_RESULTS.md'
+      - 'docs/CLIENT_BAKEOFF_BLOG.md'
+      - 'docs/CLIENT_BAKEOFF_HARNESS.md'
+      - 'docs/HOW_WE_TESTED_WITH_CLAUDE.md'
+      - 'docs/blog/CLIENT_BAKEOFF_OPERATOR_GUIDE.md'
+      - 'frontend/app/blog/bakeoff-harness/page.tsx'
+      - 'frontend/app/blog/bakeoff-results/page.tsx'
+      - 'frontend/app/blog/ethereum-client-bakeoff/page.tsx'
+      - 'frontend/app/blog/how-we-tested-with-claude/page.tsx'
+      - 'frontend/public/deck/bakeoff.html'
+      - 'test/ci_test_campaign_constants.sh'
+      - '.github/workflows/campaign-constants.yml'
+  pull_request:
+    branches: [ main, master, develop, 'cursor/**' ]
+    paths:
+      - 'docs/CLIENT_BAKEOFF_RESULTS.md'
+      - 'docs/CLIENT_BAKEOFF_BLOG.md'
+      - 'docs/CLIENT_BAKEOFF_HARNESS.md'
+      - 'docs/HOW_WE_TESTED_WITH_CLAUDE.md'
+      - 'docs/blog/CLIENT_BAKEOFF_OPERATOR_GUIDE.md'
+      - 'frontend/app/blog/bakeoff-harness/page.tsx'
+      - 'frontend/app/blog/bakeoff-results/page.tsx'
+      - 'frontend/app/blog/ethereum-client-bakeoff/page.tsx'
+      - 'frontend/app/blog/how-we-tested-with-claude/page.tsx'
+      - 'frontend/public/deck/bakeoff.html'
+      - 'test/ci_test_campaign_constants.sh'
+      - '.github/workflows/campaign-constants.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: campaign-constants-${{ github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  campaign-constants:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify measured campaign constants are consistent
+        run: bash ./test/ci_test_campaign_constants.sh

--- a/docs/CI_WORKFLOWS.md
+++ b/docs/CI_WORKFLOWS.md
@@ -9,8 +9,9 @@ Workflows run only when relevant files change. Docs-only changes skip most CI.
 | **frontend.yml** | `frontend/**`, `.github/workflows/frontend.yml` | Shell, docs, config |
 | **security.yml** | `install/security/**`, `configs/**`, `lib/common_functions.sh`, `docs/*security*`, `docs/validate_security_safe.sh` | Most changes |
 | **pr-checks.yml** | `frontend/**`, `**/*.sh`, `test/**`, `install/**`, `lib/**`, `configs/**`, `.github/**` | Docs-only |
+| **campaign-constants.yml** | The bake-off corpus only: `docs/CLIENT_BAKEOFF_*.md`, `docs/HOW_WE_TESTED_WITH_CLAUDE.md`, `docs/blog/CLIENT_BAKEOFF_OPERATOR_GUIDE.md`, the four `frontend/app/blog/*/page.tsx` bake-off pages, `frontend/public/deck/bakeoff.html` | Everything else |
 
-**Note:** docs changes now trigger `shellcheck.yml`, which also runs `test/ci_test_docs_consistency.sh` for active-doc link/legacy-reference checks. Heavy Docker integration in `ci.yml` still skips docs-only changes.
+**Note:** docs changes now trigger `shellcheck.yml`, which also runs `test/ci_test_docs_consistency.sh` for active-doc link/legacy-reference checks. Heavy Docker integration in `ci.yml` still skips docs-only changes. `campaign-constants.yml` exists because no other workflow's paths union docs *and* the frontend blog pages *and* the deck — a docs-only or frontend/deck-only PR would otherwise skip the check that keeps the bake-off campaign's measured constants (restart rate, cutoff date, history-mode caveat) consistent across all of them (see `test/ci_test_campaign_constants.sh`, issue #230).
 
 ## Artifact retention
 

--- a/docs/CLIENT_BAKEOFF_BLOG.md
+++ b/docs/CLIENT_BAKEOFF_BLOG.md
@@ -62,6 +62,8 @@ A knock-on benefit of that gate: it forced us to *empirically settle* config que
 
 Nethermind's synced-tip snapshot read ~251 GiB, well below geth's ~1.13 TiB — but that number was taken before nethermind's FastBlocks finished backfilling post-merge block bodies and receipts. Its steady-state datadir (re-measured 2026-08-01) is **~1.06 TiB (~1,088 GiB)**: state ~226–230 GiB (its compact Halite/Paprika flat storage) plus ~843 GiB of post-merge bodies and receipts plus ~19 GiB of headers and code, the same history geth keeps under `--history.chain postmerge`. Under matched history-retention configs, nethermind and geth are on par:
 
+**Update 2026-08-03:** that ~1.06 TiB figure is the full-history configuration. The shipped installer now defaults nethermind to minimal-history (`NETHERMIND_FULL_HISTORY=false`) → **~250–280 GiB, with no historical RPC**; set `=true` on a fresh/rebuilt datadir to restore the ~1.06 TiB full-history number above.
+
 | EL | Footprint (full post-merge history) | Sync time | Mode | Mainnet share |
 |----|------|------|------|------|
 | **Nethermind** | **~1.06 TiB** steady-state (~251 GiB at snap-sync, pre-backfill) | ~14.5h | snap + Halite/Paprika | 36.0% |

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -71,6 +71,9 @@ bash test/bakeoff/test_data_dirs_sync.sh
 echo "=== Docs consistency ==="
 bash test/ci_test_docs_consistency.sh
 
+echo "=== Campaign constants consistency ==="
+bash test/ci_test_campaign_constants.sh
+
 echo "=== Agent skill checks ==="
 bash test/ci_test_skill_structure.sh
 bash test/ci_test_skill_command_mapping.sh

--- a/test/README.md
+++ b/test/README.md
@@ -73,6 +73,7 @@ test/
 ├── ci_test_run_1.sh        # run_1 structure validation
 ├── ci_test_run_1_e2e.sh    # run_1 E2E (executes run_1.sh, verifies results)
 ├── ci_test_docs_consistency.sh # Active docs link/legacy-reference consistency checks
+├── ci_test_campaign_constants.sh # Bake-off measured-constant consistency across docs/frontend/deck (issue #230)
 ├── prysm_checkpoint_smoke.sh # Optional live Prysm checkpoint-sync smoke
 ├── run_e2e.sh             # Wrapper: Docker + systemd + ci_test_e2e.sh (--phase=1|2)
 ├── lib/
@@ -147,6 +148,7 @@ Previously we only verified binaries installed and MEV services active. We now *
 | `ci_test_run_1_e2e.sh` | Executes run_1.sh and verifies results (run via run_e2e.sh --phase=1) | root |
 | `ci_test_run_2.sh` | Validates run_2.sh structure, syntax, configs, Geth install | testuser |
 | `ci_test_docs_consistency.sh` | Validates active doc links and retired legacy reference absence | n/a |
+| `ci_test_campaign_constants.sh` | Validates measured bake-off constants (restart rate, cutoff date, history-mode caveat) agree across docs, operator guide, blog pages, and deck | n/a |
 
 **Note**: Full E2E testing with systemd services and snap packages requires special Docker setup. CI tests validate structure and components that work in standard Docker.
 

--- a/test/ci_test_campaign_constants.sh
+++ b/test/ci_test_campaign_constants.sh
@@ -12,6 +12,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
+if ! command -v rg >/dev/null 2>&1; then
+    echo "[ERROR] ripgrep (rg) is required by this check but is not installed." >&2
+    exit 2
+fi
+
 FAILED=0
 
 log_info() {

--- a/test/ci_test_campaign_constants.sh
+++ b/test/ci_test_campaign_constants.sh
@@ -159,7 +159,12 @@ check_nethermind_history_caveat() {
 check_no_stale_regressions() {
     log_info "Checking for regression to previously-corrected values..."
 
-    local patterns=("307 blocks/min" "307 blk/min" "6.8×")
+    # Word-boundary-anchored: a plain -F fixed-string match would also fire inside an unrelated
+    # future number, e.g. "16.8×" contains "6.8×" and "1307 blocks/min" contains "307 blocks/min".
+    # \b works here because digit-adjacent-to-digit is not a word-boundary transition in the
+    # default (Unicode-aware) regex engine, so no lookbehind is needed.
+    local display=("307 blocks/min" "307 blk/min" "6.8×")
+    local patterns=('\b307 blocks/min\b' '\b307 blk/min\b' '\b6\.8×')
     local reasons=(
         "nethermind's restart-resume rate is measured at ~302 blocks/min, not 307 (see $ARBITER EXP-A)"
         "nethermind's restart-resume rate is measured at ~302 blocks/min, not 307 (see $ARBITER EXP-A)"
@@ -173,13 +178,27 @@ check_no_stale_regressions() {
             [[ -f "$file" ]] || continue
             while IFS=: read -r line _; do
                 [[ -z "$line" ]] && continue
-                log_error "$file:$line found previously-corrected stale value '$pattern' — ${reasons[$i]}"
+                log_error "$file:$line found previously-corrected stale value '${display[$i]}' — ${reasons[$i]}"
                 FAILED=1
-            done < <(rg -n -F -e "$pattern" "$file" 2>/dev/null || true)
+            done < <(rg -n -e "$pattern" "$file" 2>/dev/null || true)
         done
     done
 }
 
+# ---------------------------------------------------------------------------
+# 5. Corpus coverage: warn (don't fail — a deletion may be intentional) if a listed artifact has
+#    gone missing, so a rename silently shrinking this check's coverage doesn't go unnoticed.
+# ---------------------------------------------------------------------------
+check_corpus_files_exist() {
+    local file
+    for file in "${ALL_ARTIFACTS[@]}"; do
+        if [[ ! -f "$file" ]]; then
+            echo "[WARN] $file is listed in ALL_ARTIFACTS but no longer exists — if renamed, update test/ci_test_campaign_constants.sh; if intentionally removed, drop it from the list"
+        fi
+    done
+}
+
+check_corpus_files_exist
 check_restart_rate_consistency
 check_campaign_cutoff_consistency
 check_nethermind_history_caveat

--- a/test/ci_test_campaign_constants.sh
+++ b/test/ci_test_campaign_constants.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# Validate measured bake-off campaign constants agree across the corpus (issue #230 item 3).
+#
+# docs/CLIENT_BAKEOFF_RESULTS.md is the arbiter. The same measured claims are repeated across
+# the operator guide, four rendered frontend/app/blog/*/page.tsx pages, the deck, and other
+# in-repo markdown sources — a value corrected in one artifact and missed in another has shipped
+# to production more than once (see issue #230 and the PRs it links).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+FAILED=0
+
+log_info() {
+    echo "[INFO] $1"
+}
+
+log_error() {
+    echo "[ERROR] $1"
+}
+
+ARBITER="docs/CLIENT_BAKEOFF_RESULTS.md"
+
+# Every artifact that carries these measured claims.
+ALL_ARTIFACTS=(
+    "$ARBITER"
+    "docs/blog/CLIENT_BAKEOFF_OPERATOR_GUIDE.md"
+    "docs/CLIENT_BAKEOFF_BLOG.md"
+    "docs/CLIENT_BAKEOFF_HARNESS.md"
+    "docs/HOW_WE_TESTED_WITH_CLAUDE.md"
+    "frontend/app/blog/bakeoff-harness/page.tsx"
+    "frontend/app/blog/bakeoff-results/page.tsx"
+    "frontend/app/blog/ethereum-client-bakeoff/page.tsx"
+    "frontend/app/blog/how-we-tested-with-claude/page.tsx"
+    "frontend/public/deck/bakeoff.html"
+)
+
+# The current-state result/guidance surface: files that state nethermind's footprint as an
+# operator-facing headline. Excludes the two methodology/timeline narratives (HOW_WE_TESTED /
+# its page, and the harness doc/page), where the same figure legitimately appears as a dated
+# historical log entry (e.g. "2026-08-01: re-measured ~1.06 TiB") without repeating the
+# minimal-history caveat every time, and where an unrelated "~1.06 TiB" also appears describing
+# a reth compaction sample, not nethermind.
+RESULTS_SURFACE=(
+    "$ARBITER"
+    "docs/blog/CLIENT_BAKEOFF_OPERATOR_GUIDE.md"
+    "docs/CLIENT_BAKEOFF_BLOG.md"
+    "frontend/app/blog/ethereum-client-bakeoff/page.tsx"
+    "frontend/app/blog/bakeoff-results/page.tsx"
+    "frontend/public/deck/bakeoff.html"
+)
+
+# ---------------------------------------------------------------------------
+# 1. Restart-resume rate. The arbiter's measured EXP-A value is the source of truth; every
+#    other artifact's "N blocks/min" mention must equal it.
+# ---------------------------------------------------------------------------
+check_restart_rate_consistency() {
+    log_info "Checking restart-resume rate (blocks/min) consistency..."
+
+    local canonical
+    canonical=$(rg -o -r '$1' -e '~([0-9]+) blocks/min' "$ARBITER" | sort -u || true)
+
+    if [[ -z "$canonical" ]]; then
+        log_error "$ARBITER: no '~N blocks/min' restart-resume rate found — the arbiter claim was reworded; update this check's pattern"
+        FAILED=1
+        return
+    fi
+    if [[ "$(printf '%s\n' "$canonical" | wc -l)" -gt 1 ]]; then
+        log_error "$ARBITER: multiple distinct blocks/min values found ($(printf '%s ' "$canonical")) — the arbiter is internally inconsistent"
+        FAILED=1
+        return
+    fi
+
+    local file line value
+    for file in "${ALL_ARTIFACTS[@]}"; do
+        [[ "$file" == "$ARBITER" ]] && continue
+        [[ -f "$file" ]] || continue
+        while IFS=: read -r line value; do
+            [[ -z "$line" ]] && continue
+            if [[ "$value" != "$canonical" ]]; then
+                log_error "$file:$line restart rate '~${value} blocks/min' disagrees with $ARBITER's measured ~${canonical} blocks/min"
+                FAILED=1
+            fi
+        done < <(rg -n -o -r '$1' -e '~?([0-9]+)[[:space:]]*(?:blocks|blk)/min' "$file" 2>/dev/null || true)
+    done
+}
+
+# ---------------------------------------------------------------------------
+# 2. Steady-state/restart-resume phase cutoff date ("the Aug 3 cutoff"). Two artifacts state it
+#    as an explicit literal: the methodology doc's prose and the deck's campaign-range kicker.
+# ---------------------------------------------------------------------------
+check_campaign_cutoff_consistency() {
+    log_info "Checking campaign steady-state cutoff date consistency..."
+
+    local narrative="docs/HOW_WE_TESTED_WITH_CLAUDE.md"
+    local deck="frontend/public/deck/bakeoff.html"
+
+    local narrative_line narrative_day deck_line deck_day
+    narrative_line=$(rg -n -m1 -e 'through August [0-9]+' "$narrative" 2>/dev/null | cut -d: -f1 || true)
+    narrative_day=$(rg -o -m1 -r '$1' -e 'through August ([0-9]+)' "$narrative" 2>/dev/null || true)
+    deck_line=$(rg -n -m1 -e '2026-06-22.{1,5}2026-08-[0-9]{2}' "$deck" 2>/dev/null | cut -d: -f1 || true)
+    deck_day=$(rg -o -m1 -r '$1' -e '2026-06-22.{1,5}2026-08-([0-9]{2})' "$deck" 2>/dev/null || true)
+
+    if [[ -z "${narrative_day:-}" ]]; then
+        log_error "$narrative: no 'through August N' steady-state cutoff phrase found — the anchor this check relies on was reworded"
+        FAILED=1
+        return
+    fi
+    if [[ -z "${deck_day:-}" ]]; then
+        log_error "$deck: no '2026-06-22 ... 2026-08-NN' campaign-range kicker found — the anchor this check relies on was reworded"
+        FAILED=1
+        return
+    fi
+
+    local narrative_num=$((10#$narrative_day))
+    local deck_num=$((10#$deck_day))
+    if [[ "$narrative_num" -ne "$deck_num" ]]; then
+        log_error "$deck:$deck_line campaign cutoff '2026-08-${deck_day}' disagrees with $narrative:$narrative_line's 'through August ${narrative_day}'"
+        FAILED=1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# 3. Fresh/rebuilt-datadir qualification. Nethermind's full-history footprint (~1.06 TiB) is an
+#    opt-in, not the shipped default — any artifact that states the full-history headline must
+#    also mention the minimal-history default it now ships with, or an operator reading only
+#    that artifact will size for the wrong number.
+# ---------------------------------------------------------------------------
+check_nethermind_history_caveat() {
+    log_info "Checking nethermind full-history headline pairs with the minimal-history caveat..."
+
+    local trigger='1\.06 TiB'
+    local required='minimal-history|NETHERMIND_FULL_HISTORY|25[0-9][^0-9]{1,3}28[0-9] ?GiB'
+
+    local file first_line
+    for file in "${RESULTS_SURFACE[@]}"; do
+        [[ -f "$file" ]] || continue
+        if rg -q -e "$trigger" "$file"; then
+            if ! rg -q -e "$required" "$file"; then
+                first_line=$(rg -n -m1 -e "$trigger" "$file" | cut -d: -f1)
+                log_error "$file:$first_line states nethermind's full-history '~1.06 TiB' footprint but never mentions the minimal-history default (NETHERMIND_FULL_HISTORY / ~250-280 GiB) anywhere in this file — set on a fresh/rebuilt datadir, per $ARBITER — an operator reading only this file will size for the wrong default"
+                FAILED=1
+            fi
+        fi
+    done
+}
+
+# ---------------------------------------------------------------------------
+# 4. Regression guard: values already found wrong and corrected must not reappear anywhere.
+# ---------------------------------------------------------------------------
+check_no_stale_regressions() {
+    log_info "Checking for regression to previously-corrected values..."
+
+    local patterns=("307 blocks/min" "307 blk/min" "6.8×")
+    local reasons=(
+        "nethermind's restart-resume rate is measured at ~302 blocks/min, not 307 (see $ARBITER EXP-A)"
+        "nethermind's restart-resume rate is measured at ~302 blocks/min, not 307 (see $ARBITER EXP-A)"
+        "the nimbus/lighthouse CL footprint ratio is ~6.9x (6.856 rounds up), not 6.8x"
+    )
+
+    local i pattern file line
+    for i in "${!patterns[@]}"; do
+        pattern="${patterns[$i]}"
+        for file in "${ALL_ARTIFACTS[@]}"; do
+            [[ -f "$file" ]] || continue
+            while IFS=: read -r line _; do
+                [[ -z "$line" ]] && continue
+                log_error "$file:$line found previously-corrected stale value '$pattern' — ${reasons[$i]}"
+                FAILED=1
+            done < <(rg -n -F -e "$pattern" "$file" 2>/dev/null || true)
+        done
+    done
+}
+
+check_restart_rate_consistency
+check_campaign_cutoff_consistency
+check_nethermind_history_caveat
+check_no_stale_regressions
+
+if [[ "$FAILED" -ne 0 ]]; then
+    log_error "Campaign constants consistency checks failed"
+    exit 1
+fi
+
+log_info "Campaign constants consistency checks passed"


### PR DESCRIPTION
## Summary
- Adds `test/ci_test_campaign_constants.sh`: uses `docs/CLIENT_BAKEOFF_RESULTS.md` as the arbiter and checks, with actionable `file:line` output, that (1) every artifact's restart-resume rate agrees with the arbiter's measured `~302 blocks/min`, (2) the steady-state cutoff date agrees between the methodology doc and the deck's campaign-range kicker ("the Aug 3 cutoff"), (3) any artifact stating nethermind's full-history `~1.06 TiB` headline also mentions the minimal-history default it now ships with ("the fresh/rebuilt-datadir qualification"), and (4) no previously-corrected stale value (`307 blocks/min`, `6.8×`) has regressed.
- Adds a new `.github/workflows/campaign-constants.yml` scoped to the exact corpus (docs + operator guide + the four rendered blog pages + the deck) — no existing workflow's path filter unions all three, which is exactly the blind spot that let the deck silently re-stale after the articles were corrected. Also wired into `scripts/pre-commit.sh`.
- Fixes a live instance of the bug class this check targets: `docs/CLIENT_BAKEOFF_BLOG.md` still stated nethermind's `~1.06 TiB steady-state` with no mention anywhere in the file of the shipped minimal-history default, unlike the operator guide, flagship page, and deck. Found by running the new check before it had anything to guard, then fixed with the same update-note wording used elsewhere in the corpus.
- The first CI run of the new workflow failed with `rg: command not found` — GitHub-hosted runners don't ship ripgrep by default. Fixed by installing it explicitly in the workflow and adding a `command -v rg` preflight to the script so a missing binary fails loudly instead of silently misreporting every constant as absent.

## Test plan
- [x] `bash test/ci_test_campaign_constants.sh` — passes clean on current `master`+this branch
- [x] Verified each check type fires red on an injected drift (restart-rate mismatch, cutoff-date mismatch, banned-value regression) with an actionable `file:line` message, then reverted the injected drift
- [x] Verified the check caught the real `CLIENT_BAKEOFF_BLOG.md` drift before the fix, and goes green after
- [x] `shellcheck -x --exclude=SC2317,SC1091,SC1090,SC2034,SC2031,SC2181 test/ci_test_campaign_constants.sh` — clean
- [x] Full `bash scripts/pre-commit.sh` — all suites pass
- [x] Verified in real GitHub Actions CI (not just locally) — `campaign-constants`, `shellcheck-extended`, `docs-consistency`, and commit-format checks all green on the PR

**Agent:** Claude Sonnet 5
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>