### PR TITLE
fix(systemd): set ETH1 stop timeout to 300 seconds

### DIFF
--- a/install/execution/besu.sh
+++ b/install/execution/besu.sh
@@ -122,7 +122,7 @@ rm -rf ./tmp/
 JAVA_OPTS="-Xmx${BESU_CACHE}m -XX:+UseG1GC"
 EXEC_START="$BESU_DIR/bin/besu --config-file=$BESU_DIR/besu.toml"
 
-create_systemd_service "eth1" "Hyperledger Besu Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "600" "5" "300"
+create_systemd_service "eth1" "Hyperledger Besu Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "300" "5" "300"
 
 # Add Java options to service file
 sudo sed -i "/\\[Service\\]/a Environment=JAVA_OPTS=\"$JAVA_OPTS\"" /etc/systemd/system/eth1.service

--- a/install/execution/erigon.sh
+++ b/install/execution/erigon.sh
@@ -88,7 +88,7 @@ ensure_jwt_secret "$HOME/secrets/jwt.hex"
 # Explicit authrpc flags ensure Engine API listens on 8551 (config file may not enable it in all Erigon versions)
 EXEC_START="$ERIGON_DIR/erigon --config $ERIGON_DIR/config.yaml --externalcl --authrpc.addr ${LH:-127.0.0.1} --authrpc.port ${ENGINE_PORT:-8551} --authrpc.jwtsecret $HOME/secrets/jwt.hex"
 
-create_systemd_service "eth1" "Erigon Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "600" "5" "300"
+create_systemd_service "eth1" "Erigon Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "300" "5" "300"
 
 # Enable and start the service
 enable_and_start_systemd_service "eth1"

--- a/install/execution/ethrex.sh
+++ b/install/execution/ethrex.sh
@@ -141,7 +141,7 @@ ETHREX_CMD="$ETHREX_DIR/ethrex \
 --log.level info"
 
 # Create systemd service
-create_systemd_service "eth1" "Ethrex Ethereum Execution Client" "$ETHREX_CMD" "$(whoami)" "on-failure" "600" "5" "300"
+create_systemd_service "eth1" "Ethrex Ethereum Execution Client" "$ETHREX_CMD" "$(whoami)" "on-failure" "300" "5" "300"
 
 # Enable and start the service
 enable_and_start_systemd_service "eth1"

--- a/install/execution/geth.sh
+++ b/install/execution/geth.sh
@@ -67,7 +67,7 @@ chmod 700 "$HOME/secrets"
 ensure_jwt_secret "$HOME/secrets/jwt.hex"
 
 # Create systemd service using common function
-create_systemd_service "eth1" "Geth Ethereum Execution Client" "$GETH_CMD" "$(whoami)" "on-failure" "600" "5" "300"
+create_systemd_service "eth1" "Geth Ethereum Execution Client" "$GETH_CMD" "$(whoami)" "on-failure" "300" "5" "300"
 
 # Enable and start the service
 enable_and_start_systemd_service "eth1"

--- a/install/execution/nethermind.sh
+++ b/install/execution/nethermind.sh
@@ -262,7 +262,7 @@ rm -rf ./tmp/
 # Create systemd service
 EXEC_START="/usr/bin/env HOME=$HOME XDG_DATA_HOME=$HOME/.local/share $NETHERMIND_DIR/Nethermind.Runner --config $NETHERMIND_DIR/nethermind.cfg --KeyStore.KeyStoreDirectory $HOME/nethermind/keystore --JsonRpc.JwtSecretFile $HOME/secrets/jwt.hex --JsonRpc.EngineHost $LH --JsonRpc.EnginePort 8551"
 
-create_systemd_service "eth1" "Nethermind Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "600" "5" "300"
+create_systemd_service "eth1" "Nethermind Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "300" "5" "300"
 
 # Apply the generated configuration to the running service. The shared helper
 # intentionally uses `start`, which is a no-op for an already-active unit; restart

--- a/install/execution/nimbus_eth1.sh
+++ b/install/execution/nimbus_eth1.sh
@@ -112,7 +112,7 @@ rm -rf ./tmp/
 # Create systemd service
 EXEC_START="$NIMBUS_EXEC executionClient --config-file=$NIMBUS_ETH1_DIR/nimbus_eth1.toml"
 
-create_systemd_service "eth1" "Nimbus Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "600" "5" "300"
+create_systemd_service "eth1" "Nimbus Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "300" "5" "300"
 
 # Enable and start the service
 enable_and_start_systemd_service "eth1"

--- a/install/execution/reth.sh
+++ b/install/execution/reth.sh
@@ -74,7 +74,7 @@ ensure_jwt_secret "$HOME/secrets/jwt.hex"
 # Verified flags against reth node --help on installed binary.
 EXEC_START="$RETH_DIR/reth node --full --prune.bodies.pre-merge --prune.receipts.pre-merge --http --http.addr $LH --http.port 8545 --http.api eth,net,web3 --authrpc.addr $LH --authrpc.port $ENGINE_PORT --authrpc.jwtsecret $HOME/secrets/jwt.hex --datadir $HOME/.local/share/reth"
 
-create_systemd_service "eth1" "Reth Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "6000" "10" "3000"
+create_systemd_service "eth1" "Reth Ethereum Execution Client" "$EXEC_START" "$(whoami)" "on-failure" "300" "10" "3000"
 
 # Enable and start the service
 enable_and_start_systemd_service "eth1"


### PR DESCRIPTION
## Summary

Set `TimeoutStopSec=300` for every ETH1 execution-client systemd unit generated by the installers: Geth, Erigon, Reth, Nethermind, Besu, Nimbus ETH1, and Ethrex.

This is one focused PR with no duplicate open PR found for this change.

## Verification

- `bash -n` on all seven changed installers
- ShellCheck on all seven changed installers
- `git diff --check`
- Explicit assertion that all 7 ETH1 service-generation calls pass `300` as `TimeoutStopSec`

**Agent:** GPT-5
**Co-authored-by:** Chimera <chimera_defi@protonmail.com>